### PR TITLE
buffer: add indexOf/lastIndexOf method

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -764,6 +764,13 @@ buffer.
     var b = new Buffer(50);
     b.fill("h");
 
+### buf.indexOf(value[, fromIndex])
+
+* `value` Buffer or String or Number
+* `fromIndex` Number, Optional, Default: 0
+
+Finds the index within the buffer of the first occurrence of the specified value, starting the search at fromIndex. Returns -1 if the value is not found.
+
 ## buffer.INSPECT_MAX_BYTES
 
 * Number, Default: 50

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -769,7 +769,18 @@ buffer.
 * `value` Buffer or String or Number
 * `fromIndex` Number, Optional, Default: 0
 
-Finds the index within the buffer of the first occurrence of the specified value, starting the search at fromIndex. Returns -1 if the value is not found.
+Finds the index within the buffer of the first occurrence of the
+specified value, starting the search at fromIndex. Returns -1 if the
+value is not found.
+
+### buf.lastIndexOf(value[, fromIndex])
+
+* `value` Buffer or String or Number
+* `fromIndex` Number, Optional, Default: 0
+
+Finds the index within the buffer of the *last* occurrence of the
+specified value, starting the search at fromIndex. Returns -1 if the
+value is not found.
 
 ## buffer.INSPECT_MAX_BYTES
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -332,6 +332,16 @@ Buffer.prototype.fill = function fill(val, start, end) {
   return this;
 };
 
+Buffer.prototype.indexOf = function indexOf(needle, pos) {
+  if (typeof needle === 'number') {
+    needle = new Buffer([needle]);
+  } else if (typeof needle === 'string') {
+    needle = new Buffer(needle);
+  } else if (!(needle instanceof Buffer)) {
+    throw new TypeError('Argument must be a Buffer, number or string');
+  }
+  return internal.indexOf(this, needle, pos);
+};
 
 // XXX remove in v0.13
 Buffer.prototype.get = util.deprecate(function get(offset) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -343,6 +343,17 @@ Buffer.prototype.indexOf = function indexOf(needle, pos) {
   return internal.indexOf(this, needle, pos);
 };
 
+Buffer.prototype.lastIndexOf = function indexOf(needle, pos) {
+  if (typeof needle === 'number') {
+    needle = new Buffer([needle]);
+  } else if (typeof needle === 'string') {
+    needle = new Buffer(needle);
+  } else if (!(needle instanceof Buffer)) {
+    throw new TypeError('Argument must be a Buffer, number or string');
+  }
+  return internal.lastIndexOf(this, needle, pos);
+};
+
 // XXX remove in v0.13
 Buffer.prototype.get = util.deprecate(function get(offset) {
   offset = ~~offset;

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1184,3 +1184,13 @@ assert.throws(function() {
   var b = new Buffer(1);
   b.equals('abc');
 });
+
+// IndexOf Tests
+assert.equal(Buffer('abc').indexOf(''), 0)
+assert.equal(Buffer('abc').indexOf('bd'), -1)
+assert.equal(Buffer('abc').indexOf('bc'), 1)
+assert.equal(Buffer('abc').indexOf(0x62), 1)
+assert.equal(Buffer('abc').indexOf(Buffer('bc')), 1)
+assert.equal(Buffer('abc').indexOf(Buffer([0x62,0x63])), 1)
+assert.equal(Buffer('abc').indexOf('bc', 1), 1)
+assert.equal(Buffer('abc').indexOf('bc', 2), -1)

--- a/test/simple/test-buffer.js
+++ b/test/simple/test-buffer.js
@@ -1194,3 +1194,13 @@ assert.equal(Buffer('abc').indexOf(Buffer('bc')), 1)
 assert.equal(Buffer('abc').indexOf(Buffer([0x62,0x63])), 1)
 assert.equal(Buffer('abc').indexOf('bc', 1), 1)
 assert.equal(Buffer('abc').indexOf('bc', 2), -1)
+
+// LastIndexOf Tests
+assert.equal(Buffer('abcabc').lastIndexOf(''), 6)
+assert.equal(Buffer('abcabc').lastIndexOf('bd'), -1)
+assert.equal(Buffer('abcabc').lastIndexOf('bc'), 4)
+assert.equal(Buffer('abcabc').lastIndexOf(0x62), 4)
+assert.equal(Buffer('abcabc').lastIndexOf(Buffer('bc')), 4)
+assert.equal(Buffer('abcabc').lastIndexOf(Buffer([0x62,0x63])), 4)
+assert.equal(Buffer('abcabc').lastIndexOf('bc', 1), 4)
+assert.equal(Buffer('abcabc').lastIndexOf('bc', 5), -1)


### PR DESCRIPTION
Expanded on @srijs code to add a `Buffer.prototype.lastIndexOf`. I used a strategy of divide/conquer, but since I'm a total c++ idiot, I have no idea whether there is a better way (some reverse memcmp variant?). Also I rebased both srijs and these commits against v0.12 hoping it would make it out sooner :)