### PR TITLE
benchmark: print score to five decimal places

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -201,7 +201,7 @@ Benchmark.prototype.end = function(operations) {
 Benchmark.prototype.report = function(value) {
   var heading = this.getHeading();
   if (!silent)
-    console.log('%s: %s', heading, value.toFixed(0));
+    console.log('%s: %s', heading, value.toFixed(5));
   process.exit(0);
 };
 


### PR DESCRIPTION
Benchmark score prints integer value. However, Node.js benchmark has 5 decimal places.

* before

```
arrays/var-int.js
arrays/var-int.js type=Array n=25: 76
arrays/var-int.js type=Buffer n=25: 121
arrays/var-int.js type=Int8Array n=25: 118
arrays/var-int.js type=Uint8Array n=25: 118
arrays/var-int.js type=Int16Array n=25: 113
arrays/var-int.js type=Uint16Array n=25: 111
arrays/var-int.js type=Int32Array n=25: 95
arrays/var-int.js type=Uint32Array n=25: 101
arrays/var-int.js type=Float32Array n=25: 70
arrays/var-int.js type=Float64Array n=25: 73
```

* after

```
arrays/var-int.js
arrays/var-int.js type=Array n=25: 73.45324
arrays/var-int.js type=Buffer n=25: 113.01765
arrays/var-int.js type=Int8Array n=25: 121.26506
arrays/var-int.js type=Uint8Array n=25: 116.51207
arrays/var-int.js type=Int16Array n=25: 109.93762
arrays/var-int.js type=Uint16Array n=25: 114.62420
arrays/var-int.js type=Int32Array n=25: 98.53783
arrays/var-int.js type=Uint32Array n=25: 100.53117
arrays/var-int.js type=Float32Array n=25: 73.30280
arrays/var-int.js type=Float64Array n=25: 76.18161
```

