### PR TITLE
version: only append "-pre" to version if no tag

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -28,25 +28,27 @@
 
 #define NODE_VERSION_IS_RELEASE 0
 
-#ifndef NODE_TAG
-# define NODE_TAG ""
-#endif
-
 #ifndef NODE_STRINGIFY
 #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)
 #define NODE_STRINGIFY_HELPER(n) #n
 #endif
 
 #if NODE_VERSION_IS_RELEASE
+# ifndef NODE_TAG
+#  define NODE_TAG ""
+# endif
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
                               NODE_TAG
 #else
+# ifndef NODE_TAG
+#  define NODE_TAG "-pre"
+# endif
 # define NODE_VERSION_STRING  NODE_STRINGIFY(NODE_MAJOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_MINOR_VERSION) "." \
                               NODE_STRINGIFY(NODE_PATCH_VERSION)     \
-                              NODE_TAG "-pre"
+                              NODE_TAG
 #endif
 
 #define NODE_VERSION "v" NODE_VERSION_STRING


### PR DESCRIPTION
I'm using the `TAG` for nightlies (not using the `NIGHTLY` mechanism in the Makefile exactly as designed, but that's a future pull request) and would like to not have `-pre` on the end for them. With this change, nightlies come out like this:

```text
$ ./iojs -v
v1.0.0-nightly20150110a32b92dbcf
```