### PR TITLE
src: fix documentation url in help message

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2911,7 +2911,7 @@ static void PrintHelp() {
 #endif
 #endif
          "\n"
-         "Documentation can be found at http://nodejs.org/\n");
+         "Documentation can be found at https://iojs.org/\n");
 }
 
 


### PR DESCRIPTION
Refer to http://iojs.org/ for documentation