### PR TITLE
util: show symbol properties

### DIFF
--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -52,8 +52,8 @@ Uses `util.inspect` on `obj` and prints resulting string to stdout. This functio
 bypasses any custom `inspect()` function on `obj`. An optional *options* object
 may be passed that alters certain aspects of the formatted string:
 
-- `showHidden` - if `true` then the object's non-enumerable properties will be
-shown too. Defaults to `false`.
+- `showHidden` - if `true` then the object's non-enumerable and symbol
+properties will be shown too. Defaults to `false`.
 
 - `depth` - tells `inspect` how many times to recurse while formatting the
 object. This is useful for inspecting large complicated objects. Defaults to

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -88,8 +88,8 @@ Return a string representation of `object`, which is useful for debugging.
 An optional *options* object may be passed that alters certain aspects of the
 formatted string:
 
- - `showHidden` - if `true` then the object's non-enumerable properties will be
-   shown too. Defaults to `false`.
+ - `showHidden` - if `true` then the object's non-enumerable and symbol
+   properties will be shown too. Defaults to `false`.
 
  - `depth` - tells `inspect` how many times to recurse while formatting the
    object. This is useful for inspecting large complicated objects. Defaults to

--- a/lib/util.js
+++ b/lib/util.js
@@ -240,6 +240,7 @@ function formatValue(ctx, value, recurseTimes) {
 
   if (ctx.showHidden) {
     keys = Object.getOwnPropertyNames(value);
+    keys = keys.concat(Object.getOwnPropertySymbols(value));
   }
 
   // This could be a boxed primitive (new String(), etc.), check valueOf()
@@ -422,7 +423,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
     }
   }
   keys.forEach(function(key) {
-    if (!key.match(/^\d+$/)) {
+    if (isSymbol(key) || !key.match(/^\d+$/)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
           key, true));
     }
@@ -446,7 +447,11 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (!hasOwnProperty(visibleKeys, key)) {
-    name = '[' + key + ']';
+    if (isSymbol(key)) {
+      name = '[' + ctx.stylize(key.toString(), 'symbol') + ']';
+    } else {
+      name = '[' + key + ']';
+    }
   }
   if (!str) {
     if (ctx.seen.indexOf(desc.value) < 0) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -243,4 +243,19 @@ if (typeof Symbol !== 'undefined') {
   assert.equal(util.inspect(Symbol('hi')), 'Symbol(hi)');
   assert.equal(util.inspect([Symbol()]), '[ Symbol() ]');
   assert.equal(util.inspect({ foo: Symbol() }), '{ foo: Symbol() }');
+
+  var options = { showHidden: true };
+  var subject = {};
+
+  subject[Symbol('symbol')] = 42;
+
+  assert.equal(util.inspect(subject), '{}');
+  assert.equal(util.inspect(subject, options), '{ [Symbol(symbol)]: 42 }');
+
+  subject = [1, 2, 3];
+  subject[Symbol('symbol')] = 42;
+
+  assert.equal(util.inspect(subject), '[ 1, 2, 3 ]');
+  assert.equal(util.inspect(subject, options), '[ 1, 2, 3, [length]: 3, [Symbol(symbol)]: 42 ]');
+
 }


### PR DESCRIPTION
Properties with symbol names are shown if option `showHidden` of `util.inspect` or `console.dir` is `true`.