### PR TITLE
doc: Remove tracing link in toc

### DIFF
--- a/doc/api/_toc.markdown
+++ b/doc/api/_toc.markdown
@@ -31,7 +31,6 @@
 * [String Decoder](string_decoder.html)
 * [Timers](timers.html)
 * [TLS/SSL](tls.html)
-* [Tracing](tracing.html)
 * [TTY](tty.html)
 * [UDP/Datagram](dgram.html)
 * [URL](url.html)


### PR DESCRIPTION
When I checked the new api documents, I got 404 error. 
[https://iojs.org/download/nightly/v1.0.0-nightly201501135ea716d895/doc/api/tracing.html](https://iojs.org/download/nightly/v1.0.0-nightly201501135ea716d895/doc/api/tracing.html)

tracing api is not included in version 1.0. 