### PR TITLE
fs: undeprecate exists() and existsSync()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -217,7 +217,7 @@ fs.accessSync = function(path, mode) {
   binding.access(pathModule._makeLong(path), mode);
 };
 
-fs.exists = util.deprecate(function(path, callback) {
+fs.exists = function(path, callback) {
   if (!nullCheck(path, cb)) return;
   var req = new FSReqWrap();
   req.oncomplete = cb;
@@ -225,9 +225,9 @@ fs.exists = util.deprecate(function(path, callback) {
   function cb(err, stats) {
     if (callback) callback(err ? false : true);
   }
-}, 'fs.exists() is deprecated. Use fs.access() instead.');
+};
 
-fs.existsSync = util.deprecate(function(path) {
+fs.existsSync = function(path) {
   try {
     nullCheck(path);
     binding.stat(pathModule._makeLong(path));
@@ -235,7 +235,7 @@ fs.existsSync = util.deprecate(function(path) {
   } catch (e) {
     return false;
   }
-}, 'fs.existsSync() is deprecated. Use fs.accessSync() instead.');
+};
 
 fs.readFile = function(path, options, callback_) {
   var callback = maybeCallback(arguments[arguments.length - 1]);


### PR DESCRIPTION
`fs.exists()` and `fs.existsSync()` were deprecated in #103. This commit removes the deprecation message, in order to stay more in sync with joyent/node for the io.js 1.0.0 release. Closes #257.

R=@piscisaureus 