### PR TITLE
test: add test/addons to default test list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ test-all: test-build test/gc/node_modules/weak/build/Release/weakref.node
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
+test-ci: test-build
+	$(PYTHON) tools/test.py -J parallel sequential message addons
+
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,6 @@ test-build: all build-addons
 
 test-all: test-build test/gc/node_modules/weak/build/Release/weakref.node
 	$(PYTHON) tools/test.py --mode=debug,release
-	make test-npm
 
 test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -210,7 +210,7 @@ _ERROR_CATEGORIES = [
 # flag. By default all errors are on, so only add here categories that should be
 # off by default (i.e., categories that must be enabled by the --filter= flags).
 # All entries here should start with a '-' or '+', as in the --filter= flag.
-_DEFAULT_FILTERS = [ '-build/include_alpha' ]
+_DEFAULT_FILTERS = [ '-build/include_alpha', '-legal/copyright' ]
 
 # We used to check for high-bit characters, but after much discussion we
 # decided those were OK, as long as they were in UTF-8 and didn't represent

--- a/tools/test.py
+++ b/tools/test.py
@@ -1357,6 +1357,7 @@ BUILT_IN_TESTS = [
   'pummel',
   'message',
   'internet',
+  'addons',
   'gc',
   'debugger',
 ]


### PR DESCRIPTION
R=@rvagg, /cc @othiym23

The only not-so-nice thing is that `make test-all` rebuilds the addons every time you run it.  I'll try to figure out something for that later.