### PR TITLE
url: fix parsing of ssh urls

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -72,9 +72,8 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
     hostEndingChars = ['/', '?', '#'],
     hostnameMaxLen = 255,
-    hostnamePatternString = '[^' + nonHostChars.join('') + ']{0,63}',
-    hostnamePartPattern = new RegExp('^' + hostnamePatternString + '$'),
-    hostnamePartStart = new RegExp('^(' + hostnamePatternString + ')(.*)$'),
+    hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/,
+    hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/,
     // protocols that can allow "unsafe" and "unwise" chars.
     unsafeProtocol = {
       'javascript': true,

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -857,6 +857,22 @@ var parseTests = {
     pathname: '%0D%0Ad/e',
     path: '%0D%0Ad/e?f',
     href: 'http://a%0D%22%20%09%0A%3C\'b:b@c/%0D%0Ad/e?f'
+  },
+
+  // git urls used by npm
+  'git+ssh://git@github.com:npm/npm': {
+    protocol: 'git+ssh:',
+    slashes: true,
+    auth: 'git',
+    host: 'github.com',
+    port: null,
+    hostname: 'github.com',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/:npm/npm',
+    path: '/:npm/npm',
+    href: 'git+ssh://git@github.com/:npm/npm'
   }
 
 };


### PR DESCRIPTION
Fix regression introduced in 61204720361824881aefd64f5bccda7d7be6617a
that broke parsing of some ssh: urls.

An example url is git+ssh://git@github.com:npm/npm.git

See #295 