### PR TITLE
net: move default address logic to `_listen2`

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1110,9 +1110,30 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
 
   // If there is not yet a handle, we need to create one and bind.
   // In the case of a server sent via IPC, we don't need to do this.
-  if (!self._handle) {
+  if (self._handle) {
+    debug('_listen2: have a handle already');
+  } else {
     debug('_listen2: create a handle');
-    var rval = createServerHandle(address, port, addressType, fd);
+
+    var rval = null;
+
+    if (!address && !util.isNumber(fd)) {
+      rval = createServerHandle('::', port, 6, fd);
+
+      if (util.isNumber(rval)) {
+        rval = null;
+        address = '0.0.0.0';
+        addressType = 4;
+      } else {
+        address = '::';
+        addressType = 6;
+      }
+
+    }
+
+    if (rval === null)
+      rval = createServerHandle(address, port, addressType, fd);
+
     if (util.isNumber(rval)) {
       var error = exceptionWithHostPort(rval, 'listen', address, port);
       process.nextTick(function() {
@@ -1121,8 +1142,6 @@ Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
       return;
     }
     self._handle = rval;
-  } else {
-    debug('_listen2: have a handle already');
   }
 
   self._handle.onconnection = onconnection;

--- a/test/sequential/test-net-server-bind.js
+++ b/test/sequential/test-net-server-bind.js
@@ -18,12 +18,14 @@ server0.listen(function() {
 // No callback to listen(), assume we can bind in 100 ms
 
 var address1;
+var connectionKey1;
 var server1 = net.createServer(function(socket) { });
 
 server1.listen(common.PORT);
 
 setTimeout(function() {
   address1 = server1.address();
+  connectionKey1 = server1._connectionKey;
   console.log('address1 %j', address1);
   server1.close();
 }, 100);
@@ -68,6 +70,15 @@ server4.listen(common.PORT + 3, 127, function() {
 process.on('exit', function() {
   assert.ok(address0.port > 100);
   assert.equal(common.PORT, address1.port);
+
+  var expectedConnectionKey1;
+
+  if (address1.family === 'IPv6')
+    expectedConnectionKey1 = '6::::' + address1.port;
+  else
+    expectedConnectionKey1 = '4:0.0.0.0:' + address1.port;
+
+  assert.equal(connectionKey1, expectedConnectionKey1);
   assert.equal(common.PORT + 1, address2.port);
   assert.equal(common.PORT + 2, address3.port);
   assert.equal(common.PORT + 3, address4.port);


### PR DESCRIPTION
When address is not provided to `server.listen()` `_connectionKey` and error messages should include actual address and correct family.

```javascript
var net = require('net');

var s = net.createServer();

s.listen(3333)

console.log(s._connectionKey)

 s = net.createServer();
s.listen(3333)
```

Before:
```
4:null:3333
events.js:76
      throw er; // Unhandled 'error' event
            ^
Error: listen EADDRINUSE null:3333
```

After:
```
6::::3333
events.js:76
      throw er; // Unhandled 'error' event
            ^
Error: listen EADDRINUSE :::3333
```

R=@bnoordhuis?