### PR TITLE
doc: fix formatting in LICENSE for RTF generation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 io.js is licensed for use as follows:
 
-====
-
+"""
 Copyright io.js contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,12 +20,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
-
-===
+"""
 
 This license applies to parts of io.js originating from the
 https://github.com/joyent/node repository:
 
+"""
 Copyright Joyent, Inc. and other Node contributors. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -45,11 +44,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
+"""
 
-====
+The io.js license applies to all parts of io.js that are not externally
+maintained libraries.
 
-This license applies to all parts of io.js that are not externally
-maintained libraries. The externally maintained libraries used by io.js are:
+The externally maintained libraries used by io.js are:
 
 - V8, located at deps/v8. V8's license follows:
   """


### PR DESCRIPTION
Current format does not render properly when converted to RTF by
the tools/license2rtf.js tool, specifically the wrong sections are
presented as bold, giving the wrong emphasis to the document.

This fix makes the formatting more consistent, with non-license
summary sections bold and the licenses themselves unformatted.