### PR TITLE
benchmark: fix command name in benchmark scripts

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,7 @@
-# Node.js core benchmark tests
+# io.js core benchmark tests
 
 This folder contains benchmark tests to measure the performance for certain
-Node.js APIs.
+io.js APIs.
 
 ## How to run tests
 
@@ -10,7 +10,7 @@ There are two ways to run benchmark tests:
 1. Run all tests of a given type, for example, buffers
 
 ```sh
-node benchmark/common.js buffers
+iojs benchmark/common.js buffers
 ```
 
 The above command will find all scripts under `buffers` directory and require
@@ -70,7 +70,7 @@ buffers/buffer-read.js noAssert=false buffer=fast type=UInt16BE millions=1: 244.
 2. Run an individual test, for example, buffer-slice.js
 
 ```sh
-node benchmark/buffers/buffer-read.js
+iojs benchmark/buffers/buffer-read.js
 ```
 The output:
 ```

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -8,7 +8,7 @@ exports.PORT = process.env.PORT || 12346;
 if (module === require.main) {
   var type = process.argv[2];
   if (!type) {
-    console.error('usage:\n ./node benchmark/common.js <type>');
+    console.error('usage:\n ./iojs benchmark/common.js <type>');
     process.exit(1);
   }
 

--- a/benchmark/http-flamegraph.sh
+++ b/benchmark/http-flamegraph.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd "$(dirname "$(dirname $0)")"
 
-node=${NODE:-./node}
+node=${NODE:-./iojs}
 
 name=${NAME:-stacks}
 
@@ -22,7 +22,7 @@ fi
 ulimit -n 100000
 $node benchmark/http_simple.js &
 nodepid=$!
-echo "node pid = $nodepid"
+echo "iojs pid = $nodepid"
 sleep 1
 
 # has to stay alive until dtrace exits
@@ -62,7 +62,7 @@ echo 'Turn the stacks into a svg'
 stackvis dtrace flamegraph-svg < "$name".src > "$name".raw.svg
 
 echo 'Prune tiny stacks out of the graph'
-node -e '
+iojs -e '
 var infile = process.argv[1];
 var outfile = process.argv[2];
 var output = "";

--- a/benchmark/http.sh
+++ b/benchmark/http.sh
@@ -24,7 +24,7 @@ if [ "$k" = "no" ]; then
 else
   k="-k"
 fi
-node=${NODE:-./node}
+node=${NODE:-./iojs}
 
 $node benchmark/http_simple.js &
 npid=$!

--- a/benchmark/http_simple_bench.sh
+++ b/benchmark/http_simple_bench.sh
@@ -14,7 +14,7 @@ if [ ! -d benchmark/ ]; then
 fi
 
 if [ $SERVER == "127.0.0.1" ]; then
-  ./node benchmark/http_simple.js &
+  ./iojs benchmark/http_simple.js &
   node_pid=$!
   sleep 1
 fi

--- a/benchmark/plot.R
+++ b/benchmark/plot.R
@@ -52,7 +52,7 @@ ab.load <- function (filename, name) {
 
 
 filename <- args[0:1]
-data <- ab.load(filename, "node")
+data <- ab.load(filename, "iojs")
 
 
 # histogram


### PR DESCRIPTION
benchmark shell scripts have `./node` command. But the command is not generated currently.