### PR TITLE
benchmark: separate RegExp benchmark from v8 basic bench

### DIFF
--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -12,7 +12,8 @@ global.print = function(s) {
 
 global.load = function (x) {
   var source = fs.readFileSync(path.join(dir, x), 'utf8');
-  vm.runInThisContext(source, x);
-}
+  vm.runInThisContext(source);
+};
 
 load('run.js');
+load('runRegExp.js');

--- a/deps/v8/benchmarks/run.js
+++ b/deps/v8/benchmarks/run.js
@@ -32,7 +32,6 @@ load('deltablue.js');
 load('crypto.js');
 load('raytrace.js');
 load('earley-boyer.js');
-load('regexp.js');
 load('splay.js');
 load('navier-stokes.js');
 

--- a/deps/v8/benchmarks/runRegExp.js
+++ b/deps/v8/benchmarks/runRegExp.js
@@ -1,0 +1,27 @@
+load('base.js');
+load('regexp.js');
+
+var success = true;
+
+function PrintResult(name, result) {
+  print(name + ': ' + result);
+}
+
+
+function PrintError(name, error) {
+  PrintResult(name, error);
+  success = false;
+}
+
+
+function PrintScore(score) {
+  if (success) {
+    print('----');
+    print('Score (version ' + BenchmarkSuite.version + '): ' + score);
+  }
+}
+
+
+BenchmarkSuite.RunSuites({ NotifyResult: PrintResult,
+                           NotifyError: PrintError,
+                           NotifyScore: PrintScore });


### PR DESCRIPTION
RegExp bench is separated from `run.js`. And I created `runRegExp.js` for running another contexts.

RegExp bench creates global `RegExp` (https://github.com/iojs/io.js/blob/v1.x/deps/v8/benchmarks/regexp.js#L40).
However, the `RegExp` causes a error. The detail is here.

https://github.com/iojs/io.js/pull/475