### PR TITLE
Improve performance of event and timer interfaces

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -173,8 +173,9 @@ exports.active = function(item) {
  */
 
 
-exports.setTimeout = function(callback, after) {
-  var timer;
+exports.setTimeout = function(callback, after, arg1, arg2, arg3) {
+  var timer, i, args;
+  var len = arguments.length;
 
   after *= 1; // coalesce to number or NaN
 
@@ -184,22 +185,38 @@ exports.setTimeout = function(callback, after) {
 
   timer = new Timeout(after);
 
-  if (arguments.length <= 2) {
-    timer._onTimeout = callback;
-  } else {
-    /*
-     * Sometimes setTimeout is called with arguments, EG
-     *
-     *   setTimeout(callback, 2000, "hello", "world")
-     *
-     * If that's the case we need to call the callback with
-     * those args. The overhead of an extra closure is not
-     * desired in the normal case.
-     */
-    var args = Array.prototype.slice.call(arguments, 2);
-    timer._onTimeout = function() {
-      callback.apply(timer, args);
-    };
+  switch (len) {
+    // fast cases
+    case 0:
+    case 1:
+    case 2:
+      timer._onTimeout = callback;
+      break;
+    case 3:
+      timer._onTimeout = function() {
+        callback.call(timer, arg1);
+      };
+      break;
+    case 4:
+      timer._onTimeout = function() {
+        callback.call(timer, arg1, arg2);
+      };
+      break;
+    case 5:
+      timer._onTimeout = function() {
+        callback.call(timer, arg1, arg2, arg3);
+      };
+      break;
+    // slow case
+    default:
+      args = new Array(len - 2);
+      for (i = 2; i < len; i++)
+        args[i - 2] = arguments[i];
+
+      timer._onTimeout = function() {
+        callback.apply(timer, args);
+      };
+      break;
   }
 
   if (process.domain) timer.domain = process.domain;
@@ -222,17 +239,24 @@ exports.clearTimeout = function(timer) {
 };
 
 
-exports.setInterval = function(callback, repeat) {
+exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   repeat *= 1; // coalesce to number or NaN
 
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour
   }
 
+  var args, i;
   var timer = new Timeout(repeat);
-  var args = Array.prototype.slice.call(arguments, 2);
+  var len = arguments.length - 2;
   timer._onTimeout = wrapper;
   timer._repeat = true;
+  // Initialize args once for repeated invocation of slow case below
+  if (len > 3) {
+    args = new Array(len);
+    for (i = 0; i < len; i++)
+      args[i] = arguments[i + 2];
+  }
 
   if (process.domain) timer.domain = process.domain;
   exports.active(timer);
@@ -240,7 +264,25 @@ exports.setInterval = function(callback, repeat) {
   return timer;
 
   function wrapper() {
-    callback.apply(this, args);
+    switch (len) {
+      // fast cases
+      case 0:
+        callback.call(this);
+        break;
+      case 1:
+        callback.call(this, arg1);
+        break;
+      case 2:
+        callback.call(this, arg1, arg2);
+        break;
+      case 3:
+        callback.call(this, arg1, arg2, arg3);
+        break;
+      // slow case
+      default:
+        callback.apply(this, args);
+        break;
+    }
     // If callback called clearInterval().
     if (timer._repeat === false) return;
     // If timer is unref'd (or was - it's permanently removed from the list.)
@@ -361,22 +403,44 @@ Immediate.prototype._idleNext = undefined;
 Immediate.prototype._idlePrev = undefined;
 
 
-exports.setImmediate = function(callback) {
+exports.setImmediate = function(callback, arg1, arg2, arg3) {
+  var i, args;
+  var len = arguments.length;
   var immediate = new Immediate();
-  var args, index;
 
   L.init(immediate);
 
-  immediate._onImmediate = callback;
+  switch (len) {
+    // fast cases
+    case 0:
+    case 1:
+      immediate._onImmediate = callback;
+      break;
+    case 2:
+      immediate._onImmediate = function() {
+        callback.call(immediate, arg1);
+      };
+      break;
+    case 3:
+      immediate._onImmediate = function() {
+        callback.call(immediate, arg1, arg2);
+      };
+      break;
+    case 4:
+      immediate._onImmediate = function() {
+        callback.call(immediate, arg1, arg2, arg3);
+      };
+      break;
+    // slow case
+    default:
+      args = new Array(len - 1);
+      for (i = 1; i < len; i++)
+        args[i - 1] = arguments[i];
 
-  if (arguments.length > 1) {
-    args = [];
-    for (index = 1; index < arguments.length; index++)
-      args.push(arguments[index]);
-
-    immediate._onImmediate = function() {
-      callback.apply(immediate, args);
-    };
+      immediate._onImmediate = function() {
+        callback.apply(immediate, args);
+      };
+      break;
   }
 
   if (!process._needImmediateCallback) {


### PR DESCRIPTION
**This pull request speeds up multi-listener event callbacks, `setImmediate`, `setTimeout`, and `setInterval` by differentiating between zero-, one-, and two-argument callbacks. This technique was previously only applied to single-listener event callbacks—and even they have been sped up.**

### Current situation

The `EventEmitter#emit` code has special cases for zero-, one-, and two-argument callbacks as follows:

```JavaScript
len = arguments.length;
switch (len) {
  // fast cases
  case 1: handler.call(this); break;
  case 2: handler.call(this, arguments[1]); break;
  case 3: handler.call(this, arguments[1], arguments[2]); break;
  // slower
  default:
    args = new Array(len - 1);
    for (i = 1; i < len; i++)
      args[i - 1] = arguments[i];
    handler.apply(this, args);
}
 ```

### Improvements in this pull request

On the one hand, this pull request speeds up this technique by avoiding the use of `arguments` indexing, instead adding actual function arguments `arg1` and `arg2`.

On the other hand, this pull request also applies the same technique to listeners with multiple callbacks, as well as the timer functions `setImmediate`, `setTimeout`, and `setInterval`.

Below are my results of [performance tests](https://github.com/RubenVerborgh/Node-Events-Timers-Performance) that examine these cases (ran on a 2010 MacBook Pro).

| |a7f530964b1c4430d0be7e3796700a0f81068dc5|← diff →| 17701f939db247233e574bb1ff07191f8c00c877 |
|---|---:|---:|---:|---:|---:|
|**event with one listener**|631 ms|**-24.25%**|**478 ms**|
|**event with two listeners**|2,899 ms|**-44.98%**|**1,595 ms**|
|**setImmediate**|6,758 ms|**-40.17%**|**4,043 ms**|
|**setTimeout**|8,828 ms|**-65.17%**|**3,075 ms**|
|**setInterval**|8,830 ms|**-71.77%**|**2,493 ms**|

### Considerations

Given the importance of callbacks in io.js, delivering maximum performance for common cases is crucial. The only drawback of this pull request seems to be the increased code length; but it brings consistency since the optimization technique was previously only applied to one particular case (and slightly suboptimally).

I added each change in a different commit, so you can decide which ones to merge. All commits are independent of each other, except for the second, which depends on the first.

If you want these commits squashed, or applied to a different branch, please let me know and I'll do so.

PS This pull request is the equivalent of joyent/node#9007.