### PR TITLE
Module search security 8830

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -212,6 +212,8 @@ Module._nodeModulePaths = function(from) {
   // to be absolute.  Doing a fully-edge-case-correct path.split
   // that works on both Windows and Posix is non-trivial.
   var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
+  var home_dir = process.env[
+    (process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
   var paths = [];
   var parts = from.split(splitRe);
 
@@ -220,6 +222,8 @@ Module._nodeModulePaths = function(from) {
     if (parts[tip] === 'node_modules') continue;
     var dir = parts.slice(0, tip + 1).concat('node_modules').join(path.sep);
     paths.push(dir);
+    // If we have reached the user's home directory, stop searching
+    if (parts.slice(0, tip + 1).join(path.sep) == home_dir) break;
   }
 
   return paths;

--- a/test/simple/test-module-nodemodulepaths.js
+++ b/test/simple/test-module-nodemodulepaths.js
@@ -26,17 +26,40 @@ var module = require('module');
 
 var isWindows = process.platform === 'win32';
 
-var file, delimiter, paths;
+var file, delimiter, paths, expected_paths, old_home;
 
 if (isWindows) {
   file = 'C:\\Users\\Rocko Artischocko\\node_stuff\\foo';
   delimiter = '\\'
+  expected_paths = [
+    'C:\\Users\\Rocko Artischocko\\node_stuff\\foo\\node_modules',
+    'C:\\Users\\Rocko Artischocko\\node_stuff\\node_modules',
+    'C:\\Users\\Rocko Artischocko\\node_modules'
+  ];
+  old_home = process.env.USERPROFILE;
+  process.env.USERPROFILE = 'C:\\Users\\Rocko Artischocko';
 } else {
   file = '/usr/test/lib/node_modules/npm/foo';
   delimiter = '/'
+  expected_paths = [
+    '/usr/test/lib/node_modules/npm/foo/node_modules',
+    '/usr/test/lib/node_modules/npm/node_modules',
+    '/usr/test/lib/node_modules',
+    '/usr/test/node_modules'
+  ];
+  old_home = process.env.HOME;
+  process.env.HOME = '/usr/test';
 }
 
 paths = module._nodeModulePaths(file);
 
 assert.ok(paths.indexOf(file + delimiter + 'node_modules') !== -1);
+assert.deepEqual(expected_paths, paths);
 assert.ok(Array.isArray(paths));
+
+// Restore mocked home directory environment variables for other tests
+if (isWindows) {
+  process.env.USERPROFILE = old_home;
+} else {
+  process.env.HOME = old_home;
+}


### PR DESCRIPTION
It seems like some core contributors aren't the biggest fans of this, but this is a concern which should not be completely ignored.
I think that this is reasonable to protect against on multi-user Windows systems.
I would also update the accompanying docs.
I do not like what I'm doing with environment variables in the test, so if there is a better way to mock $HOME or the process module, please let me know.