### PR TITLE
src: limit .gitattributes eol to vcbuild.bat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 test/fixtures/* -text
-*.bat text eol=crlf
+vcbuild.bat text eol=crlf


### PR DESCRIPTION
Fixes: https://github.com/iojs/io.js/issues/330

limit the crlf change to vcbuild.bat