### PR TITLE
crypto: add sync methods, deprecate optional callbacks

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -657,11 +657,15 @@ exports.setEngine = function setEngine(id, flags) {
   return binding.setEngine(id, flags);
 };
 
-exports.randomBytes = randomBytes;
-exports.pseudoRandomBytes = pseudoRandomBytes;
+exports.randomBytes = util.deprecateSync(randomBytes, '`crypto.randomBytes(size)` is deprecated. Please use `crypto.randomBytesSync(size)` instead.');
+exports.randomBytesSync = randomBytes;
+exports.pseudoRandomBytes = util.deprecateSync(pseudoRandomBytes, '`crypto.pseudoRandomBytes(size)` is deprecated. Please use `crypto.pseudoRandomBytesSync(size)` instead.');
+exports.pseudoRandomBytesSync = pseudoRandomBytes;
 
-exports.rng = randomBytes;
-exports.prng = pseudoRandomBytes;
+exports.rng = util.deprecateSync(randomBytes, '`crypto.rng(size)` is deprecated. Please us `crypto.rngSync(size)` instead.');
+exports.rngSync = randomBytes;
+exports.prng = util.deprecateSync(pseudoRandomBytes, '`crypto.prng(size)` is deprecated. Please us `crypto.prngSync(size)` instead.');
+exports.prngSync = pseudoRandomBytes;
 
 
 exports.getCiphers = function() {

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,6 +94,42 @@ exports.deprecate = function(fn, msg) {
   return deprecated;
 };
 
+// Mark that the synchronous version of a function is deprecated.
+// This is essentially the same as `exports.deprecate()`,
+// except it only warns if the last argument is not a callback function.
+exports.deprecateSync = function(fn, msg) {
+  // Allow for deprecating things in the process of starting up.
+  if (isUndefined(global.process)) {
+    return function() {
+      return exports.deprecateSync(fn, msg).apply(this, arguments);
+    };
+  }
+
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  var warned = false;
+  function deprecated() {
+    var cb = arguments[arguments.length - 1];
+    if (isFunction(cb))
+      return fn.apply(this, arguments);
+
+    if (!warned) {
+      if (process.throwDeprecation) {
+        throw new Error(msg);
+      } else if (process.traceDeprecation) {
+        console.trace(msg);
+      } else {
+        console.error(msg);
+      }
+      warned = true;
+    }
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};
 
 var debugs = {};
 var debugEnviron;


### PR DESCRIPTION
See https://github.com/iojs/io.js/issues/5

- would you like me to add/change tests?
- didn't bother disallowing callbacks in the `sync` version. after all this is about the public API. is that something you guys want?
- want doc updates?
- only changed `.randomBytes()` and `.pseudoRandomBytes()`. were there others?