### PR TITLE
src,deps: wrap library name with TEXT()

### DIFF
--- a/deps/cares/src/ares_library_init.c
+++ b/deps/cares/src/ares_library_init.c
@@ -45,7 +45,7 @@ static int ares_win32_init(void)
 #ifdef USE_WINSOCK
 
   hnd_iphlpapi = 0;
-  hnd_iphlpapi = LoadLibrary("iphlpapi.dll");
+  hnd_iphlpapi = LoadLibraryW(L"iphlpapi.dll");
   if (!hnd_iphlpapi)
     return ARES_ELOADIPHLPAPI;
 
@@ -73,7 +73,7 @@ static int ares_win32_init(void)
    */
 
   hnd_advapi32 = 0;
-  hnd_advapi32 = LoadLibrary("advapi32.dll");
+  hnd_advapi32 = LoadLibraryW(L"advapi32.dll");
   if (hnd_advapi32)
     {
       ares_fpSystemFunction036 = (fpSystemFunction036_t)

--- a/src/node_win32_etw_provider.cc
+++ b/src/node_win32_etw_provider.cc
@@ -167,7 +167,7 @@ void NTAPI etw_events_enable_callback(
 void init_etw() {
   events_enabled = 0;
 
-  advapi = LoadLibrary("advapi32.dll");
+  advapi = LoadLibraryW(L"advapi32.dll");
   if (advapi) {
     event_register = (EventRegisterFunc)
       GetProcAddress(advapi, "EventRegister");

--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -135,7 +135,7 @@ void InitPerfCountersWin32() {
   wcscpy_s(Inst, INST_MAX_LEN, INST_PREFIX);
   _itow_s(pid, Inst + INST_PREFIX_LEN, INST_MAX_LEN - INST_PREFIX_LEN, 10);
 
-  advapimod = LoadLibrary("advapi32.dll");
+  advapimod = LoadLibraryW(L"advapi32.dll");
   if (advapimod) {
     perfctr_startProvider = (PerfStartProviderExFunc)
       GetProcAddress(advapimod, "PerfStartProviderEx");


### PR DESCRIPTION
On Windows when compiling with unicode support, "LoadLibrary" will become "LoadLibraryW" and feeding it with an ANSCII string will cause crash in runtime.

Using TEXT() macro can make the code work no matter whether the unicode support is on.