### PR TITLE
fs: make F_OK/R_OK/W_OK/X_OK not writable

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -27,10 +27,6 @@ const O_RDWR = constants.O_RDWR || 0;
 const O_SYNC = constants.O_SYNC || 0;
 const O_TRUNC = constants.O_TRUNC || 0;
 const O_WRONLY = constants.O_WRONLY || 0;
-const F_OK = constants.F_OK || 0;
-const R_OK = constants.R_OK || 0;
-const W_OK = constants.W_OK || 0;
-const X_OK = constants.X_OK || 0;
 
 var isWindows = process.platform === 'win32';
 
@@ -164,10 +160,12 @@ fs.Stats.prototype.isSocket = function() {
   return this._checkModeProperty(constants.S_IFSOCK);
 };
 
-fs.F_OK = F_OK;
-fs.R_OK = R_OK;
-fs.W_OK = W_OK;
-fs.X_OK = X_OK;
+// Don't allow mode to accidentally be overwritten.
+['F_OK', 'R_OK', 'W_OK', 'X_OK'].forEach(function(key) {
+  Object.defineProperty(fs, key, {
+    enumerable: true, value: constants[key] || 0, writable: false
+  });
+});
 
 fs.access = function(path, mode, callback) {
   if (!nullCheck(path, callback))
@@ -175,7 +173,7 @@ fs.access = function(path, mode, callback) {
 
   if (typeof mode === 'function') {
     callback = mode;
-    mode = F_OK;
+    mode = fs.F_OK;
   } else if (typeof callback !== 'function') {
     throw new TypeError('callback must be a function');
   }
@@ -190,7 +188,7 @@ fs.accessSync = function(path, mode) {
   nullCheck(path);
 
   if (mode === undefined)
-    mode = F_OK;
+    mode = fs.F_OK;
   else
     mode = mode | 0;
 


### PR DESCRIPTION
change the fs.F_OK/R_OK/W_OK/X_OK out of fs.js will lead unexpect
exception. make these properties readonly.