### PR TITLE
deps: make node-gyp work again on windows

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -42,7 +42,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l"<(node_root_dir)/$(ConfigurationName)/node.lib"'
+          '-l"<(node_root_dir)/$(ConfigurationName)/iojs.lib"'
         ],
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'

--- a/deps/npm/node_modules/node-gyp/lib/build.js
+++ b/deps/npm/node_modules/node-gyp/lib/build.js
@@ -173,7 +173,7 @@ function build (gyp, argv, callback) {
   }
 
   /**
-   * Copies the node.lib file for the current target architecture into the
+   * Copies the iojs.lib file for the current target architecture into the
    * current proper dev dir location.
    */
 
@@ -181,15 +181,15 @@ function build (gyp, argv, callback) {
     if (!win || !copyDevLib) return doBuild()
 
     var buildDir = path.resolve(nodeDir, buildType)
-      , archNodeLibPath = path.resolve(nodeDir, arch, 'node.lib')
-      , buildNodeLibPath = path.resolve(buildDir, 'node.lib')
+      , archNodeLibPath = path.resolve(nodeDir, arch, 'iojs.lib')
+      , buildNodeLibPath = path.resolve(buildDir, 'iojs.lib')
 
     mkdirp(buildDir, function (err, isNew) {
       if (err) return callback(err)
       log.verbose('"' + buildType + '" dir needed to be created?', isNew)
       var rs = fs.createReadStream(archNodeLibPath)
         , ws = fs.createWriteStream(buildNodeLibPath)
-      log.verbose('copying "node.lib" for ' + arch, buildNodeLibPath)
+      log.verbose('copying "iojs.lib" for ' + arch, buildNodeLibPath)
       rs.pipe(ws)
       rs.on('error', callback)
       ws.on('error', callback)

--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -267,7 +267,7 @@ function install (gyp, argv, callback) {
         var async = 0
 
         if (win) {
-          // need to download node.lib
+          // need to download iojs.lib
           async++
           downloadNodeLib(deref)
         }
@@ -295,7 +295,8 @@ function install (gyp, argv, callback) {
             // check content shasums
             for (var k in contentShasums) {
               log.verbose('validating download checksum for ' + k, '(%s == %s)', contentShasums[k], expectShasums[k])
-              if (contentShasums[k] !== expectShasums[k]) {
+              // TODO(piscisaureus) re-enable checksum verification when the correct files are in place.
+              if (false || contentShasums[k] !== expectShasums[k]) {
                 cb(new Error(k + ' local checksum ' + contentShasums[k] + ' not match remote ' + expectShasums[k]))
                 return
               }
@@ -343,36 +344,36 @@ function install (gyp, argv, callback) {
       }
 
       function downloadNodeLib (done) {
-        log.verbose('on Windows; need to download `node.lib`...')
+        log.verbose('on Windows; need to download `iojs.lib`...')
         var dir32 = path.resolve(devDir, 'ia32')
           , dir64 = path.resolve(devDir, 'x64')
-          , nodeLibPath32 = path.resolve(dir32, 'node.lib')
-          , nodeLibPath64 = path.resolve(dir64, 'node.lib')
-          , nodeLibUrl32 = distUrl + '/v' + version + '/node.lib'
-          , nodeLibUrl64 = distUrl + '/v' + version + '/x64/node.lib'
+          , nodeLibPath32 = path.resolve(dir32, 'iojs.lib')
+          , nodeLibPath64 = path.resolve(dir64, 'iojs.lib')
+          , nodeLibUrl32 = distUrl + '/v' + version + '/win-x86/iojs.lib'
+          , nodeLibUrl64 = distUrl + '/v' + version + '/win-x64/iojs.lib'
 
-        log.verbose('32-bit node.lib dir', dir32)
-        log.verbose('64-bit node.lib dir', dir64)
-        log.verbose('`node.lib` 32-bit url', nodeLibUrl32)
-        log.verbose('`node.lib` 64-bit url', nodeLibUrl64)
+        log.verbose('32-bit iojs.lib dir', dir32)
+        log.verbose('64-bit iojs.lib dir', dir64)
+        log.verbose('`iojs.lib` 32-bit url', nodeLibUrl32)
+        log.verbose('`iojs.lib` 64-bit url', nodeLibUrl64)
 
         var async = 2
         mkdir(dir32, function (err) {
           if (err) return done(err)
-          log.verbose('streaming 32-bit node.lib to:', nodeLibPath32)
+          log.verbose('streaming 32-bit iojs.lib to:', nodeLibPath32)
 
           var req = download(nodeLibUrl32)
           if (!req) return
           req.on('error', done)
           req.on('response', function (res) {
             if (res.statusCode !== 200) {
-              done(new Error(res.statusCode + ' status code downloading 32-bit node.lib'))
+              done(new Error(res.statusCode + ' status code downloading 32-bit iojs.lib'))
               return
             }
 
             getContentSha(res, function (_, checksum) {
-              contentShasums['node.lib'] = checksum
-              log.verbose('content checksum', 'node.lib', checksum)
+              contentShasums['win-x86/iojs.lib'] = checksum
+              log.verbose('content checksum', 'win-x86/iojs.lib', checksum)
             })
 
             var ws = fs.createWriteStream(nodeLibPath32)
@@ -385,20 +386,20 @@ function install (gyp, argv, callback) {
         })
         mkdir(dir64, function (err) {
           if (err) return done(err)
-          log.verbose('streaming 64-bit node.lib to:', nodeLibPath64)
+          log.verbose('streaming 64-bit iojs.lib to:', nodeLibPath64)
 
           var req = download(nodeLibUrl64)
           if (!req) return
           req.on('error', done)
           req.on('response', function (res) {
             if (res.statusCode !== 200) {
-              done(new Error(res.statusCode + ' status code downloading 64-bit node.lib'))
+              done(new Error(res.statusCode + ' status code downloading 64-bit iojs.lib'))
               return
             }
 
             getContentSha(res, function (_, checksum) {
-              contentShasums['x64/node.lib'] = checksum
-              log.verbose('content checksum', 'x64/node.lib', checksum)
+              contentShasums['win-x64/iojs.lib'] = checksum
+              log.verbose('content checksum', 'win-x64/iojs.lib', checksum)
             })
 
             var ws = fs.createWriteStream(nodeLibPath64)


### PR DESCRIPTION
* Fetch from the correct url.
* use iojs.lib instead of node.lib.
* Disable checksum checks for iojs.lib until our website supports them.

R=@bnoordhuis
R=@rvagg