### PR TITLE
doc: bump punycode api stability to 'stable'

### DIFF
--- a/doc/api/punycode.markdown
+++ b/doc/api/punycode.markdown
@@ -1,6 +1,6 @@
 # punycode
 
-    Stability: 2 - Unstable
+    Stability: 3 - Stable
 
 [Punycode.js](https://mths.be/punycode) is bundled with io.js v1.0.0+ and
 Node.js v0.6.2+. Use `require('punycode')` to access it. (To use it with


### PR DESCRIPTION
The punycode library has been in the tree for over three years now and
has been de facto stable for all that time, if not perhaps de jure.
Let's make it official.

R=@iojs/tc - something for the next TC meeting.