### PR TITLE
build: disable harmony classes

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3355,6 +3355,12 @@ void Init(int* argc,
                 DispatchDebugMessagesAsyncCallback);
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
+  // TODO(bnoordhuis) V8 3.32 is unshipping Harmony classes for the moment.
+  // We're currently at 3.31, disable classes for feature parity.  Remove
+  // again when we upgrade.
+  V8::SetFlagsFromString("--noharmony_classes",
+                         sizeof("--noharmony_classes") - 1);
+
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
   // so the user can disable a flag --foo at run-time by passing

--- a/src/node.cc
+++ b/src/node.cc
@@ -3360,6 +3360,8 @@ void Init(int* argc,
   // again when we upgrade.
   V8::SetFlagsFromString("--noharmony_classes",
                          sizeof("--noharmony_classes") - 1);
+  V8::SetFlagsFromString("--noharmony_object_literals",
+                         sizeof("--noharmony_object_literals") - 1);
 
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()

--- a/test/parallel/test-v8-features.js
+++ b/test/parallel/test-v8-features.js
@@ -19,3 +19,13 @@ var args = ['--harmony_classes', '--use_strict', '-p', 'class C {}'];
 var cp = spawnSync(process.execPath, args);
 assert.equal(cp.status, 0);
 assert.equal(cp.stdout.toString('utf8').trim(), '[Function: C]');
+
+// Now do the same for --harmony_object_literals.
+assert.throws(function() { eval('({ f() {} })'); }, SyntaxError);
+v8.setFlagsFromString('--harmony_object_literals');
+eval('({ f() {} })');
+
+var args = ['--harmony_object_literals', '-p', '({ f() {} })'];
+var cp = spawnSync(process.execPath, args);
+assert.equal(cp.status, 0);
+assert.equal(cp.stdout.toString('utf8').trim(), '{ f: [Function: f] }');

--- a/test/parallel/test-v8-features.js
+++ b/test/parallel/test-v8-features.js
@@ -1,0 +1,21 @@
+var common = require('../common');
+var assert = require('assert');
+var spawnSync = require('child_process').spawnSync;
+var v8 = require('v8');
+
+// --harmony_classes implies --harmony_scoping; ensure that scoping still works
+// when classes are disabled.
+assert.throws(function() { eval('"use strict"; class C {}'); }, SyntaxError);
+eval('"use strict"; let x = 42');  // Should not throw.
+eval('"use strict"; const y = 42');  // Should not throw.
+
+v8.setFlagsFromString('--harmony_classes');
+eval('"use strict"; class C {}');  // Should not throw.
+eval('"use strict"; let x = 42');  // Should not throw.
+eval('"use strict"; const y = 42');  // Should not throw.
+
+// Verify that the --harmony_classes flag unlocks classes again.
+var args = ['--harmony_classes', '--use_strict', '-p', 'class C {}'];
+var cp = spawnSync(process.execPath, args);
+assert.equal(cp.status, 0);
+assert.equal(cp.stdout.toString('utf8').trim(), '[Function: C]');


### PR DESCRIPTION
The V8 development branch has unshipped ES6 classes pending resolution
of a number of inheritance edge cases.  Disable classes in io.js for
the sake of feature parity.

See https://github.com/iojs/io.js/issues/251 for background and
discussion.

R=@iojs/tc