### PR TITLE
build: remove artefacts on distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ distclean:
 	-rm -rf node_modules
 	-rm -rf deps/icu
 	-rm -rf deps/icu4c*.tgz deps/icu4c*.zip deps/icu-tmp
+	-rm -f $(BINARYTAR).* $(TARBALL).*
 
 test: all
 	$(PYTHON) tools/test.py --mode=release message parallel sequential -J


### PR DESCRIPTION
since .pkg-files already lives in out/ they're already gone. instead of
moving artefacts into out/ (which might mess with upload scripts),
delete their current location.

Refs #301 

/cc @rvagg 