### PR TITLE
src: silence clang warnings

### DIFF
--- a/src/node_v8_platform.h
+++ b/src/node_v8_platform.h
@@ -53,9 +53,9 @@ class Platform : public v8::Platform {
   virtual ~Platform() override;
 
   void CallOnBackgroundThread(v8::Task* task,
-                              ExpectedRuntime expected_runtime);
-  void CallOnForegroundThread(v8::Isolate* isolate, v8::Task* task);
-  double MonotonicallyIncreasingTime();
+                              ExpectedRuntime expected_runtime) override;
+  void CallOnForegroundThread(v8::Isolate* isolate, v8::Task* task) override;
+  double MonotonicallyIncreasingTime() override;
 
  protected:
   static void WorkerBody(void* arg);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -32,11 +32,11 @@ class ExternString: public ResourceType {
       isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
     }
 
-    const TypeName* data() const {
+    const TypeName* data() const override {
       return data_;
     }
 
-    size_t length() const {
+    size_t length() const override {
       return length_;
     }
 


### PR DESCRIPTION
Mark several methods "override" in order to remove build warnings.

R=@bnoordhuis