### PR TITLE
net: improve error message when no address

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1126,7 +1126,7 @@ var createServerHandle = exports._createServerHandle =
 
 
 Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
-  debug('listen2', address, port, addressType, backlog);
+  debug('listen2', address, port, addressType, backlog, fd);
   var self = this;
 
   // If there is not yet a handle, we need to create one and bind.
@@ -1135,6 +1135,7 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
     debug('_listen2: create a handle');
     var rval = createServerHandle(address, port, addressType, fd);
     if (util.isNumber(rval)) {
+      address = address || '0.0.0.0';
       var error = exceptionWithHostPort(rval, 'listen', address, port);
       process.nextTick(function() {
         self.emit('error', error);

--- a/test/parallel/test-net-better-error-message-address.js
+++ b/test/parallel/test-net-better-error-message-address.js
@@ -1,0 +1,12 @@
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+
+var server = net.createServer(assert.fail);
+server.listen(1, assert.fail);
+server.on('error', common.mustCall(function(e) {
+  assert.equal(e.address, '0.0.0.0');
+  assert.equal(e.port, 1);
+  assert.equal(e.syscall, 'listen');
+  assert.equal(e.message, 'listen EACCES 0.0.0.0:1');
+}));


### PR DESCRIPTION
when use 'listen(80)' will get the 'listen EACCES null:80'. this fix will
make the error message better. like 'listen EACCES 0.0.0.0:80'.