### PR TITLE
docs: more explicit crypto.pseudoRandomBytes information

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -654,13 +654,9 @@ are drained.
 
 ## crypto.pseudoRandomBytes(size[, callback])
 
-Generates *non*-cryptographically strong pseudo-random data. The data
-returned will be unique if it is sufficiently long, but is not
-necessarily unpredictable. For this reason, the output of this
-function should never be used where unpredictability is important,
-such as in the generation of encryption keys.
-
-Usage is otherwise identical to `crypto.randomBytes`.
+Identical to `crypto.randomBytes` except that, instead of throwing an error when
+there is not enough accumulated entropy to generate cryptographically strong data,
+it will silently return **non**-cryptographically strong data.
 
 ## Class: Certificate
 


### PR DESCRIPTION
the docs as it is make it sound like pseudoRandomBytes is tapping a different entropy source or possibly might be a `/dev/urandom` to `crypto.pseudoRandomBytes`'s `/dev/random`.

Is there a reason pseudoRandomBytes is in the api in the first place?