### PR TITLE
test: introduce a test for process.versions output

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -1,0 +1,7 @@
+require('../common');
+var assert = require('assert');
+
+var expected_keys = ['ares', 'http_parser', 'modules', 'node',
+                     'openssl', 'uv', 'v8', 'zlib'];
+
+assert.deepEqual(Object.keys(process.versions).sort(), expected_keys);


### PR DESCRIPTION
make sure that process.versions contains an expected list to avoid potential mistakes with refactoring.

/cc @indutny 