### PR TITLE
child_process: remove redundant condition

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1057,8 +1057,7 @@ util.inherits(ChildProcess, EventEmitter);
 function flushStdio(subprocess) {
   if (subprocess.stdio == null) return;
   subprocess.stdio.forEach(function(stream, fd, stdio) {
-    if (!stream || !stream.readable || stream._consuming ||
-        stream._readableState.flowing)
+    if (!stream || !stream.readable || stream._consuming)
       return;
     stream.resume();
   });


### PR DESCRIPTION
There is no need to check `flowing` since `resume` does nothing when `flowing` is already true.

See: #445

R=@chrisdickinson 