### PR TITLE
deps: make node-gyp fetch tarballs from iojs.org

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
 
 
   // Determine which node dev files version we are installing
@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
 
       // now download the node tarball
       var tarPath = gyp.opts['tarball']
-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
+      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
         , badDownload = false
         , extractCount = 0
         , gunzip = zlib.createGunzip()


### PR DESCRIPTION
Apply a small patch that makes node-gyp fetch the tarballs from
https://iojs.org/ instead of http://nodejs.org/

A patch better suited for inclusion upstream will be put together
shortly.

R=@rvagg

Note that /dist doesn't currently exist.