### PR TITLE
src: add process.versions.iojs

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2562,6 +2562,9 @@ void SetupProcessObject(Environment* env,
                     "node",
                     OneByteString(env->isolate(), NODE_VERSION + 1));
   READONLY_PROPERTY(versions,
+                    "iojs",
+                    OneByteString(env->isolate(), NODE_VERSION + 1));
+  READONLY_PROPERTY(versions,
                     "v8",
                     OneByteString(env->isolate(), V8::GetVersion()));
   READONLY_PROPERTY(versions,

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -1,7 +1,7 @@
 require('../common');
 var assert = require('assert');
 
-var expected_keys = ['ares', 'http_parser', 'modules', 'node',
+var expected_keys = ['ares', 'http_parser', 'iojs', 'modules', 'node',
                      'openssl', 'uv', 'v8', 'zlib'];
 
 assert.deepEqual(Object.keys(process.versions).sort(), expected_keys);


### PR DESCRIPTION
This gives user code a forward-compatible means for determining whether it's running in io.js or Node.js. Also, to ensure backwards compatibility, it leaves the existing `process.versions.node` alone.

This will be helpful for tools like `node-gyp` to figure out whether they're running against Node.js or io.js. See TooTallNate/node-gyp#564 for a discussion of how this might be useful.

Everything's basically the same except:

```javascript
// % ./out/Release/iojs -p process.versions
{ http_parser: '2.4',
  node: '1.0.3',        // <-- not removed
  iojs: '1.0.3',        // <-- added
  v8: '3.31.74.1',
  uv: '1.2.1',
  zlib: '1.2.8',
  ares: '1.10.0-DEV',
  modules: '42',
  openssl: '1.0.1k' }
```

PR: @rvagg 
PR: @bnoordhuis 