### PR TITLE
http: make the error more descriptive

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -311,7 +311,7 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
   if (typeof name !== 'string')
     throw new TypeError('"name" should be a string');
   if (value === undefined)
-    throw new Error('"name" and "value" are required for setHeader().');
+    throw new Error('"value" is required for header "' + name + '" in setHeader().');
   if (this._header)
     throw new Error('Can\'t set headers after they are sent.');
 


### PR DESCRIPTION
I think printing the name of the header whose value is undefined would make debugging slightly more easy.