### PR TITLE
fs: add error code on null byte paths

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -86,6 +86,7 @@ function assertEncoding(encoding) {
 function nullCheck(path, callback) {
   if (('' + path).indexOf('\u0000') !== -1) {
     var er = new Error('Path must be a string without null bytes.');
+    er.code = 'ENOENT';
     if (!callback)
       throw er;
     process.nextTick(function() {

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -7,6 +7,7 @@ function check(async, sync) {
   var argsSync = Array.prototype.slice.call(arguments, 2);
   var argsAsync = argsSync.concat(function(er) {
     assert(er && er.message.match(expected));
+    assert.equal(er.code, 'ENOENT');
   });
 
   if (sync)


### PR DESCRIPTION
This commit adds a `code` field to the error returned by `nullCheck()`. Closes #517