### PR TITLE
benchmark: fix tcp raw benchmarks after internal api change

### DIFF
--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -14,6 +14,8 @@ var bench = common.createBenchmark(main, {
 });
 
 var TCP = process.binding('tcp_wrap').TCP;
+var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+var WriteWrap = process.binding('stream_wrap').WriteWrap;
 var PORT = common.PORT;
 
 var dur;
@@ -91,7 +93,7 @@ function client() {
   }
 
   var clientHandle = new TCP();
-  var connectReq = {};
+  var connectReq = new TCPConnectWrap();
   var err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
 
   if (err)
@@ -108,7 +110,8 @@ function client() {
   };
 
   function write() {
-    var writeReq = { oncomplete: afterWrite };
+    var writeReq = new WriteWrap();
+    writeReq.oncomplete = afterWrite;
     var err;
     switch (type) {
       case 'buf':

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -14,6 +14,8 @@ var bench = common.createBenchmark(main, {
 });
 
 var TCP = process.binding('tcp_wrap').TCP;
+var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+var WriteWrap = process.binding('stream_wrap').WriteWrap;
 var PORT = common.PORT;
 
 var dur;
@@ -68,7 +70,9 @@ function server() {
       write();
 
     function write() {
-      var writeReq = { async: false, oncomplete: afterWrite };
+      var writeReq = new WriteWrap();
+      writeReq.async = false;
+      writeReq.oncomplete = afterWrite;
       var err;
       switch (type) {
         case 'buf':
@@ -91,7 +95,7 @@ function server() {
       }
     }
 
-    function afterWrite(err, handle, req) {
+    function afterWrite(status, handle, req, err) {
       if (err)
         fail(err, 'write');
 
@@ -105,7 +109,7 @@ function server() {
 
 function client() {
   var clientHandle = new TCP();
-  var connectReq = {};
+  var connectReq = new TCPConnectWrap();
   var err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
 
   if (err)


### PR DESCRIPTION
tcp raw benchmarks are broken. I got assertion failures when benchmark test is executed.

```
Assertion failed: ((object->InternalFieldCount()) > (0)), function Wrap, file ../src/util-inl.h, line 83.
```

I found the internal api changes on this commit (https://github.com/iojs/io.js/commit/819690fd983d61f90cdf05714a30782fe3b553cd).
I think I fixed the benchmarks.

The result is here.
```
$ ./iojs benchmark/common.js net tcp
net/tcp-raw-c2s.js
net/tcp-raw-c2s.js len=102400 type=utf dur=5: 6
net/tcp-raw-c2s.js len=102400 type=asc dur=5: 11
net/tcp-raw-c2s.js len=102400 type=buf dur=5: 13
net/tcp-raw-c2s.js len=16777216 type=utf dur=5: 5
net/tcp-raw-c2s.js len=16777216 type=asc dur=5: 9
net/tcp-raw-c2s.js len=16777216 type=buf dur=5: 13

net/tcp-raw-pipe.js
net/tcp-raw-pipe.js len=102400 type=utf dur=5: 8
net/tcp-raw-pipe.js len=102400 type=asc dur=5: 11
net/tcp-raw-pipe.js len=102400 type=buf dur=5: 12
net/tcp-raw-pipe.js len=16777216 type=utf dur=5: 7
net/tcp-raw-pipe.js len=16777216 type=asc dur=5: 9
net/tcp-raw-pipe.js len=16777216 type=buf dur=5: 12

net/tcp-raw-s2c.js
net/tcp-raw-s2c.js len=102400 type=utf dur=5: 6
net/tcp-raw-s2c.js len=102400 type=asc dur=5: 11
net/tcp-raw-s2c.js len=102400 type=buf dur=5: 13
net/tcp-raw-s2c.js len=16777216 type=utf dur=5: 4
net/tcp-raw-s2c.js len=16777216 type=asc dur=5: 8
net/tcp-raw-s2c.js len=16777216 type=buf dur=5: 13
```