### PR TITLE
doc: Extend example of http.request by end event

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -511,6 +511,9 @@ Example:
       res.on('data', function (chunk) {
         console.log('BODY: ' + chunk);
       });
+      res.on('end', function() {
+        console.log('No more data in response.')
+      })
     });
 
     req.on('error', function(e) {


### PR DESCRIPTION
Added .on('end', callback) event to http.request example, because
for first sign it's not clear from http documentation, how to
handle end of request.