### PR TITLE
net: fix error details in connect()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -765,6 +765,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
   assert.ok(self._connecting);
 
   var err;
+  var ex;
 
   if (localAddress || localPort) {
     var bind;
@@ -788,7 +789,7 @@ function connect(self, address, port, addressType, localAddress, localPort) {
     err = bind(localAddress, localPort);
 
     if (err) {
-      var ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
+      ex = exceptionWithHostPort(err, 'bind', localAddress, localPort);
       self._destroy(ex);
       return;
     }
@@ -813,14 +814,14 @@ function connect(self, address, port, addressType, localAddress, localPort) {
   }
 
   if (err) {
-    self._getsockname();
+    var sockname = self._getsockname();
     var details;
-    if (self._sockname) {
-      ex.localAddress = self._sockname.address;
-      ex.localPort = self._sockname.port;
-      details = ex.localAddress + ':' + ex.localPort;
+
+    if (sockname) {
+      details = sockname.address + ':' + sockname.port;
     }
-    var ex = exceptionWithHostPort(err, 'connect', address, port, details);
+
+    ex = exceptionWithHostPort(err, 'connect', address, port, details);
     self._destroy(ex);
   }
 }


### PR DESCRIPTION
3ac494195319efb9c923c0ee89b6e0f2617d53ef introduced a slight bug in the improved error messages. Closes #510