### PR TITLE
build: create separate rebuild-doc-addons target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,11 @@ test/gc/node_modules/weak/build/Release/weakref.node: $(NODE_EXE)
 		--directory="$(shell pwd)/test/gc/node_modules/weak" \
 		--nodedir="$(shell pwd)"
 
-build-addons: $(NODE_EXE)
+rebuild-doc-addons: $(NODE_EXE)
 	rm -rf test/addons/doc-*/
 	./$(NODE_EXE) tools/doc/addon-verify.js
+
+build-addons: rebuild-doc-addons
 	$(foreach dir, \
 			$(sort $(dir $(wildcard test/addons/*/*.gyp))), \
 			./$(NODE_EXE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \


### PR DESCRIPTION
this allows the build-addons target to "see" the
directories that verify-addons.js is creating, which
prevents errors in downstream targets on clean test runs.

---------

NB: I am not a wizard with `make` -- if you see something wrong here, I'm probably totally wrong!