### PR TITLE
lib: fix TypeError with EventEmitter#on() abuse

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -46,11 +46,14 @@ EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   return this;
 };
 
-EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
-  if (!util.isUndefined(this._maxListeners))
-    return this._maxListeners;
-  else
+function $getMaxListeners(that) {
+  if (util.isUndefined(that._maxListeners))
     return EventEmitter.defaultMaxListeners;
+  return that._maxListeners;
+}
+
+EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
+  return $getMaxListeners(this);
 };
 
 EventEmitter.prototype.emit = function emit(type) {
@@ -151,7 +154,7 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
 
   // Check for listener leak
   if (util.isObject(this._events[type]) && !this._events[type].warned) {
-    var m = this.getMaxListeners();
+    var m = $getMaxListeners(this);
     if (m && m > 0 && this._events[type].length > m) {
       this._events[type].warned = true;
       console.error('(node) warning: possible EventEmitter memory ' +

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -1,24 +1,3 @@
-// Copyright io.js contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 var common = require('../common');
 var assert = require('assert');
 var EventEmitter = require('events');

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -11,3 +11,8 @@ assert.strictEqual(emitter.getMaxListeners(), 0);
 
 emitter.setMaxListeners(3);
 assert.strictEqual(emitter.getMaxListeners(), 3);
+
+// https://github.com/iojs/io.js/issues/523 - second call should not throw.
+var recv = {};
+EventEmitter.prototype.on.call(recv, 'event', function() {});
+EventEmitter.prototype.on.call(recv, 'event', function() {});

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -6,8 +6,8 @@ var emitter = new EventEmitter();
 
 assert.strictEqual(emitter.getMaxListeners(), EventEmitter.defaultMaxListeners);
 
-emitter.setMaxListeners(0)
-assert.strictEqual(emitter.getMaxListeners(), 0)
+emitter.setMaxListeners(0);
+assert.strictEqual(emitter.getMaxListeners(), 0);
 
-emitter.setMaxListeners(3)
-assert.strictEqual(emitter.getMaxListeners(), 3)
+emitter.setMaxListeners(3);
+assert.strictEqual(emitter.getMaxListeners(), 3);

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -1,24 +1,3 @@
-// Copyright io.js contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -1,23 +1,3 @@
-// Copyright (C) 2011 by Ben Noordhuis <info@bnoordhuis.nl>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 var common = require('../common');
 var punycode = require('punycode');
 var assert = require('assert');

--- a/test/parallel/test-require-process.js
+++ b/test/parallel/test-require-process.js
@@ -1,24 +1,3 @@
-// Copyright io.js contributors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 var assert = require('assert');
 
 var nativeProcess = require('process');

--- a/test/parallel/test-timers-unref-call.js
+++ b/test/parallel/test-timers-unref-call.js
@@ -1,17 +1,3 @@
-// Copyright (c) 2014, StrongLoop Inc.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 var common = require('../common');
 
 var Timer = process.binding('timer_wrap').Timer;

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -1,17 +1,3 @@
-// Copyright (c) 2014, StrongLoop Inc.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 var common = require('../common');
 var assert = require('assert');
 var v8 = require('v8');

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -1,17 +1,3 @@
-// Copyright (c) 2014, StrongLoop Inc.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
 var common = require('../common');
 var assert = require('assert');
 var v8 = require('v8');


### PR DESCRIPTION
Commit 2931348 added EventEmitter#getMaxListeners() but introduced a
regression when people abuse EventEmitter.prototype.on.call() to call
EventEmitter#on() on a non-EE object.  Add a workaround for that.

Fixes: iojs#523

R=@yosuke-furukawa