### PR TITLE
fs: define constants with const

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -16,21 +16,21 @@ var FSReqWrap = binding.FSReqWrap;
 var Readable = Stream.Readable;
 var Writable = Stream.Writable;
 
-var kMinPoolSpace = 128;
-var kMaxLength = require('smalloc').kMaxLength;
+const kMinPoolSpace = 128;
+const kMaxLength = require('smalloc').kMaxLength;
 
-var O_APPEND = constants.O_APPEND || 0;
-var O_CREAT = constants.O_CREAT || 0;
-var O_EXCL = constants.O_EXCL || 0;
-var O_RDONLY = constants.O_RDONLY || 0;
-var O_RDWR = constants.O_RDWR || 0;
-var O_SYNC = constants.O_SYNC || 0;
-var O_TRUNC = constants.O_TRUNC || 0;
-var O_WRONLY = constants.O_WRONLY || 0;
-var F_OK = constants.F_OK || 0;
-var R_OK = constants.R_OK || 0;
-var W_OK = constants.W_OK || 0;
-var X_OK = constants.X_OK || 0;
+const O_APPEND = constants.O_APPEND || 0;
+const O_CREAT = constants.O_CREAT || 0;
+const O_EXCL = constants.O_EXCL || 0;
+const O_RDONLY = constants.O_RDONLY || 0;
+const O_RDWR = constants.O_RDWR || 0;
+const O_SYNC = constants.O_SYNC || 0;
+const O_TRUNC = constants.O_TRUNC || 0;
+const O_WRONLY = constants.O_WRONLY || 0;
+const F_OK = constants.F_OK || 0;
+const R_OK = constants.R_OK || 0;
+const W_OK = constants.W_OK || 0;
+const X_OK = constants.X_OK || 0;
 
 var isWindows = process.platform === 'win32';
 


### PR DESCRIPTION
Define `fs` constants using `const`. In the tests that I've done, it appears that v8 is able to optimize `const`. Suggesting this as an alternative to #507. If this is acceptable, I'd be interested in updating other constants throughout the JS codebase.