### PR TITLE
core: throw TypeError if chdir() args don't match signature

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1499,8 +1499,7 @@ static void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   if (args.Length() != 1 || !args[0]->IsString()) {
-    // FIXME(bnoordhuis) ThrowTypeError?
-    return env->ThrowError("Bad argument.");
+    return env->ThrowTypeError("Bad argument.");
   }
 
   node::Utf8Value path(args.GetIsolate(), args[0]);

--- a/test/sequential/test-chdir.js
+++ b/test/sequential/test-chdir.js
@@ -38,3 +38,8 @@ assert(process.cwd() == dir);
 process.chdir('..');
 assert(process.cwd() == path.resolve(common.fixturesDir));
 fs.rmdirSync(dir);
+
+assert.throws(function() { process.chdir({}); }, TypeError, 'Bad argument.');
+assert.throws(function() { process.chdir(); }, TypeError, 'Bad argument.');
+assert.throws(function() { process.chdir("x", "y"); }, TypeError, 'Bad argument.');
+


### PR DESCRIPTION
A little stab at #264. I'm doing my part!

The compat risk for changing this is pretty low. (there are a lot of other APIs implemented in C++ which should be changed in the same way)