### PR TITLE
v8: optimize `getHeapStatistics`

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,5 +15,29 @@
 'use strict';
 
 var v8binding = process.binding('v8');
-exports.getHeapStatistics = v8binding.getHeapStatistics;
+var smalloc = require('smalloc');
+
+var heapStatisticsBuffer = smalloc.alloc(v8binding.kHeapStatisticsBufferLength,
+                                         v8binding.kHeapStatisticsBufferType);
+
+var kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
+var kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
+var kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
+var kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
+var kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
+
+exports.getHeapStatistics = function() {
+  var buffer = heapStatisticsBuffer;
+
+  v8binding.getHeapStatistics(buffer);
+
+  return {
+    'total_heap_size': buffer[kTotalHeapSizeIndex],
+    'total_heap_size_executable': buffer[kTotalHeapSizeExecutableIndex],
+    'total_physical_size': buffer[kTotalPhysicalSizeIndex],
+    'used_heap_size': buffer[kUsedHeapSizeIndex],
+    'heap_size_limit': buffer[kHeapSizeLimitIndex]
+  };
+};
+
 exports.setFlagsFromString = v8binding.setFlagsFromString;

--- a/src/env.h
+++ b/src/env.h
@@ -92,7 +92,6 @@ namespace node {
   V(fsevent_string, "FSEvent")                                                \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
-  V(heap_size_limit_string, "heap_size_limit")                                \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(hostmaster_string, "hostmaster")                                          \
@@ -198,13 +197,9 @@ namespace node {
   V(tls_sni_string, "tls_sni")                                                \
   V(tls_string, "tls")                                                        \
   V(tls_ticket_string, "tlsTicket")                                           \
-  V(total_heap_size_executable_string, "total_heap_size_executable")          \
-  V(total_heap_size_string, "total_heap_size")                                \
-  V(total_physical_size_string, "total_physical_size")                        \
   V(type_string, "type")                                                      \
   V(uid_string, "uid")                                                        \
   V(unknown_string, "<unknown>")                                              \
-  V(used_heap_size_string, "used_heap_size")                                  \
   V(user_string, "user")                                                      \
   V(uv_string, "uv")                                                          \
   V(valid_from_string, "valid_from")                                          \

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -49,7 +49,7 @@ NODE_EXTERN size_t ExternalArraySize(enum v8::ExternalArrayType type);
  *        v8::kExternalFloatArray);
  *    v8::Local<v8::Object> obj = v8::Object::New();
  *    char* data = static_cast<char*>(malloc(byte_length * array_length));
- *    node::smalloc::Alloc(obj, data, byte_length, v8::kExternalFloatArray);
+ *    node::smalloc::Alloc(env, obj, data, byte_length, v8::kExternalFloatArray);
  *    obj->Set(v8::String::NewFromUtf8("length"),
  *             v8::Integer::NewFromUnsigned(array_length));
  * \code


### PR DESCRIPTION
Set statistics data to external uint32 array instead of creating object.

R=@trevnorris or @bnoordhuis ?