### PR TITLE
test: fix message tests regression

### DIFF
--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_custom_error.js:31
+*test*message*throw_custom_error.js:7
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });
 ^
 MyCustomError: This is a custom message

--- a/test/message/throw_in_line_with_tabs.out
+++ b/test/message/throw_in_line_with_tabs.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_in_line_with_tabs.js:32
+*test*message*throw_in_line_with_tabs.js:8
 	throw ({ foo: 'bar' });
 	^
 [object Object]

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_non_error.js:31
+*test*message*throw_non_error.js:7
 throw ({ foo: 'bar' });
 ^
 [object Object]

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_null.js:25
+*test*message*throw_null.js:4
 throw null;
 ^      
 null

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_undefined.js:25
+*test*message*throw_undefined.js:4
 throw undefined;
       ^
 undefined


### PR DESCRIPTION
Commit 3e1b1dd ("Remove excessive copyright/license boilerplate") broke
some of the message tests because without the license boilerplate at
the top, the line numbers no longer match up.

R=@isaacs