### PR TITLE
test: fix `make test-addons` target

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -173,5 +173,6 @@ class AddonTestConfiguration(SimpleTestConfiguration):
     for test in all_tests:
       if self.Contains(path, test):
         file_path = join(self.root, reduce(join, test[1:], "") + ".js")
-        result.append(SimpleTestCase(test, file_path, mode, self.context, self))
+        result.append(
+            SimpleTestCase(test, file_path, arch, mode, self.context, self))
     return result


### PR DESCRIPTION
I broke the python script in commit edaf7af but because test-all does
not run test-addons, it slipped under the radar.  Mea culpa.

Fixes the following test runner error:

    Traceback (most recent call last):
      File "tools/test.py", line 1522, in <module>
        sys.exit(Main())
      File "tools/test.py", line 1454, in Main
        test_list = root.ListTests([], path, context, arch, mode)
      File "tools/test.py", line 720, in ListTests
        test.AddTestsToList(result, full_path, path, context, arch, mode)
      File "tools/test.py", line 690, in AddTestsToList
        arch, mode)
      File "/home/bnoordhuis/src/v1.x/test/gc/../testpy/__init__.py", line 176, in ListTests
        result.append(SimpleTestCase(test, file_path, mode, self.context, self))
    TypeError: __init__() takes at least 7 arguments (6 given)

R=@chrisdickinson