### PR TITLE
build,src: remove sslv3 support

### DIFF
--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -1098,6 +1098,9 @@
       # twenty years now.
       'OPENSSL_NO_SSL2',
 
+      # SSLv3 is susceptible to downgrade attacks (POODLE.)
+      'OPENSSL_NO_SSL3',
+
       # Heartbeat is a TLS extension, that couldn't be turned off or
       # asked to be not advertised. Unfortunately this is unacceptable for
       # Microsoft's IIS, which seems to be ignoring whole ClientHello after

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -61,13 +61,15 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
 
   // Check hello protocol version.  Protocol tuples that we know about:
   //
-  // (3,0) SSL v3.0
   // (3,1) TLS v1.0
   // (3,2) TLS v1.1
   // (3,3) TLS v1.2
   //
-  if (data[body_offset_ + 4] != 0x03 || data[body_offset_ + 5] > 0x03)
+  if (data[body_offset_ + 4] != 0x03 ||
+      data[body_offset_ + 5] < 0x01 ||
+      data[body_offset_ + 5] > 0x03) {
     goto fail;
+  }
 
   if (data[body_offset_] == kClientHello) {
     if (state_ == kTLSHeader) {

--- a/test/parallel/test-tls-no-sslv23.js
+++ b/test/parallel/test-tls-no-sslv23.js
@@ -1,0 +1,52 @@
+if (!process.versions.openssl) {
+  console.error('Skipping because node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var tls = require('tls');
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'blargh' });
+}, /Unknown method/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_method' });
+}, /SSLv2 methods disabled/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_client_method' });
+}, /SSLv2 methods disabled/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv2_server_method' });
+}, /SSLv2 methods disabled/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_method' });
+}, /SSLv3 methods disabled/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_client_method' });
+}, /SSLv3 methods disabled/);
+
+assert.throws(function() {
+  tls.createSecureContext({ secureProtocol: 'SSLv3_server_method' });
+}, /SSLv3 methods disabled/);
+
+// Note that SSLv2 and SSLv3 are disallowed but SSLv2_method and friends are
+// still accepted.  They are OpenSSL's way of saying that all known protocols
+// are supported unless explicitly disabled (which we do for SSLv2 and SSLv3.)
+tls.createSecureContext({ secureProtocol: 'SSLv23_method' });
+tls.createSecureContext({ secureProtocol: 'SSLv23_client_method' });
+tls.createSecureContext({ secureProtocol: 'SSLv23_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_1_server_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_client_method' });
+tls.createSecureContext({ secureProtocol: 'TLSv1_2_server_method' });

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -1,0 +1,34 @@
+if (!process.versions.openssl) {
+  console.error('Skipping because node compiled without OpenSSL.');
+  process.exit(0);
+}
+
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var spawn = require('child_process').spawn;
+var tls = require('tls');
+
+var cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');
+var key = fs.readFileSync(common.fixturesDir + '/test_key.pem');
+var server = tls.createServer({ cert: cert, key: key }, assert.fail);
+
+server.listen(common.PORT, '127.0.0.1', function() {
+  var address = this.address().address + ':' + this.address().port;
+  var args = ['s_client',
+              '-no_ssl2',
+              '-ssl3',
+              '-no_tls1',
+              '-no_tls1_1',
+              '-no_tls1_2',
+              '-connect', address];
+  var client = spawn(common.opensslCli, args, { stdio: 'inherit' });
+  client.once('exit', common.mustCall(function(exitCode) {
+    assert.equal(exitCode, 1);
+    server.close();
+  }));
+});
+
+server.once('clientError', common.mustCall(function(err, conn) {
+  assert(/SSL3_GET_CLIENT_HELLO:wrong version number/.test(err.message));
+}));


### PR DESCRIPTION
SSLv3 is susceptible to downgrade attacks.  Provide secure defaults,
disable v3 protocol support entirely.

R=@indutny, /cc @iojs/tc