### PR TITLE
Added links to Changelog for external http_parser/libuv upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * Windows installer fixes
 * Bundled node-gyp fixes for Windows
-* http_parser v2.4.1 upgrade
-* libuv v1.2.1 upgrade
+* [http_parser v2.4.1 upgrade](https://github.com/joyent/http-parser/compare/v2.3...v2.4.1)
+* [libuv v1.2.1 upgrade](https://github.com/libuv/libuv/compare/v1.2.0...v1.2.1)
 
 ### Commits
 


### PR DESCRIPTION
This makes it easier to see what's actually changed (in case people need to be aware of it).

Alternatives would be linking to the pull requests:

https://github.com/iojs/io.js/pull/397/files
https://github.com/iojs/io.js/pull/423/files

Or, at least in the case of libuv, linking to its Changelog:

https://github.com/libuv/libuv/blob/v1.2.1/ChangeLog