### PR TITLE
build: shorten configuration print on stdout

### DIFF
--- a/configure
+++ b/configure
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import shutil
 import string
+import textwrap
 
 CC = os.environ.get('CC', 'cc')
 CXX = os.environ.get('CXX', 'c++')
@@ -960,7 +961,7 @@ output = {
   'variables': variables,
   'target_defaults': output
 }
-pprint.pprint(output, indent=2)
+print textwrap.fill(str(output), 78)
 
 write('config.gypi', do_not_edit +
       pprint.pformat(output, indent=2) + '\n')


### PR DESCRIPTION
The configure script prints out a prettyprinted dictionary of mostly v8 options, which right now results in a total of 34 lines being output to stdout on a regular build. Warnings like [this](https://github.com/iojs/io.js/blob/4764eef9b2efdf17cafeb4ec40898c6669a84e3b/configure#L483) or [this](https://github.com/iojs/io.js/blob/4764eef9b2efdf17cafeb4ec40898c6669a84e3b/configure#L670) are printed before the dictionary, and are likely being scrolled out of sight almost instantly on terminals with < 30 lines height.

This commit removes the pretty print resulting in single-line output, making warnings more visible, while on the other hand making the options harder to read by a human, so I'm open to suggestions!

#### Before:
```
ctrpp not found in WinSDK path--using pre-gen files from tools/msvs/genfiles.
creating  ./icu_config.gypi
{'target_defaults': {'cflags': [],
                     'default_configuration': 'Release',
                     'defines': [],
                     'include_dirs': [],
                     'libraries': []},
 'variables': {'host_arch': 'ia32',
               'icu_small': 'false',
               'node_install_npm': 'true',
               'node_prefix': '',
               'node_shared_http_parser': 'false',
               'node_shared_libuv': 'false',
               'node_shared_openssl': 'false',
               'node_shared_v8': 'false',
               'node_shared_zlib': 'false',
               'node_tag': '',
               'node_use_dtrace': 'false',
               'node_use_etw': 'true',
               'node_use_mdb': 'false',
               'node_use_openssl': 'true',
               'node_use_perfctr': 'true',
               'openssl_no_asm': 0,
               'python': '/bin/python',
               'target_arch': 'ia32',
               'uv_library': 'static_library',
               'v8_enable_gdbjit': 0,
               'v8_enable_i18n_support': 0,
               'v8_no_strict_aliasing': 1,
               'v8_optimized_debug': 0,
               'v8_random_seed': 0,
               'v8_use_snapshot': 'true',
               'want_separate_host_toolset': 0}}
creating  ./config.gypi
creating  ./config.mk
```
#### After:
```
ctrpp not found in WinSDK path--using pre-gen files from tools/msvs/genfiles.
creating  ./icu_config.gypi
{'variables': {'node_shared_http_parser': 'false', 'want_separate_host_toolset': 0, 'icu_small': 'false', 'node_use_mdb': 'false', 'target_arch': 'ia32', 'host_arch': 'ia32', 'v8_optimized_debug': 0, 'node_install_npm': 'true', 'openssl_no_asm': 0, 'v8_no_strict_aliasing': 1, 'node_shared_zlib': 'false', 'node_use_dtrace': 'false', 'python': '/bin/python', 'v8_enable_gdbjit': 0, 'node_use_etw': 'true', 'v8_enable_i18n_support': 0, 'node_use_perfctr': 'true', 'v8_random_seed': 0, 'node_prefix': '', 'node_shared_openssl': 'false', 'node_shared_v8': 'false', 'node_use_openssl': 'true', 'uv_library': 'static_library', 'v8_use_snapshot': 'true', 'node_shared_libuv': 'false', 'node_tag': ''}, 'target_defaults': {'libraries': [], 'default_configuration': 'Release', 'cflags': [], 'include_dirs': [], 'defines': []}}
creating  ./config.gypi
creating  ./config.mk
```