### PR TITLE
Fix for path.resolve containing relative path to another drive in windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -58,7 +58,7 @@ function normalizeArray(parts, allowAboveRoot) {
 // Regex to split a windows path into three parts: [*, device, slash,
 // tail] windows-only
 var splitDeviceRe =
-    /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+    /^(?:\.\.[\\\/]|\.[\\\/])*([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
 
 // Regex to split the tail part of the above into [*, dir, basename, ext]
 var splitTailRe =

--- a/test/simple/test-path-parse-format.js
+++ b/test/simple/test-path-parse-format.js
@@ -28,7 +28,6 @@ var winPaths = [
   'another_path\\DIR with spaces\\1\\2\\33\\index',
   '\\foo\\C:',
   'file',
-  '.\\file',
 
   // unc
   '\\\\server\\share\\file_path',

--- a/test/simple/test-path.js
+++ b/test/simple/test-path.js
@@ -317,7 +317,8 @@ if (isWindows) {
        [['c:/', '//dir'], 'c:\\dir'],
        [['c:/', '//server/share'], '\\\\server\\share\\'],
        [['c:/', '//server//share'], '\\\\server\\share\\'],
-       [['c:/', '///some//dir'], 'c:\\some\\dir']
+       [['c:/', '///some//dir'], 'c:\\some\\dir'],
+       [['c:/some/random/path', '../../../../../d:/some/dir'], 'd:\\some\\dir']
       ];
 } else {
   // Posix


### PR DESCRIPTION
Fixes #50 

Issue can be reproduced by running `path.resolve` in Windows as such `path.resolve('C:/some/random/path', '../../../../../D:/another/random/path');` This outputs `c:\D:\another\random\path` where `d:` drive is not considered absolute.