### PR TITLE
src: generate debug symbols bundle on OS X

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -344,6 +344,9 @@
             # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
             'PLATFORM="darwin"',
           ],
+          'xcode_settings': {
+            'DEBUG_INFORMATION_FORMAT': 'dwarf-with-dsym',
+          },
         }],
         [ 'OS=="freebsd"', {
           'libraries': [


### PR DESCRIPTION
This will generate *.dSYM symbols on OS X, when we dispatch Node
binaries without debug symbols to users, it can be used to restore
meaningful stack trace from the crash report.

It doesn't affect generated binary.