### PR TITLE
src: fixed a small inconsistency between a check and error

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1963,7 +1963,7 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(modpending, nullptr);
 
-  if (args.Length() < 2) {
+  if (args.Length() != 2) {
     env->ThrowError("process.dlopen takes exactly 2 arguments.");
     return;
   }


### PR DESCRIPTION
I was digging through the source and noticed this pretty trivial inconsistency between the check that's made and the error that's thrown in DLOpen and thought it would be good practice for going through the contribution process.