### PR TITLE
Remove TODO for moving net.isIP into dns

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1442,8 +1442,6 @@ Server.prototype.unref = function() {
 };
 
 
-// TODO: isIP should be moved to the DNS code. Putting it here now because
-// this is what the legacy system did.
 exports.isIP = cares.isIP;
 
 


### PR DESCRIPTION
Moves isIP and related functions to dns.

This change does affect how the dns module is loaded in net. It is no longer loaded lazily. 

This PR also updates the docs for the change.

**EDIT: Updated to simply remove the comment.**