### PR TITLE
build: move armv6 snapshot test to configure_arm()

### DIFF
--- a/configure
+++ b/configure
@@ -436,6 +436,10 @@ def configure_arm(o):
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi
 
+  # Print warning when snapshot is enabled and building on armv6
+  if is_arch_armv6() and not options.without_snapshot:
+    print '\033[1;33mWarning!! When building on ARMv6 use --without-snapshot\033[1;m'
+
 
 def configure_node(o):
   if options.dest_os == 'android':
@@ -943,9 +947,5 @@ else:
   gyp_args += ['-f', 'make-' + flavor]
 
 gyp_args += args
-
-#print warning when snapshot is enabled and building on armv6
-if (is_arch_armv6()) and (not options.without_snapshot):
-  print '\033[1;33mWarning!! When building on ARMv6 use --without-snapshot\033[1;m'
 
 sys.exit(subprocess.call(gyp_args))


### PR DESCRIPTION
fails on windows because is_arch_armv6() calls CC to get properties, so moved to a scope where we know we're at least on ARM

please review @chrisdickinson 

/cc @Cydox 