### PR TITLE
events: Alias EventEmitter.protoype.removeListener as EventEmitter.prototype.off 

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -57,6 +57,7 @@ it is removed.
 Returns emitter, so calls can be chained.
 
 ### emitter.removeListener(event, listener)
+### emitter.off(event, listener)
 
 Remove a listener from the listener array for the specified event.
 **Caution**: changes array indices in the listener array behind the listener.

--- a/lib/events.js
+++ b/lib/events.js
@@ -238,6 +238,8 @@ EventEmitter.prototype.removeListener =
       return this;
     };
 
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
       var key, listeners;

--- a/test/parallel/test-event-emitter-method-names.js
+++ b/test/parallel/test-event-emitter-method-names.js
@@ -6,7 +6,7 @@ var E = events.EventEmitter.prototype;
 assert.equal(E.constructor.name, 'EventEmitter');
 assert.equal(E.on, E.addListener);  // Same method.
 Object.getOwnPropertyNames(E).forEach(function(name) {
-  if (name === 'constructor' || name === 'on') return;
+  if (name === 'constructor' || name === 'on' || name === 'off') return;
   if (typeof E[name] !== 'function') return;
   assert.equal(E[name].name, name);
 });

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -61,3 +61,6 @@ e4.on('removeListener', common.mustCall(function(name, cb) {
 e4.on('quux', remove1);
 e4.on('quux', remove2);
 e4.removeListener('quux', remove1);
+
+var e5 = new events.EventEmitter();
+assert.equal(e5.removeListener, e5.off);


### PR DESCRIPTION
EventEmitter should have `off` alias for io.js beginners, preventing event leaks, API symmetry etc....
 
I understand the historical reason why events does not have `off` alias. 

https://github.com/joyent/node/pull/3338
https://github.com/joyent/node/issues/5352

Of course, I understand the API of events is frozen in io.js. However io.js have already added the new API `getMaxListeners`.
And this change does not break backward compatibility. I really would like to add this alias in io.js.

I know io.js follows semantic versioning. If this changes is not patch version (v1.0.x), I can wait for io.js to merge this change until minor version up (v1.1.x).