### PR TITLE
util: check RegExp is function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -81,7 +81,8 @@ exports.debuglog = function(set) {
     debugEnviron = process.env.NODE_DEBUG || '';
   set = set.toUpperCase();
   if (!debugs[set]) {
-    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
+    if (isFunction(RegExp) &&
+        new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
       var pid = process.pid;
       debugs[set] = function() {
         var msg = exports.format.apply(exports, arguments);


### PR DESCRIPTION
I am checking benchmark tests.
When I execute the following tests, I got the errors.

```
$ ./iojs benchmark/common.js misc/
misc//v8-bench.js
util.js:84
    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
        ^
TypeError: object is not a function
    at Object.exports.debuglog (util.js:84:32)
    at timers.js:12:29
    at NativeModule.compile (node.js:800:5)
    at NativeModule.require (node.js:769:18)
    at net.js:5:14
    at NativeModule.compile (node.js:800:5)
    at NativeModule.require (node.js:769:18)
    at tty.js:4:11
    at NativeModule.compile (node.js:800:5)
    at Function.NativeModule.require (node.js:769:18)
```

I don't understand why this error is occurred, but I guess `RegExp` is not function in vm context.
So I just checked RegExp is function, the benchmark test works fine.

```
misc//v8-bench.js
misc/v8_bench.js Richards: 24581
misc/v8_bench.js DeltaBlue: 37548
misc/v8_bench.js Crypto: 20758
misc/v8_bench.js RayTrace: 52835
misc/v8_bench.js EarleyBoyer: 31814
misc/v8_bench.js RegExp: 4523
misc/v8_bench.js Splay: 12264
misc/v8_bench.js NavierStokes: 23945
misc/v8_bench.js Score (version 7): 21326
``` 
