### PR TITLE
build: rename ChangeLog to CHANGELOG.md in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ $(apidoc_dirs):
 out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets/
 	cp $< $@
 
-out/doc/changelog.html: ChangeLog doc/changelog-head.html doc/changelog-foot.html tools/build-changelog.sh $(NODE_EXE)
+out/doc/changelog.html: CHANGELOG.md doc/changelog-head.html doc/changelog-foot.html tools/build-changelog.sh $(NODE_EXE)
 	bash tools/build-changelog.sh
 
 out/doc/%: doc/%
@@ -212,7 +212,7 @@ out/doc/api/%.json: doc/api/%.markdown $(NODE_EXE)
 out/doc/api/%.html: doc/api/%.markdown $(NODE_EXE)
 	out/Release/$(NODE_EXE) tools/doc/generate.js --format=html --template=doc/template.html $< > $@
 
-email.md: ChangeLog tools/email-footer.md
+email.md: CHANGELOG.md tools/email-footer.md
 	bash tools/changelog-head.sh | sed 's|^\* #|* \\#|g' > $@
 	cat tools/email-footer.md | sed -e 's|__VERSION__|'$(VERSION)'|g' >> $@
 
@@ -335,7 +335,7 @@ $(BINARYTAR): release-only
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
 	cp README.md $(BINARYNAME)
 	cp LICENSE $(BINARYNAME)
-	cp ChangeLog $(BINARYNAME)
+	cp CHANGELOG.md $(BINARYNAME)
 	tar -cf $(BINARYNAME).tar $(BINARYNAME)
 	rm -rf $(BINARYNAME)
 	gzip -c -f -9 $(BINARYNAME).tar > $(BINARYNAME).tar.gz

--- a/tools/build-changelog.sh
+++ b/tools/build-changelog.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cat ChangeLog \
+cat CHANGELOG.md \
   | sed -E 's|([^/ ]+/[^#]+)#([0-9]+)|[\1#\2](https://github.com/\1/issues/\2)|g' \
   | sed -E 's| #([0-9]+)| [#\1](https://github.com/joyent/node/issues/\1)|g' \
   | sed -E 's|([0-9]+\.[0-9]+\.[0-9]+),? Version ([0-9]+\.[0-9]+\.[0-9]+)|<a id="v\2"></a>\

--- a/tools/changelog-head.sh
+++ b/tools/changelog-head.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cat ChangeLog | {
+cat CHANGELOG.md | {
   s=-1
   while read line; do
     if [ "${line:0:1}" == "-" ]; then


### PR DESCRIPTION
This only matters for the Makefile tarball target
as we aren't auto-building changelog.html at the moment
so the changes in tools/ are for completeness, but
not functional with the Markdown CHANGELOG.md.