### PR TITLE
benchmark: stop v8 benchmark clobbering RegExp

### DIFF
--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -10,9 +10,13 @@ global.print = function(s) {
   console.log('misc/v8_bench.js %s', s);
 };
 
-global.load = function (x) {
-  var source = fs.readFileSync(path.join(dir, x), 'utf8');
-  vm.runInThisContext(source, x);
-}
+global.load = function(filename) {
+  var source = fs.readFileSync(path.join(dir, filename), 'utf8');
+  // deps/v8/benchmarks/regexp.js breaks console.log() because it clobbers
+  // the RegExp global,  Restore the original when the script is done.
+  var $RegExp = global.RegExp;
+  vm.runInThisContext(source, { filename: filename });
+  global.RegExp = $RegExp;
+};
 
 load('run.js');


### PR DESCRIPTION
deps/v8/benchmarks/regexp.js clobbers the RegExp global, breaking
util.format() and console.log().  Unclobber it to keep the other
benchmarks working.

Fixes the following error when running benchmark/misc/v8-bench.js:

    $ out/Release/iojs benchmark/misc/v8-bench.js
    util.js:84
        if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
            ^
    TypeError: object is not a function
        at Object.exports.debuglog (util.js:84:9)
        at timers.js:12:29
        at NativeModule.compile (node.js:800:5)
        at NativeModule.require (node.js:769:18)
        at net.js:5:14
        at NativeModule.compile (node.js:800:5)
        at NativeModule.require (node.js:769:18)
        at tty.js:4:11
        at NativeModule.compile (node.js:800:5)
        at Function.NativeModule.require (node.js:769:18)

This could alternatively be addressed by caching the RegExp global
in lib/util.js.  That's not a bad approach and I considered it but
doing it for just RegExp and not other globals would be half-baked.

Maybe the more thorough approach where we cache all globals at
start-up is something for a follow-up pull request.

Fixes: https://github.com/iojs/io.js/pull/475

R=@chrisdickinson @yosuke-furukawa