### PR TITLE
addon: update NODE_MODULE_VERSION macro

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -66,6 +66,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 14 /* v0.12 */
+#define NODE_MODULE_VERSION 42  /* io.js v1.0.0 */
 
 #endif  /* SRC_NODE_VERSION_H_ */


### PR DESCRIPTION
io.js v1.0.0 is not ABI-compatible with joyent/node@v0.12, update
the NODE_MODULE_VERSION macro to reflect that.  Update to a much
larger value to avoid future clashes with joyent/node.

R=@piscisaureus