### PR TITLE
lib: use const to define constants

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -1,17 +1,16 @@
 'use strict';
 
-var assert = require('assert');
-var net = require('net');
-var util = require('util');
-var Buffer = require('buffer').Buffer;
-
-var Transform = require('stream').Transform;
+const assert = require('assert');
+const net = require('net');
+const util = require('util');
+const Buffer = require('buffer').Buffer;
+const Transform = require('stream').Transform;
 
 exports.start = function start() {
   var agent = new Agent();
 
   // Do not let `agent.listen()` request listening from cluster master
-  var cluster = require('cluster');
+  const cluster = require('cluster');
   cluster.isWorker = false;
   cluster.isMaster = true;
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var util = require('util'),
-    path = require('path'),
-    net = require('net'),
-    vm = require('vm'),
-    module = require('module'),
-    repl = module.requireRepl(),
-    inherits = util.inherits,
-    assert = require('assert'),
-    spawn = require('child_process').spawn;
+const util = require('util');
+const path = require('path');
+const net = require('net');
+const vm = require('vm');
+const module = require('module');
+const repl = module.requireRepl();
+const inherits = util.inherits;
+const assert = require('assert');
+const spawn = require('child_process').spawn;
 
 exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
@@ -137,7 +137,7 @@ Protocol.prototype.serialize = function(req) {
 };
 
 
-var NO_FRAME = -1;
+const NO_FRAME = -1;
 
 function Client() {
   net.Stream.call(this);
@@ -176,7 +176,7 @@ Client.prototype._addHandle = function(desc) {
 };
 
 
-var natives = process.binding('natives');
+const natives = process.binding('natives');
 
 
 Client.prototype._addScript = function(desc) {
@@ -645,7 +645,7 @@ Client.prototype.fullTrace = function(cb) {
 
 
 
-var commands = [
+const commands = [
   [
     'run (r)',
     'cont (c)',
@@ -772,22 +772,22 @@ function Interface(stdin, stdout, args) {
   process.once('SIGTERM', process.exit.bind(process, 0));
   process.once('SIGHUP', process.exit.bind(process, 0));
 
-  var proto = Interface.prototype,
-      ignored = ['pause', 'resume', 'exitRepl', 'handleBreak',
-                 'requireConnection', 'killChild', 'trySpawn',
-                 'controlEval', 'debugEval', 'print', 'childPrint',
-                 'clearline'],
-      shortcut = {
-        'run': 'r',
-        'cont': 'c',
-        'next': 'n',
-        'step': 's',
-        'out': 'o',
-        'backtrace': 'bt',
-        'setBreakpoint': 'sb',
-        'clearBreakpoint': 'cb',
-        'pause_': 'pause'
-      };
+  var proto = Interface.prototype;
+  const ignored = ['pause', 'resume', 'exitRepl', 'handleBreak',
+                   'requireConnection', 'killChild', 'trySpawn',
+                   'controlEval', 'debugEval', 'print', 'childPrint',
+                   'clearline'];
+  const shortcut = {
+    'run': 'r',
+    'cont': 'c',
+    'next': 'n',
+    'step': 's',
+    'out': 'o',
+    'backtrace': 'bt',
+    'setBreakpoint': 'sb',
+    'clearBreakpoint': 'cb',
+    'pause_': 'pause'
+  };
 
   function defineProperty(key, protoKey) {
     // Check arity

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var net = require('net');
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
-var debug = util.debuglog('http');
+const net = require('net');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+const debug = util.debuglog('http');
 
 // New Agent code.
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var util = require('util');
-var net = require('net');
-var url = require('url');
-var EventEmitter = require('events').EventEmitter;
-var HTTPParser = process.binding('http_parser').HTTPParser;
-var assert = require('assert').ok;
-
-var common = require('_http_common');
-
-var httpSocketSetup = common.httpSocketSetup;
-var parsers = common.parsers;
-var freeParser = common.freeParser;
-var debug = common.debug;
-
-var OutgoingMessage = require('_http_outgoing').OutgoingMessage;
-
-var Agent = require('_http_agent');
+const util = require('util');
+const net = require('net');
+const url = require('url');
+const EventEmitter = require('events').EventEmitter;
+const HTTPParser = process.binding('http_parser').HTTPParser;
+const assert = require('assert').ok;
+const common = require('_http_common');
+const httpSocketSetup = common.httpSocketSetup;
+const parsers = common.parsers;
+const freeParser = common.freeParser;
+const debug = common.debug;
+const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
+const Agent = require('_http_agent');
 
 
 function ClientRequest(options, cb) {
@@ -56,7 +52,8 @@ function ClientRequest(options, cb) {
                     'Expected "' + expectedProtocol + '".');
   }
 
-  var defaultPort = options.defaultPort || self.agent && self.agent.defaultPort;
+  const defaultPort = options.defaultPort ||
+                      self.agent && self.agent.defaultPort;
 
   var port = options.port = options.port || defaultPort || 80;
   var host = options.host = options.hostname || options.host || 'localhost';

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var FreeList = require('freelist').FreeList;
-var HTTPParser = process.binding('http_parser').HTTPParser;
+const FreeList = require('freelist').FreeList;
+const HTTPParser = process.binding('http_parser').HTTPParser;
 
-var incoming = require('_http_incoming');
-var IncomingMessage = incoming.IncomingMessage;
-var readStart = incoming.readStart;
-var readStop = incoming.readStop;
+const incoming = require('_http_incoming');
+const IncomingMessage = incoming.IncomingMessage;
+const readStart = incoming.readStart;
+const readStop = incoming.readStop;
 
-var isNumber = require('util').isNumber;
-var debug = require('util').debuglog('http');
+const isNumber = require('util').isNumber;
+const debug = require('util').debuglog('http');
 exports.debug = debug;
 
 exports.CRLF = '\r\n';
@@ -17,10 +17,10 @@ exports.chunkExpression = /chunk/i;
 exports.continueExpression = /100-continue/i;
 exports.methods = HTTPParser.methods;
 
-var kOnHeaders = HTTPParser.kOnHeaders | 0;
-var kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
-var kOnBody = HTTPParser.kOnBody | 0;
-var kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
+const kOnHeaders = HTTPParser.kOnHeaders | 0;
+const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
+const kOnBody = HTTPParser.kOnBody | 0;
+const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 
 // Only called in the slow case where slow means
 // that the request headers were either fragmented

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var util = require('util');
-var Stream = require('stream');
+const util = require('util');
+const Stream = require('stream');
 
 function readStart(socket) {
   if (socket && !socket._paused && socket.readable)

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -1,25 +1,23 @@
 'use strict';
 
-var assert = require('assert').ok;
-var Stream = require('stream');
-var timers = require('timers');
-var util = require('util');
+const assert = require('assert').ok;
+const Stream = require('stream');
+const timers = require('timers');
+const util = require('util');
+const common = require('_http_common');
 
-var common = require('_http_common');
+const CRLF = common.CRLF;
+const chunkExpression = common.chunkExpression;
+const debug = common.debug;
 
-var CRLF = common.CRLF;
-var chunkExpression = common.chunkExpression;
-var debug = common.debug;
+const connectionExpression = /Connection/i;
+const transferEncodingExpression = /Transfer-Encoding/i;
+const closeExpression = /close/i;
+const contentLengthExpression = /Content-Length/i;
+const dateExpression = /Date/i;
+const expectExpression = /Expect/i;
 
-
-var connectionExpression = /Connection/i;
-var transferEncodingExpression = /Transfer-Encoding/i;
-var closeExpression = /close/i;
-var contentLengthExpression = /Content-Length/i;
-var dateExpression = /Date/i;
-var expectExpression = /Expect/i;
-
-var automaticHeaders = {
+const automaticHeaders = {
   connection: true,
   'content-length': true,
   'transfer-encoding': true,
@@ -477,7 +475,7 @@ OutgoingMessage.prototype.addTrailers = function(headers) {
 };
 
 
-var crlf_buf = new Buffer('\r\n');
+const crlf_buf = new Buffer('\r\n');
 
 
 OutgoingMessage.prototype.end = function(data, encoding, callback) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -1,24 +1,21 @@
 'use strict';
 
-var util = require('util');
-var net = require('net');
-var EventEmitter = require('events').EventEmitter;
-var HTTPParser = process.binding('http_parser').HTTPParser;
-var assert = require('assert').ok;
+const util = require('util');
+const net = require('net');
+const EventEmitter = require('events').EventEmitter;
+const HTTPParser = process.binding('http_parser').HTTPParser;
+const assert = require('assert').ok;
+const common = require('_http_common');
+const parsers = common.parsers;
+const freeParser = common.freeParser;
+const debug = common.debug;
+const CRLF = common.CRLF;
+const continueExpression = common.continueExpression;
+const chunkExpression = common.chunkExpression;
+const httpSocketSetup = common.httpSocketSetup;
+const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
-var common = require('_http_common');
-var parsers = common.parsers;
-var freeParser = common.freeParser;
-var debug = common.debug;
-var CRLF = common.CRLF;
-var continueExpression = common.continueExpression;
-var chunkExpression = common.chunkExpression;
-var httpSocketSetup = common.httpSocketSetup;
-
-var OutgoingMessage = require('_http_outgoing').OutgoingMessage;
-
-
-var STATUS_CODES = exports.STATUS_CODES = {
+const STATUS_CODES = exports.STATUS_CODES = {
   100 : 'Continue',
   101 : 'Switching Protocols',
   102 : 'Processing',                 // RFC 2518, obsoleted by RFC 4918

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -6,9 +6,10 @@
 'use strict';
 
 module.exports = Duplex;
-var util = require('util');
-var Readable = require('_stream_readable');
-var Writable = require('_stream_writable');
+
+const util = require('util');
+const Readable = require('_stream_readable');
+const Writable = require('_stream_writable');
 
 util.inherits(Duplex, Readable);
 

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -6,8 +6,8 @@
 
 module.exports = PassThrough;
 
-var Transform = require('_stream_transform');
-var util = require('util');
+const Transform = require('_stream_transform');
+const util = require('util');
 util.inherits(PassThrough, Transform);
 
 function PassThrough(options) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -3,11 +3,11 @@
 module.exports = Readable;
 Readable.ReadableState = ReadableState;
 
-var EE = require('events').EventEmitter;
-var Stream = require('stream');
-var util = require('util');
+const EE = require('events').EventEmitter;
+const Stream = require('stream');
+const util = require('util');
+const debug = util.debuglog('stream');
 var StringDecoder;
-var debug = util.debuglog('stream');
 
 util.inherits(Readable, Stream);
 
@@ -189,7 +189,7 @@ Readable.prototype.setEncoding = function(enc) {
 };
 
 // Don't raise the hwm > 128MB
-var MAX_HWM = 0x800000;
+const MAX_HWM = 0x800000;
 function roundUpToNextPowerOf2(n) {
   if (n >= MAX_HWM) {
     n = MAX_HWM;
@@ -781,7 +781,7 @@ Readable.prototype.wrap = function(stream) {
   }
 
   // proxy certain important events.
-  var events = ['error', 'close', 'destroy', 'pause', 'resume'];
+  const events = ['error', 'close', 'destroy', 'pause', 'resume'];
   events.forEach(function(ev) {
     stream.on(ev, self.emit.bind(self, ev));
   });

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -44,8 +44,8 @@
 
 module.exports = Transform;
 
-var Duplex = require('_stream_duplex');
-var util = require('util');
+const Duplex = require('_stream_duplex');
+const util = require('util');
 util.inherits(Transform, Duplex);
 
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -7,9 +7,9 @@
 module.exports = Writable;
 Writable.WritableState = WritableState;
 
-var util = require('util');
-var Stream = require('stream');
-var debug = util.debuglog('stream');
+const util = require('util');
+const Stream = require('stream');
+const debug = util.debuglog('stream');
 
 util.inherits(Writable, Stream);
 
@@ -409,7 +409,6 @@ function clearBuffer(stream, state) {
 
 Writable.prototype._write = function(chunk, encoding, cb) {
   cb(new Error('not implemented'));
-
 };
 
 Writable.prototype._writev = null;

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var util = require('util');
-var constants = require('constants');
-var tls = require('tls');
+const util = require('util');
+const constants = require('constants');
+const tls = require('tls');
 
 // Lazily loaded
 var crypto = null;
 
-var binding = process.binding('crypto');
-var NativeSecureContext = binding.SecureContext;
+const binding = process.binding('crypto');
+const NativeSecureContext = binding.SecureContext;
 
 function SecureContext(secureProtocol, flags, context) {
   if (!(this instanceof SecureContext)) {

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -1,21 +1,19 @@
 'use strict';
 
-var assert = require('assert');
-var events = require('events');
-var stream = require('stream');
-var tls = require('tls');
-var util = require('util');
-var common = require('_tls_common');
-
-var Timer = process.binding('timer_wrap').Timer;
+const assert = require('assert');
+const events = require('events');
+const stream = require('stream');
+const tls = require('tls');
+const util = require('util');
+const common = require('_tls_common');
+const debug = util.debuglog('tls-legacy');
+const Timer = process.binding('timer_wrap').Timer;
 var Connection = null;
 try {
   Connection = process.binding('crypto').Connection;
 } catch (e) {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
-
-var debug = util.debuglog('tls-legacy');
 
 function SlabBuffer() {
   this.create();

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1,20 +1,18 @@
 'use strict';
 
-var assert = require('assert');
-var crypto = require('crypto');
-var net = require('net');
-var tls = require('tls');
-var util = require('util');
-var listenerCount = require('events').listenerCount;
-var common = require('_tls_common');
-
-var Timer = process.binding('timer_wrap').Timer;
-var tls_wrap = process.binding('tls_wrap');
+const assert = require('assert');
+const crypto = require('crypto');
+const net = require('net');
+const tls = require('tls');
+const util = require('util');
+const listenerCount = require('events').listenerCount;
+const common = require('_tls_common');
+const debug = util.debuglog('tls');
+const Timer = process.binding('timer_wrap').Timer;
+const tls_wrap = process.binding('tls_wrap');
 
 // Lazy load
 var tls_legacy;
-
-var debug = util.debuglog('tls');
 
 function onhandshakestart() {
   debug('onhandshakestart');

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,14 +25,14 @@
 'use strict';
 
 // UTILITY
-var util = require('util');
-var pSlice = Array.prototype.slice;
+const util = require('util');
+const pSlice = Array.prototype.slice;
 
 // 1. The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
 
-var assert = module.exports = ok;
+const assert = module.exports = ok;
 
 // 2. The AssertionError is defined in assert.
 // new assert.AssertionError({ message: message,

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var buffer = process.binding('buffer');
-var smalloc = process.binding('smalloc');
-var util = require('util');
-var alloc = smalloc.alloc;
-var truncate = smalloc.truncate;
-var sliceOnto = smalloc.sliceOnto;
-var kMaxLength = smalloc.kMaxLength;
+const buffer = process.binding('buffer');
+const smalloc = process.binding('smalloc');
+const util = require('util');
+const alloc = smalloc.alloc;
+const truncate = smalloc.truncate;
+const sliceOnto = smalloc.sliceOnto;
+const kMaxLength = smalloc.kMaxLength;
 var internal = {};
 
 exports.Buffer = Buffer;
@@ -333,8 +333,8 @@ Buffer.prototype.set = util.deprecate(function set(offset, v) {
 // TODO(trevnorris): fix these checks to follow new standard
 // write(string, offset = 0, length = buffer.length, encoding = 'utf8')
 var writeWarned = false;
-var writeMsg = '.write(string, encoding, offset, length) is deprecated.' +
-               ' Use write(string[, offset[, length]][, encoding]) instead.';
+const writeMsg = '.write(string, encoding, offset, length) is deprecated.' +
+                 ' Use write(string[, offset[, length]][, encoding]) instead.';
 Buffer.prototype.write = function(string, offset, length, encoding) {
   // Buffer#write(string);
   if (util.isUndefined(offset)) {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var StringDecoder = require('string_decoder').StringDecoder;
-var EventEmitter = require('events').EventEmitter;
-var net = require('net');
-var dgram = require('dgram');
-var assert = require('assert');
-var util = require('util');
+const StringDecoder = require('string_decoder').StringDecoder;
+const EventEmitter = require('events').EventEmitter;
+const net = require('net');
+const dgram = require('dgram');
+const assert = require('assert');
+const util = require('util');
 
-var Process = process.binding('process_wrap').Process;
-var WriteWrap = process.binding('stream_wrap').WriteWrap;
-var uv = process.binding('uv');
+const Process = process.binding('process_wrap').Process;
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
+const uv = process.binding('uv');
 
 var spawn_sync; // Lazy-loaded process.binding('spawn_sync')
 var constants;  // Lazy-loaded process.binding('constants')
 
-var errnoException = util._errnoException;
+const errnoException = util._errnoException;
 var handleWraps = {};
 
 function handleWrapGetter(name, callback) {
@@ -66,7 +66,7 @@ function createSocket(pipe, readable) {
 
 // this object contain function to convert TCP objects to native handle objects
 // and back again.
-var handleConversion = {
+const handleConversion = {
   'net.Native': {
     simultaneousAccepts: true,
 
@@ -292,7 +292,7 @@ function getSocketList(type, slave, key) {
   return socketList;
 }
 
-var INTERNAL_PREFIX = 'NODE_';
+const INTERNAL_PREFIX = 'NODE_';
 function handleMessage(target, message, handle) {
   var eventName = 'message';
   if (!util.isNull(message) &&

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var assert = require('assert');
-var dgram = require('dgram');
-var fork = require('child_process').fork;
-var net = require('net');
-var util = require('util');
-var SCHED_NONE = 1;
-var SCHED_RR = 2;
+const EventEmitter = require('events').EventEmitter;
+const assert = require('assert');
+const dgram = require('dgram');
+const fork = require('child_process').fork;
+const net = require('net');
+const util = require('util');
+const SCHED_NONE = 1;
+const SCHED_RR = 2;
 
-var cluster = new EventEmitter;
+const cluster = new EventEmitter;
 module.exports = cluster;
 cluster.Worker = Worker;
 cluster.isWorker = ('NODE_UNIQUE_ID' in process.env);
@@ -311,9 +311,9 @@ function masterInit() {
 
   cluster.fork = function(env) {
     cluster.setupMaster();
-    var id = ++ids;
-    var workerProcess = createWorkerProcess(id, env);
-    var worker = new Worker({
+    const id = ++ids;
+    const workerProcess = createWorkerProcess(id, env);
+    const worker = new Worker({
       id: id,
       process: workerProcess
     });

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var util = require('util');
+const util = require('util');
 
 function Console(stdout, stderr) {
   if (!(this instanceof Console)) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -15,11 +15,11 @@ try {
   throw new Error('node.js not compiled with openssl crypto support.');
 }
 
-var constants = require('constants');
-var stream = require('stream');
-var util = require('util');
+const constants = require('constants');
+const stream = require('stream');
+const util = require('util');
 
-var DH_GENERATOR = 2;
+const DH_GENERATOR = 2;
 
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want
@@ -36,8 +36,8 @@ function toBuf(str, encoding) {
 exports._toBuf = toBuf;
 
 
-var assert = require('assert');
-var StringDecoder = require('string_decoder').StringDecoder;
+const assert = require('assert');
+const StringDecoder = require('string_decoder').StringDecoder;
 
 
 function LazyTransform(options) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var assert = require('assert');
-var util = require('util');
-var events = require('events');
-var constants = require('constants');
+const assert = require('assert');
+const util = require('util');
+const events = require('events');
+const constants = require('constants');
 
-var UDP = process.binding('udp_wrap').UDP;
-var SendWrap = process.binding('udp_wrap').SendWrap;
+const UDP = process.binding('udp_wrap').UDP;
+const SendWrap = process.binding('udp_wrap').SendWrap;
 
-var BIND_STATE_UNBOUND = 0;
-var BIND_STATE_BINDING = 1;
-var BIND_STATE_BOUND = 2;
+const BIND_STATE_UNBOUND = 0;
+const BIND_STATE_BINDING = 1;
+const BIND_STATE_BOUND = 2;
 
 // lazily loaded
 var cluster = null;
 var dns = null;
 
-var errnoException = util._errnoException;
-var exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = util._errnoException;
+const exceptionWithHostPort = util._exceptionWithHostPort;
 
 function lookup(address, family, callback) {
   if (!dns)
@@ -146,7 +146,7 @@ Socket.prototype.bind = function(port /*, address, callback*/) {
   if (util.isFunction(arguments[arguments.length - 1]))
     self.once('listening', arguments[arguments.length - 1]);
 
-  var UDP = process.binding('udp_wrap').UDP;
+  const UDP = process.binding('udp_wrap').UDP;
   if (port instanceof UDP) {
     replaceHandle(self, port);
     startListening(self);

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var net = require('net');
-var util = require('util');
+const net = require('net');
+const util = require('util');
 
-var cares = process.binding('cares_wrap');
-var uv = process.binding('uv');
+const cares = process.binding('cares_wrap');
+const uv = process.binding('uv');
 
-var GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
-var GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
+const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
+const GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
 
-var isIp = net.isIP;
+const isIp = net.isIP;
 
 
 function errnoException(err, syscall, hostname) {

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -5,9 +5,9 @@
 // No new pull requests targeting this module will be accepted
 // unless they address existing, critical bugs.
 
-var util = require('util');
-var EventEmitter = require('events');
-var inherits = util.inherits;
+const util = require('util');
+const EventEmitter = require('events');
+const inherits = util.inherits;
 
 // communicate with events module, but don't require that
 // module to have to load this one, since this module has

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var domain;
-var util = require('util');
+const util = require('util');
 
 function EventEmitter() {
   EventEmitter.init.call(this);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,18 +3,18 @@
 
 'use strict';
 
-var util = require('util');
-var pathModule = require('path');
+const util = require('util');
+const pathModule = require('path');
 
-var binding = process.binding('fs');
-var constants = process.binding('constants');
-var fs = exports;
-var Stream = require('stream').Stream;
-var EventEmitter = require('events').EventEmitter;
-var FSReqWrap = binding.FSReqWrap;
+const binding = process.binding('fs');
+const constants = process.binding('constants');
+const fs = exports;
+const Stream = require('stream').Stream;
+const EventEmitter = require('events').EventEmitter;
+const FSReqWrap = binding.FSReqWrap;
 
-var Readable = Stream.Readable;
-var Writable = Stream.Writable;
+const Readable = Stream.Readable;
+const Writable = Stream.Writable;
 
 const kMinPoolSpace = 128;
 const kMaxLength = require('smalloc').kMaxLength;
@@ -32,10 +32,10 @@ const R_OK = constants.R_OK || 0;
 const W_OK = constants.W_OK || 0;
 const X_OK = constants.X_OK || 0;
 
-var isWindows = process.platform === 'win32';
+const isWindows = process.platform === 'win32';
 
-var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
-var errnoException = util._errnoException;
+const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
+const errnoException = util._errnoException;
 
 
 function rethrow() {

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,30 +1,30 @@
 'use strict';
 
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 
 exports.IncomingMessage = require('_http_incoming').IncomingMessage;
 
 
-var common = require('_http_common');
+const common = require('_http_common');
 exports.METHODS = util._extend([], common.methods).sort();
 
 
 exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
 
-var server = require('_http_server');
+const server = require('_http_server');
 exports.ServerResponse = server.ServerResponse;
 exports.STATUS_CODES = server.STATUS_CODES;
 
 
-var agent = require('_http_agent');
-var Agent = exports.Agent = agent.Agent;
+const agent = require('_http_agent');
+const Agent = exports.Agent = agent.Agent;
 exports.globalAgent = agent.globalAgent;
 
-var client = require('_http_client');
-var ClientRequest = exports.ClientRequest = client.ClientRequest;
+const client = require('_http_client');
+const ClientRequest = exports.ClientRequest = client.ClientRequest;
 
 exports.request = function(options, cb) {
   return new ClientRequest(options, cb);
@@ -37,7 +37,7 @@ exports.get = function(options, cb) {
 };
 
 exports._connectionListener = server._connectionListener;
-var Server = exports.Server = server.Server;
+const Server = exports.Server = server.Server;
 
 exports.createServer = function(requestListener) {
   return new Server(requestListener);

--- a/lib/https.js
+++ b/lib/https.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var tls = require('tls');
-var url = require('url');
-var http = require('http');
-var util = require('util');
-var inherits = require('util').inherits;
-var debug = util.debuglog('https');
+const tls = require('tls');
+const url = require('url');
+const http = require('http');
+const util = require('util');
+const inherits = require('util').inherits;
+const debug = util.debuglog('https');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -102,7 +102,7 @@ Agent.prototype.getName = function(options) {
   return name;
 };
 
-var globalAgent = new Agent();
+const globalAgent = new Agent();
 
 exports.globalAgent = globalAgent;
 exports.Agent = Agent;

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var NativeModule = require('native_module');
-var util = NativeModule.require('util');
-var runInThisContext = require('vm').runInThisContext;
-var runInNewContext = require('vm').runInNewContext;
-var assert = require('assert').ok;
-var fs = NativeModule.require('fs');
+const NativeModule = require('native_module');
+const util = NativeModule.require('util');
+const runInThisContext = require('vm').runInThisContext;
+const runInNewContext = require('vm').runInNewContext;
+const assert = require('assert').ok;
+const fs = NativeModule.require('fs');
 
 
 // If obj.hasOwnProperty has been overridden, then calling
@@ -42,13 +42,13 @@ Module.globalPaths = [];
 Module.wrapper = NativeModule.wrapper;
 Module.wrap = NativeModule.wrap;
 
-var path = NativeModule.require('path');
+const path = NativeModule.require('path');
 
 Module._debug = util.debuglog('module');
 
 
 // We use this alias for the preprocessor that filters it out
-var debug = Module._debug;
+const debug = Module._debug;
 
 
 // given a module name, and a list of paths to test, returns the first
@@ -70,7 +70,7 @@ function statPath(path) {
 }
 
 // check if the directory is a package.json dir
-var packageMainCache = {};
+const packageMainCache = {};
 
 function readPackage(requestPath) {
   if (hasOwnProperty(packageMainCache, requestPath)) {
@@ -490,7 +490,7 @@ Module.runMain = function() {
 };
 
 Module._initPaths = function() {
-  var isWindows = process.platform === 'win32';
+  const isWindows = process.platform === 'win32';
 
   if (isWindows) {
     var homeDir = process.env.USERPROFILE;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var events = require('events');
-var stream = require('stream');
-var timers = require('timers');
-var util = require('util');
-var assert = require('assert');
-var cares = process.binding('cares_wrap');
-var uv = process.binding('uv');
-var Pipe = process.binding('pipe_wrap').Pipe;
+const events = require('events');
+const stream = require('stream');
+const timers = require('timers');
+const util = require('util');
+const assert = require('assert');
+const cares = process.binding('cares_wrap');
+const uv = process.binding('uv');
+const Pipe = process.binding('pipe_wrap').Pipe;
 
-var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
-var PipeConnectWrap = process.binding('pipe_wrap').PipeConnectWrap;
-var ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
-var WriteWrap = process.binding('stream_wrap').WriteWrap;
+const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+const PipeConnectWrap = process.binding('pipe_wrap').PipeConnectWrap;
+const ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
 
 
 var cluster;
-var errnoException = util._errnoException;
-var exceptionWithHostPort = util._exceptionWithHostPort;
+const errnoException = util._errnoException;
+const exceptionWithHostPort = util._exceptionWithHostPort;
 
 function noop() {}
 
@@ -42,7 +42,7 @@ function createHandle(fd) {
 }
 
 
-var debug = util.debuglog('net');
+const debug = util.debuglog('net');
 
 function isPipeName(s) {
   return util.isString(s) && toNumber(s) === false;
@@ -872,7 +872,7 @@ Socket.prototype.connect = function(options, cb) {
     connect(self, options.path);
 
   } else {
-    var dns = require('dns');
+    const dns = require('dns');
     var host = options.host || 'localhost';
     var port = options.port | 0;
     var localAddress = options.localAddress;
@@ -1204,7 +1204,7 @@ Server.prototype.listen = function() {
   // When the ip is omitted it can be the second argument.
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
 
-  var TCP = process.binding('tcp_wrap').TCP;
+  const TCP = process.binding('tcp_wrap').TCP;
 
   if (arguments.length === 0 || util.isFunction(arguments[0])) {
     // Bind to a random port.

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var binding = process.binding('os');
-var util = require('util');
-var isWindows = process.platform === 'win32';
+const binding = process.binding('os');
+const util = require('util');
+const isWindows = process.platform === 'win32';
 
 exports.hostname = binding.getHostname;
 exports.loadavg = binding.getLoadAvg;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var isWindows = process.platform === 'win32';
-var util = require('util');
+const isWindows = process.platform === 'win32';
+const util = require('util');
 
 
 // resolves . and .. elements in a path array with directory names there
@@ -33,11 +33,11 @@ function normalizeArray(parts, allowAboveRoot) {
 
 // Regex to split a windows path into three parts: [*, device, slash,
 // tail] windows-only
-var splitDeviceRe =
+const splitDeviceRe =
     /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
 
 // Regex to split the tail part of the above into [*, dir, basename, ext]
-var splitTailRe =
+const splitTailRe =
     /^([\s\S]*?)((?:\.{1,2}|[^\\\/]+?|)(\.[^.\/\\]*|))(?:[\\\/]*)$/;
 
 var win32 = {};
@@ -378,7 +378,7 @@ win32.delimiter = ';';
 
 // Split a filename into [root, dir, basename, ext], unix version
 // 'root' is just a slash, or nothing.
-var splitPathRe =
+const splitPathRe =
     /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;
 var posix = {};
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
-var QueryString = exports;
-var util = require('util');
+const QueryString = exports;
+const util = require('util');
 
 
 // If obj.hasOwnProperty has been overridden, then calling

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-var kHistorySize = 30;
+const kHistorySize = 30;
 
-var util = require('util');
-var inherits = require('util').inherits;
-var EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const inherits = util.inherits;
+const EventEmitter = require('events').EventEmitter;
 
 
 exports.createInterface = function(input, output, completer, terminal) {
@@ -294,7 +294,7 @@ Interface.prototype.write = function(d, key) {
 };
 
 // \r\n, \n, or \r followed by something other than \n
-var lineEnding = /\r?\n|\r(?!\n)/;
+const lineEnding = /\r?\n|\r(?!\n)/;
 Interface.prototype._normalWrite = function(b) {
   if (util.isUndefined(b)) {
     return;
@@ -939,15 +939,15 @@ exports.emitKeypressEvents = emitKeypressEvents;
 */
 
 // Regexes used for ansi escape code splitting
-var metaKeyCodeReAnywhere = /(?:\x1b)([a-zA-Z0-9])/;
-var metaKeyCodeRe = new RegExp('^' + metaKeyCodeReAnywhere.source + '$');
-var functionKeyCodeReAnywhere = new RegExp('(?:\x1b+)(O|N|\\[|\\[\\[)(?:' + [
+const metaKeyCodeReAnywhere = /(?:\x1b)([a-zA-Z0-9])/;
+const metaKeyCodeRe = new RegExp('^' + metaKeyCodeReAnywhere.source + '$');
+const functionKeyCodeReAnywhere = new RegExp('(?:\x1b+)(O|N|\\[|\\[\\[)(?:' + [
   '(\\d+)(?:;(\\d+))?([~^$])',
   '(?:M([@ #!a`])(.)(.))', // mouse
   '(?:1;)?(\\d+)?([a-zA-Z])'
 ].join('|') + ')');
-var functionKeyCodeRe = new RegExp('^' + functionKeyCodeReAnywhere.source);
-var escapeCodeReAnywhere = new RegExp([
+const functionKeyCodeRe = new RegExp('^' + functionKeyCodeReAnywhere.source);
+const escapeCodeReAnywhere = new RegExp([
   functionKeyCodeReAnywhere.source, metaKeyCodeReAnywhere.source, /\x1b./.source
 ].join('|'));
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -21,16 +21,16 @@
 
 'use strict';
 
-var util = require('util');
-var inherits = require('util').inherits;
-var Stream = require('stream');
-var vm = require('vm');
-var path = require('path');
-var fs = require('fs');
-var rl = require('readline');
-var Console = require('console').Console;
-var domain = require('domain');
-var debug = util.debuglog('repl');
+const util = require('util');
+const inherits = util.inherits;
+const Stream = require('stream');
+const vm = require('vm');
+const path = require('path');
+const fs = require('fs');
+const rl = require('readline');
+const Console = require('console').Console;
+const domain = require('domain');
+const debug = util.debuglog('repl');
 
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
@@ -414,8 +414,8 @@ ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
-var requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
-var simpleExpressionRE =
+const requireRE = /\brequire\s*\(['"](([\w\.\/-]+\/)?([\w\.\/-]*))/;
+const simpleExpressionRE =
     /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
 
 
@@ -890,8 +890,8 @@ function defineDefaultCommands(repl) {
 
 
 function trimWhitespace(cmd) {
-  var trimmer = /^\s*(.+)\s*$/m,
-      matches = trimmer.exec(cmd);
+  const trimmer = /^\s*(.+)\s*$/m;
+  var matches = trimmer.exec(cmd);
 
   if (matches && matches.length === 2) {
     return matches[1];
@@ -914,9 +914,9 @@ function regexpEscape(s) {
  * @return {String} The converted command.
  */
 REPLServer.prototype.convertToContext = function(cmd) {
-  var self = this, matches,
-      scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m,
-      scopeFunc = /^\s*function\s*([_\w\$]+)/;
+  const scopeVar = /^\s*var\s*([_\w\$]+)(.*)$/m;
+  const scopeFunc = /^\s*function\s*([_\w\$]+)/;
+  var self = this, matches;
 
   // Replaces: var foo = "bar";  with: self.context.foo = bar;
   matches = scopeVar.exec(cmd);

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var smalloc = process.binding('smalloc');
-var kMaxLength = smalloc.kMaxLength;
-var util = require('util');
+const smalloc = process.binding('smalloc');
+const kMaxLength = smalloc.kMaxLength;
+const util = require('util');
 
 exports.alloc = alloc;
 exports.copyOnto = smalloc.copyOnto;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -2,8 +2,8 @@
 
 module.exports = Stream;
 
-var EE = require('events').EventEmitter;
-var util = require('util');
+const EE = require('events').EventEmitter;
+const util = require('util');
 
 util.inherits(Stream, EE);
 Stream.Readable = require('_stream_readable');

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -14,7 +14,7 @@ function assertEncoding(encoding) {
 // to reason about this code, so it should be split up in the future.
 // @TODO There should be a utf8-strict encoding that rejects invalid UTF-8 code
 // points as used by CESU-8.
-var StringDecoder = exports.StringDecoder = function(encoding) {
+const StringDecoder = exports.StringDecoder = function(encoding) {
   this.encoding = (encoding || 'utf8').toLowerCase().replace(/[-_]/, '');
   assertEncoding(encoding);
   switch (this.encoding) {

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var util = require('util');
+const util = require('util');
 
 // the sys module was renamed to 'util'.
 // this shim remains to keep old programs working.
 // sys is deprecated and shouldn't be used
 
-var setExports = util.deprecate(function() {
+const setExports = util.deprecate(function() {
   module.exports = util;
 }, 'sys is deprecated. Use util instead.');
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var Timer = process.binding('timer_wrap').Timer;
-var L = require('_linklist');
-var assert = require('assert').ok;
+const Timer = process.binding('timer_wrap').Timer;
+const L = require('_linklist');
+const assert = require('assert').ok;
 
-var kOnTimeout = Timer.kOnTimeout | 0;
+const kOnTimeout = Timer.kOnTimeout | 0;
 
 // Timeout values > TIMEOUT_MAX are set to 1.
-var TIMEOUT_MAX = 2147483647; // 2^31-1
+const TIMEOUT_MAX = 2147483647; // 2^31-1
 
-var debug = require('util').debuglog('timer');
+const debug = require('util').debuglog('timer');
 
 
 // IDLE TIMEOUTS
@@ -114,7 +114,7 @@ function listOnTimeout() {
 }
 
 
-var unenroll = exports.unenroll = function(item) {
+const unenroll = exports.unenroll = function(item) {
   L.remove(item);
 
   var list = lists[item._idleTimeout];
@@ -256,7 +256,7 @@ exports.clearInterval = function(timer) {
 };
 
 
-var Timeout = function(after) {
+const Timeout = function(after) {
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var net = require('net');
-var url = require('url');
-var util = require('util');
+const net = require('net');
+const url = require('url');
+const util = require('util');
 
 // Allow {CLIENT_RENEG_LIMIT} client-initiated session renegotiations
 // every {CLIENT_RENEG_WINDOW} seconds. An error event is emitted if more
@@ -22,7 +22,7 @@ exports.DEFAULT_CIPHERS =
 exports.DEFAULT_ECDH_CURVE = 'prime256v1';
 
 exports.getCiphers = function() {
-  var names = process.binding('crypto').getSSLCiphers();
+  const names = process.binding('crypto').getSSLCiphers();
   // Drop all-caps names in favor of their lowercase aliases,
   var ctx = {};
   names.forEach(function(name) {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var inherits = require('util').inherits;
-var net = require('net');
-var TTY = process.binding('tty_wrap').TTY;
-var isTTY = process.binding('tty_wrap').isTTY;
-var util = require('util');
+const inherits = require('util').inherits;
+const net = require('net');
+const TTY = process.binding('tty_wrap').TTY;
+const isTTY = process.binding('tty_wrap').isTTY;
+const util = require('util');
 
-var errnoException = util._errnoException;
+const errnoException = util._errnoException;
 
 
 exports.isatty = function(fd) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var punycode = require('punycode');
-var util = require('util');
+const punycode = require('punycode');
+const util = require('util');
 
 exports.parse = urlParse;
 exports.resolve = urlResolve;
@@ -29,54 +29,54 @@ function Url() {
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-var protocolPattern = /^([a-z0-9.+-]+:)/i,
-    portPattern = /:[0-9]*$/,
+const protocolPattern = /^([a-z0-9.+-]+:)/i;
+const portPattern = /:[0-9]*$/;
 
-    // Special case for a simple path URL
-    simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/,
+// Special case for a simple path URL
+const simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/;
 
-    // RFC 2396: characters reserved for delimiting URLs.
-    // We actually just auto-escape these.
-    delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
+// RFC 2396: characters reserved for delimiting URLs.
+// We actually just auto-escape these.
+const delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'];
 
-    // RFC 2396: characters not allowed for various reasons.
-    unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
+// RFC 2396: characters not allowed for various reasons.
+const unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims);
 
-    // Allowed by RFCs, but cause of XSS attacks.  Always escape these.
-    autoEscape = ['\''].concat(unwise),
-    // Characters that are never ever allowed in a hostname.
-    // Note that any invalid chars are also handled, but these
-    // are the ones that are *expected* to be seen, so we fast-path
-    // them.
-    nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
-    hostEndingChars = ['/', '?', '#'],
-    hostnameMaxLen = 255,
-    hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/,
-    // protocols that can allow "unsafe" and "unwise" chars.
-    unsafeProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that never have a hostname.
-    hostlessProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that always contain a // bit.
-    slashedProtocol = {
-      'http': true,
-      'https': true,
-      'ftp': true,
-      'gopher': true,
-      'file': true,
-      'http:': true,
-      'https:': true,
-      'ftp:': true,
-      'gopher:': true,
-      'file:': true
-    },
-    querystring = require('querystring');
+// Allowed by RFCs, but cause of XSS attacks.  Always escape these.
+const autoEscape = ['\''].concat(unwise);
+
+// Characters that are never ever allowed in a hostname.
+// Note that any invalid chars are also handled, but these
+// are the ones that are *expected* to be seen, so we fast-path them.
+const nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape);
+const hostEndingChars = ['/', '?', '#'];
+const hostnameMaxLen = 255;
+const hostnamePartPattern = /^[+a-z0-9A-Z_-]{0,63}$/;
+const hostnamePartStart = /^([+a-z0-9A-Z_-]{0,63})(.*)$/;
+// protocols that can allow "unsafe" and "unwise" chars.
+const unsafeProtocol = {
+  'javascript': true,
+  'javascript:': true
+};
+// protocols that never have a hostname.
+const hostlessProtocol = {
+  'javascript': true,
+  'javascript:': true
+};
+// protocols that always contain a // bit.
+const slashedProtocol = {
+  'http': true,
+  'https': true,
+  'ftp': true,
+  'gopher': true,
+  'file': true,
+  'http:': true,
+  'https:': true,
+  'ftp:': true,
+  'gopher:': true,
+  'file:': true
+};
+const querystring = require('querystring');
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url && util.isObject(url) && url instanceof Url) return url;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var formatRegExp = /%[sdj%]/g;
+const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
   if (!isString(f)) {
     var objects = [];
@@ -495,7 +495,7 @@ function reduceToSingleString(output, base, braces) {
 
 // NOTE: These type checking functions intentionally don't use `instanceof`
 // because it is fragile and can be easily faked with `Object.create()`.
-var isArray = exports.isArray = Array.isArray;
+const isArray = exports.isArray = Array.isArray;
 
 function isBoolean(arg) {
   return typeof arg === 'boolean';
@@ -583,8 +583,8 @@ function pad(n) {
 }
 
 
-var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
-              'Oct', 'Nov', 'Dec'];
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
+                'Oct', 'Nov', 'Dec'];
 
 // 26 Feb 16:19:34
 function timestamp() {

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -14,17 +14,18 @@
 
 'use strict';
 
-var v8binding = process.binding('v8');
-var smalloc = require('smalloc');
+const v8binding = process.binding('v8');
+const smalloc = require('smalloc');
 
-var heapStatisticsBuffer = smalloc.alloc(v8binding.kHeapStatisticsBufferLength,
-                                         v8binding.kHeapStatisticsBufferType);
+const heapStatisticsBuffer =
+    smalloc.alloc(v8binding.kHeapStatisticsBufferLength,
+                  v8binding.kHeapStatisticsBufferType);
 
-var kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
-var kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
-var kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
-var kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
-var kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
+const kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
+const kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
+const kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
+const kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
+const kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
 
 exports.getHeapStatistics = function() {
   var buffer = heapStatisticsBuffer;

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var binding = process.binding('contextify');
-var Script = binding.ContextifyScript;
-var util = require('util');
+const binding = process.binding('contextify');
+const Script = binding.ContextifyScript;
+const util = require('util');
 
 // The binding provides a few useful primitives:
 // - ContextifyScript(code, { filename = "evalmachine.anonymous",

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var Transform = require('_stream_transform');
-
-var binding = process.binding('zlib');
-var util = require('util');
-var assert = require('assert').ok;
+const Transform = require('_stream_transform');
+const binding = process.binding('zlib');
+const util = require('util');
+const assert = require('assert').ok;
 
 // zlib doesn't provide these, so kludge them in following the same
 // const naming scheme zlib uses.
@@ -28,7 +27,7 @@ binding.Z_MAX_LEVEL = 9;
 binding.Z_DEFAULT_LEVEL = binding.Z_DEFAULT_COMPRESSION;
 
 // expose all the zlib constants
-var bkeys = Object.keys(binding);
+const bkeys = Object.keys(binding);
 for (var bk = 0; bk < bkeys.length; bk++) {
   var bkey = bkeys[bk];
   if (bkey.match(/^Z/)) exports[bkey] = binding[bkey];
@@ -47,7 +46,7 @@ exports.codes = {
   Z_VERSION_ERROR: binding.Z_VERSION_ERROR
 };
 
-var ckeys = Object.keys(exports.codes);
+const ckeys = Object.keys(exports.codes);
 for (var ck = 0; ck < ckeys.length; ck++) {
   var ckey = ckeys[ck];
   exports.codes[exports.codes[ckey]] = ckey;


### PR DESCRIPTION
This commit replaces a number of `var` statements throughout the `lib` code with `const` statements.