### PR TITLE
src: fix `process.platform`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -325,7 +325,7 @@
           'defines': [
             'FD_SETSIZE=1024',
             # we need to use node's preferred "win32" rather than gyp's preferred "win"
-            'PLATFORM="win32"',
+            'NODE_PLATFORM="win32"',
             '_UNICODE=1',
           ],
           'libraries': [ '-lpsapi.lib' ]
@@ -337,11 +337,11 @@
           # like Instruments require it for some features
           'libraries': [ '-framework CoreFoundation' ],
           'defines!': [
-            'PLATFORM="mac"',
+            'NODE_PLATFORM="mac"',
           ],
           'defines': [
             # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
-            'PLATFORM="darwin"',
+            'NODE_PLATFORM="darwin"',
           ],
         }],
         [ 'OS=="freebsd"', {
@@ -356,12 +356,12 @@
             '-lumem',
           ],
           'defines!': [
-            'PLATFORM="solaris"',
+            'NODE_PLATFORM="solaris"',
           ],
           'defines': [
             # we need to use node's preferred "sunos"
             # rather than gyp's preferred "solaris"
-            'PLATFORM="sunos"',
+            'NODE_PLATFORM="sunos"',
           ],
         }],
         [ 'OS=="freebsd" or OS=="linux"', {

--- a/src/node.cc
+++ b/src/node.cc
@@ -2626,14 +2626,9 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(process, "arch", OneByteString(env->isolate(), NODE_ARCH));
 
   // process.platform
-#ifdef _WIN32
-  // As determined by gyp, NODE_PLATFORM equals 'win' on windows. However
-  // for historic reasons process.platform should be 'win32'.
-  Local<String> platform = OneByteString(env->isolate(), "win32");
-#else
-  Local<String> platform = OneByteString(env->isolate(), NODE_PLATFORM);
-#endif
-  READONLY_PROPERTY(process, "platform", platform);
+  READONLY_PROPERTY(process,
+                    "platform",
+                    OneByteString(env->isolate(), NODE_PLATFORM));
 
   // process.argv
   Local<Array> arguments = Array::New(env->isolate(), argc);


### PR DESCRIPTION
e1fe270fd7788836 introduces NODE_PLATFORM macro which had to be redefined in node.gyp for `process.platform` to return expected values.

Not sure about win and solaris (can't test), but for OS X `process.platform` returned `mac` instead of `darwin` and broke some tests.

/cc @piscisaureus 