### PR TITLE
src: reduce cpu profiler overhead

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3331,6 +3331,10 @@ inline void PlatformInit() {
   RegisterSignalHandler(SIGINT, SignalExit, true);
   RegisterSignalHandler(SIGTERM, SignalExit, true);
 
+  // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the
+  // performance penalty of frequent EINTR wakeups when the profiler is running.
+  uv_loop_configure(uv_default_loop(), UV_LOOP_BLOCK_SIGNAL, SIGPROF);
+
   // Raise the open file descriptor limit.
   struct rlimit lim;
   if (getrlimit(RLIMIT_NOFILE, &lim) == 0 && lim.rlim_cur != lim.rlim_max) {


### PR DESCRIPTION
Reduce the overhead of the CPU profiler by suppressing SIGPROF signals
when sleeping / polling for events.  Avoids unnecessary wakeups when
the CPU profiler is active.

The benefits are quite substantial on systems where it is expensive to
query the system time (most virtualized environments).  Before, it was
common to see over 20% of wall clock time being spent on clock_gettime()
system calls.

R=@piscisaureus