### PR TITLE
v8: fix template literal NULL pointer deref

### DIFF
--- a/deps/v8/src/preparser.h
+++ b/deps/v8/src/preparser.h
@@ -2875,9 +2875,15 @@ ParserBase<Traits>::ParseTemplateLiteral(ExpressionT tag, int start, bool* ok) {
 
   do {
     next = peek();
-    if (!next) {
+    if (next == Token::EOS) {
       ReportMessageAt(Scanner::Location(start, peek_position()),
                       "unterminated_template");
+      *ok = false;
+      return Traits::EmptyExpression();
+    } else if (next == Token::ILLEGAL) {
+      Traits::ReportMessageAt(
+          Scanner::Location(position() + 1, peek_position()),
+          "unexpected_token", "ILLEGAL", false);
       *ok = false;
       return Traits::EmptyExpression();
     }
@@ -2898,9 +2904,15 @@ ParserBase<Traits>::ParseTemplateLiteral(ExpressionT tag, int start, bool* ok) {
     next = scanner()->ScanTemplateContinuation();
     Next();
 
-    if (!next) {
-      ReportMessageAt(Scanner::Location(start, position()),
+    if (next == Token::EOS) {
+      ReportMessageAt(Scanner::Location(start, peek_position()),
                       "unterminated_template");
+      *ok = false;
+      return Traits::EmptyExpression();
+    } else if (next == Token::ILLEGAL) {
+      Traits::ReportMessageAt(
+          Scanner::Location(position() + 1, peek_position()),
+          "unexpected_token", "ILLEGAL", false);
       *ok = false;
       return Traits::EmptyExpression();
     }

--- a/deps/v8/test/cctest/test-parsing.cc
+++ b/deps/v8/test/cctest/test-parsing.cc
@@ -4549,6 +4549,28 @@ TEST(ScanUnterminatedTemplateLiterals) {
 }
 
 
+TEST(TemplateLiteralsIllegalTokens) {
+  const char* context_data[][2] = {{"'use strict';", ""},
+                                   {"function foo(){ 'use strict';"
+                                    "  var a, b, c; return ", "}"},
+                                   {NULL, NULL}};
+  const char* data[] = {
+      "`hello\\x`",
+      "`hello\\x${1}`",
+      "`hello${1}\\x`",
+      "`hello${1}\\x${2}`",
+      "`hello\\x\n`",
+      "`hello\\x\n${1}`",
+      "`hello${1}\\x\n`",
+      "`hello${1}\\x\n${2}`",
+      NULL};
+
+  static const ParserFlag always_flags[] = {kAllowHarmonyTemplates};
+  RunParserSyncTest(context_data, data, kError, NULL, 0, always_flags,
+                    arraysize(always_flags));
+}
+
+
 TEST(LexicalScopingSloppyMode) {
   const char* context_data[][2] = {
       {"", ""},


### PR DESCRIPTION
Fixes a NULL pointer dereference with unterminated template literals.

This is a back-port of commit v8/v8-git-mirror@02218ad from the V8
master branch, see https://code.google.com/p/v8/issues/detail?id=3820.

R=@indutny @caitp

I'm going to send this upstream after `make x64.release.quickcheck` completes...