### PR TITLE
doc: fix net.Server.listen bind behavior

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -163,9 +163,9 @@ If a client connection emits an 'error' event, it will be forwarded here.
 ### server.listen(port[, hostname][, backlog][, callback])
 
 Begin accepting connections on the specified `port` and `hostname`. If the
-`hostname` is omitted, the server will accept connections on `::` when IPv6
-is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
-random port.
+`hostname` is omitted, the server will accept connections on any IPv6 address
+(`::`) when IPv6 is available, or any IPv4 address (`0.0.0.0`) otherwise. A
+port value of zero will assign a random port.
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 

--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -162,9 +162,10 @@ If a client connection emits an 'error' event, it will be forwarded here.
 
 ### server.listen(port[, hostname][, backlog][, callback])
 
-Begin accepting connections on the specified port and hostname.  If the
-hostname is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`).
+Begin accepting connections on the specified `port` and `hostname`. If the
+`hostname` is omitted, the server will accept connections on `::` when IPv6
+is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
+random port.
 
 To listen to a unix socket, supply a filename instead of port and hostname.
 

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -140,9 +140,9 @@ This class is used to create a TCP or local server.
 ### server.listen(port[, hostname][, backlog][, callback])
 
 Begin accepting connections on the specified `port` and `hostname`. If the
-`hostname` is omitted, the server will accept connections on `::` when IPv6
-is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
-random port.
+`hostname` is omitted, the server will accept connections on any IPv6 address
+(`::`) when IPv6 is available, or any IPv4 address (`0.0.0.0`) otherwise. A
+port value of zero will assign a random port.
 
 Backlog is the maximum length of the queue of pending connections.
 The actual length will be determined by your OS through sysctl settings such as

--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -137,11 +137,12 @@ A factory method which returns a new ['net.Socket'](#net_class_net_socket).
 
 This class is used to create a TCP or local server.
 
-### server.listen(port[, host][, backlog][, callback])
+### server.listen(port[, hostname][, backlog][, callback])
 
-Begin accepting connections on the specified `port` and `host`.  If the
-`host` is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`). A port value of zero will assign a random port.
+Begin accepting connections on the specified `port` and `hostname`. If the
+`hostname` is omitted, the server will accept connections on `::` when IPv6
+is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
+random port.
 
 Backlog is the maximum length of the queue of pending connections.
 The actual length will be determined by your OS through sysctl settings such as

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -589,9 +589,9 @@ certificates.
 ### server.listen(port[, hostname][, callback])
 
 Begin accepting connections on the specified `port` and `hostname`. If the
-`hostname` is omitted, the server will accept connections on `::` when IPv6
-is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
-random port.
+`hostname` is omitted, the server will accept connections on any IPv6 address
+(`::`) when IPv6 is available, or any IPv4 address (`0.0.0.0`) otherwise. A
+port value of zero will assign a random port.
 
 This function is asynchronous. The last parameter `callback` will be called
 when the server has been bound.

--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -586,11 +586,12 @@ NOTE: you may want to use some npm module like [asn1.js] to parse the
 certificates.
 
 
-### server.listen(port[, host][, callback])
+### server.listen(port[, hostname][, callback])
 
-Begin accepting connections on the specified `port` and `host`.  If the
-`host` is omitted, the server will accept connections directed to any
-IPv4 address (`INADDR_ANY`).
+Begin accepting connections on the specified `port` and `hostname`. If the
+`hostname` is omitted, the server will accept connections on `::` when IPv6
+is available, or on `0.0.0.0` otherwise. A port value of zero will assign a
+random port.
 
 This function is asynchronous. The last parameter `callback` will be called
 when the server has been bound.


### PR DESCRIPTION
https://github.com/iojs/io.js/commit/2272052461445dfcae729cc6420a3d3229362158 changed `net.Server.listen`'s behavior so that when the bind `address` is omitted, IPv6 is tried first and IPv4 is used as a fallback.

Also, added the note about the random port to `http` and `tls`, since that's true for them too but only `net` mentioned it. And, changed the argument name to `hostname` for `net` and `tls` because, although it's not named in `listen`, that argument is eventually passed to `dns.lookup` and it calls it `hostname` (plus `http` already called it that).