### PR TITLE
doc: Update docs for writable streams default encoding

### DIFF
--- a/doc/api/stream.markdown
+++ b/doc/api/stream.markdown
@@ -567,10 +567,8 @@ Flush all data, buffered since `.cork()` call.
 #### writable.setDefaultEncoding(encoding)
 
 * `encoding` {String} The new default encoding
-* Return: `Boolean`
 
-Sets the default encoding for a writable stream. Returns `true` if the encoding
-is valid and is set. Otherwise returns `false`.
+Sets the default encoding for a writable stream.
 
 #### writable.end([chunk][, encoding][, callback])
 


### PR DESCRIPTION
Setting the default encoding for a writable stream does
not return a boolean (true if successful or false if not)
as the docs indicate. Instead, if the operation is successful
nothing is returned and the method throws an error when
something goes wrong.

This stems from a contribution that was tweaked but the
docs were never updated accordingly.