### PR TITLE
build: Warn when using snapshot on Armv6

### DIFF
--- a/configure
+++ b/configure
@@ -954,4 +954,8 @@ else:
 
 gyp_args += args
 
+#print warning when snapshot is enabled and building on armv6
+if (is_arch_armv6()) and (not options.without_snapshot):
+  print '\033[1;33mWarning!! When building on ARMv6 use --without-snapshot\033[1;m'
+
 sys.exit(subprocess.call(gyp_args))


### PR DESCRIPTION
Building io.js on armv6 with snapshot enabled does not work due to a bug in v8, so it now is disabled by default when building on armv6.
However I added a --force-snapshot option so the user can enable snapshot for debuging purposes.

I found this problem while trying to build io.js on my Raspberry Pi. With snapshot disabled v8 and all of the code compiles
, but still when testing io.js I get an 'illegal instruction' error. I´ll open an issue for that.