### PR TITLE
deps: fix zlib -Wimplicit-function-declaration

### DIFF
--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -62,6 +62,7 @@
             ['OS!="win"', {
               'product_name': 'chrome_zlib',
               'cflags!': [ '-ansi' ],
+              'defines': [ 'Z_HAVE_UNISTD_H' ],
               'sources!': [
                 'contrib/minizip/iowin32.c'
               ],


### PR DESCRIPTION
Build the bundled zlib with -DZ_HAVE_UNISTD_H to make the definition of
close(), read() and other unistd.h functions available to gzread.c and
gzwrite.c.  It's kind of silly that we have to jump through hoops here
because we never call any of the functions that do I/O directly, but
at least it squelches the -Wimplicit-function-declaration warnings.

R=@piscisaureus or @shigeki