### PR TITLE
benchmark: fix net/dgram.js infinite loop

### DIFF
--- a/benchmark/net/dgram.js
+++ b/benchmark/net/dgram.js
@@ -39,7 +39,7 @@ function server() {
   function onsend() {
     if (sent++ % num == 0)
       for (var i = 0; i < num; i++)
-        socket.send(chunk, 0, chunk.length, PORT, '127.0.0.1', onsend);
+        socket.send(chunk, 0, chunk.length, PORT, '127.0.0.1', setImmediate(onsend));
   }
 
   socket.on('listening', function() {


### PR DESCRIPTION
benchmark script is not finished. net/dgram.js has infinite loop.