### PR TITLE
doc: remove changelog.html from doc make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ website_files = \
 	out/doc/sh_main.js    \
 	out/doc/sh_javascript.min.js
 
-doc: $(apidoc_dirs) $(website_files) $(apiassets) $(apidocs) tools/doc/ out/doc/changelog.html $(NODE_EXE)
+doc: $(apidoc_dirs) $(website_files) $(apiassets) $(apidocs) tools/doc/ $(NODE_EXE)
 
 $(apidoc_dirs):
 	mkdir -p $@


### PR DESCRIPTION
While we figure out what to do about our changelog, I'd like it removed from the `make doc` target. It fails now anyway because `tools/build_changelog.sh` uses `./node` which doesn't exist.
We can put it back in later if need be but it may be best to keep it separate anyway since they aren't tightly linked to the rest of the docs.