### PR TITLE
deps: make node-gyp fetch .lib from correct url

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -348,8 +348,8 @@ function install (gyp, argv, callback) {
           , dir64 = path.resolve(devDir, 'x64')
           , nodeLibPath32 = path.resolve(dir32, 'node.lib')
           , nodeLibPath64 = path.resolve(dir64, 'node.lib')
-          , nodeLibUrl32 = distUrl + '/v' + version + '/node.lib'
-          , nodeLibUrl64 = distUrl + '/v' + version + '/x64/node.lib'
+          , nodeLibUrl32 = distUrl + '/v' + version + '/win-x86/node.lib'
+          , nodeLibUrl64 = distUrl + '/v' + version + '/win-x64/node.lib'
 
         log.verbose('32-bit node.lib dir', dir32)
         log.verbose('64-bit node.lib dir', dir64)


### PR DESCRIPTION
The .lib files at nodejs.org are at /dist/v1.2.3/node.lib and
/dist/v1.2.3/x64/node.lib but on iojs.org, they are located at
/dist/v1.2.3/win-x86/node.lib and /dist/v1.2.3/win-x64/node.lib
respectively.  Update the download URLs.

R=@piscisaureus, /cc @seishun