### PR TITLE
doc: change to iojs from node in the Usage message

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -14,7 +14,7 @@ exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
 
   if (argv.length < 1) {
-    console.error('Usage: node debug script.js');
+    console.error('Usage: iojs debug script.js');
     process.exit(1);
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2870,8 +2870,8 @@ static bool ParseDebugOpt(const char* arg) {
 }
 
 static void PrintHelp() {
-  printf("Usage: node [options] [ -e script | script.js ] [arguments] \n"
-         "       node debug script.js [arguments] \n"
+  printf("Usage: iojs [options] [ -e script | script.js ] [arguments] \n"
+         "       iojs debug script.js [arguments] \n"
          "\n"
          "Options:\n"
          "  -v, --version        print node's version\n"


### PR DESCRIPTION
the usage message is mismatched with actual command. so, I changed it.

before:
```
$ ./iojs --help
Usage: node [options] [ -e script | script.js ] [arguments]
       node debug script.js [arguments]
```