### PR TITLE
fs: use ES6 octal literals for mode

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -270,7 +270,7 @@ Synchronous rmdir(2).
 ## fs.mkdir(path[, mode], callback)
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback. `mode` defaults to `0777`.
+to the completion callback. `mode` defaults to `0o777`.
 
 ## fs.mkdirSync(path[, mode])
 
@@ -486,7 +486,7 @@ string. Otherwise it returns a buffer.
 * `data` {String | Buffer}
 * `options` {Object}
   * `encoding` {String | Null} default = `'utf8'`
-  * `mode` {Number} default = `438` (aka `0666` in Octal)
+  * `mode` {Number} default = `0o666`
   * `flag` {String} default = `'w'`
 * `callback` {Function}
 
@@ -513,7 +513,7 @@ The synchronous version of `fs.writeFile`.
 * `data` {String | Buffer}
 * `options` {Object}
   * `encoding` {String | Null} default = `'utf8'`
-  * `mode` {Number} default = `438` (aka `0666` in Octal)
+  * `mode` {Number} default = `0o666`
   * `flag` {String} default = `'a'`
 * `callback` {Function}
 
@@ -770,7 +770,7 @@ Returns a new ReadStream object (See `Readable Stream`).
     { flags: 'r',
       encoding: null,
       fd: null,
-      mode: 0666,
+      mode: 0o666,
       autoClose: true
     }
 
@@ -812,7 +812,7 @@ Returns a new WriteStream object (See `Writable Stream`).
     { flags: 'w',
       encoding: null,
       fd: null,
-      mode: 0666 }
+      mode: 0o666 }
 
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -19,11 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Maintainers, keep in mind that octal literals are not allowed
-// in strict mode. Use the decimal value and add a comment with
-// the octal value. Example:
-//
-//   var mode = 438; /* mode=0666 */
+// Maintainers, keep in mind that ES1-style octal literals (`0666`) are not
+// allowed in strict mode. Use ES6-style octal literals instead (`0o666`).
 
 'use strict';
 
@@ -262,7 +259,7 @@ fs.readFile = function(path, options, callback_) {
   var fd;
 
   var flag = options.flag || 'r';
-  fs.open(path, flag, 438 /*=0666*/, function(er, fd_) {
+  fs.open(path, flag, 0o666, function(er, fd_) {
     if (er) return callback(er);
     fd = fd_;
 
@@ -352,7 +349,7 @@ fs.readFileSync = function(path, options) {
   assertEncoding(encoding);
 
   var flag = options.flag || 'r';
-  var fd = fs.openSync(path, flag, 438 /*=0666*/);
+  var fd = fs.openSync(path, flag, 0o666);
 
   var size;
   var threw = true;
@@ -484,7 +481,7 @@ function modeNum(m, def) {
 
 fs.open = function(path, flags, mode, callback) {
   callback = makeCallback(arguments[arguments.length - 1]);
-  mode = modeNum(mode, 438 /*=0666*/);
+  mode = modeNum(mode, 0o666);
 
   if (!nullCheck(path, callback)) return;
 
@@ -498,7 +495,7 @@ fs.open = function(path, flags, mode, callback) {
 };
 
 fs.openSync = function(path, flags, mode) {
-  mode = modeNum(mode, 438 /*=0666*/);
+  mode = modeNum(mode, 0o666);
   nullCheck(path);
   return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
 };
@@ -743,14 +740,14 @@ fs.mkdir = function(path, mode, callback) {
   var req = new FSReqWrap();
   req.oncomplete = callback;
   binding.mkdir(pathModule._makeLong(path),
-                modeNum(mode, 511 /*=0777*/),
+                modeNum(mode, 0o777),
                 req);
 };
 
 fs.mkdirSync = function(path, mode) {
   nullCheck(path);
   return binding.mkdir(pathModule._makeLong(path),
-                       modeNum(mode, 511 /*=0777*/));
+                       modeNum(mode, 0o777));
 };
 
 fs.readdir = function(path, callback) {
@@ -1069,9 +1066,9 @@ fs.writeFile = function(path, data, options, callback) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
   if (util.isFunction(options) || !options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
+    options = { encoding: 'utf8', mode: 0o666, flag: 'w' };
   } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'w' };
+    options = { encoding: options, mode: 0o666, flag: 'w' };
   } else if (!util.isObject(options)) {
     throw new TypeError('Bad arguments');
   }
@@ -1093,9 +1090,9 @@ fs.writeFile = function(path, data, options, callback) {
 
 fs.writeFileSync = function(path, data, options) {
   if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'w' };
+    options = { encoding: 'utf8', mode: 0o666, flag: 'w' };
   } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'w' };
+    options = { encoding: options, mode: 0o666, flag: 'w' };
   } else if (!util.isObject(options)) {
     throw new TypeError('Bad arguments');
   }
@@ -1124,9 +1121,9 @@ fs.appendFile = function(path, data, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);
 
   if (util.isFunction(options) || !options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
+    options = { encoding: 'utf8', mode: 0o666, flag: 'a' };
   } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'a' };
+    options = { encoding: options, mode: 0o666, flag: 'a' };
   } else if (!util.isObject(options)) {
     throw new TypeError('Bad arguments');
   }
@@ -1138,9 +1135,9 @@ fs.appendFile = function(path, data, options, callback_) {
 
 fs.appendFileSync = function(path, data, options) {
   if (!options) {
-    options = { encoding: 'utf8', mode: 438 /*=0666*/, flag: 'a' };
+    options = { encoding: 'utf8', mode: 0o666, flag: 'a' };
   } else if (util.isString(options)) {
-    options = { encoding: options, mode: 438, flag: 'a' };
+    options = { encoding: options, mode: 0o666, flag: 'a' };
   } else if (!util.isObject(options)) {
     throw new TypeError('Bad arguments');
   }
@@ -1578,7 +1575,7 @@ function ReadStream(path, options) {
   this.path = path;
   this.fd = options.hasOwnProperty('fd') ? options.fd : null;
   this.flags = options.hasOwnProperty('flags') ? options.flags : 'r';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+  this.mode = options.hasOwnProperty('mode') ? options.mode : 0o666;
 
   this.start = options.hasOwnProperty('start') ? options.start : undefined;
   this.end = options.hasOwnProperty('end') ? options.end : undefined;
@@ -1746,7 +1743,7 @@ function WriteStream(path, options) {
 
   this.fd = options.hasOwnProperty('fd') ? options.fd : null;
   this.flags = options.hasOwnProperty('flags') ? options.flags : 'w';
-  this.mode = options.hasOwnProperty('mode') ? options.mode : 438; /*=0666*/
+  this.mode = options.hasOwnProperty('mode') ? options.mode : 0o666;
 
   this.start = options.hasOwnProperty('start') ? options.start : undefined;
   this.pos = undefined;


### PR DESCRIPTION
Update docs, comments and code to use ES6 octal literals instead of decimal + comment.