### PR TITLE
buffer: add indexOf method

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -764,6 +764,13 @@ buffer.
     var b = new Buffer(50);
     b.fill("h");
 
+### buf.indexOf(value[, fromIndex])
+
+* `value` Buffer or String or Number
+* `fromIndex` Number, Optional, Default: 0
+
+Finds the index within the buffer of the first occurrence of the specified value, starting the search at fromIndex. Returns -1 if the value is not found.
+
 ## buffer.INSPECT_MAX_BYTES
 
 * Number, Default: 50

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -332,6 +332,16 @@ Buffer.prototype.fill = function fill(val, start, end) {
   return this;
 };
 
+Buffer.prototype.indexOf = function indexOf(needle, pos) {
+  if (typeof needle === 'number') {
+    needle = new Buffer([needle]);
+  } else if (typeof needle === 'string') {
+    needle = new Buffer(needle);
+  } else if (!(needle instanceof Buffer)) {
+    throw new TypeError('Argument must be a Buffer, number or string');
+  }
+  return internal.indexOf(this, needle, pos);
+};
 
 // XXX remove in v0.13
 Buffer.prototype.get = util.deprecate(function get(offset) {

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1184,3 +1184,13 @@ assert.throws(function() {
   var b = new Buffer(1);
   b.equals('abc');
 });
+
+// IndexOf Tests
+assert.equal(Buffer('abc').indexOf(''), 0)
+assert.equal(Buffer('abc').indexOf('bd'), -1)
+assert.equal(Buffer('abc').indexOf('bc'), 1)
+assert.equal(Buffer('abc').indexOf(0x62), 1)
+assert.equal(Buffer('abc').indexOf(Buffer('bc')), 1)
+assert.equal(Buffer('abc').indexOf(Buffer([0x62,0x63])), 1)
+assert.equal(Buffer('abc').indexOf('bc', 1), 1)
+assert.equal(Buffer('abc').indexOf('bc', 2), -1)


### PR DESCRIPTION
Adds a `.indexOf` method to `Buffer`, which borrows semantics from
both `Array.prototype.indexOf` and `String.prototype.indexOf`.

`Buffer.prototype.indexOf` can be invoked with a Buffer, a string
or a number as the needle.  If the needle a Buffer or string, it will
find the first occurrence of this sequence of bytes.  If the needle is
a number, it will find the first occurrence of this byte.

Fixes #95.

If you're unsure about or not happy with the semantics, let's discuss :)