### PR TITLE
deps: fix v8 armv6 run-time detection

### DIFF
--- a/configure
+++ b/configure
@@ -406,11 +406,6 @@ def is_arch_armv6():
           '__ARM_ARCH_6M__' in cc_macros_cache)
 
 
-def is_arm_neon():
-  """Check for ARM NEON support"""
-  return '__ARM_NEON__' in cc_macros()
-
-
 def is_arm_hard_float_abi():
   """Check for hardfloat or softfloat eabi on ARM"""
   # GCC versions 4.6 and above define __ARM_PCS or __ARM_PCS_VFP to specify
@@ -469,11 +464,9 @@ def configure_arm(o):
 
   if is_arch_armv7():
     o['variables']['arm_fpu'] = 'vfpv3'
-    o['variables']['arm_neon'] = int(is_arm_neon())
     o['variables']['arm_version'] = '7'
   else:
     o['variables']['arm_fpu'] = 'vfpv2'
-    o['variables']['arm_neon'] = 0
     o['variables']['arm_version'] = '6' if is_arch_armv6() else 'default'
 
   o['variables']['arm_thumb'] = 0      # -marm

--- a/configure
+++ b/configure
@@ -468,14 +468,14 @@ def configure_arm(o):
     arm_float_abi = 'default'
 
   if is_arch_armv7():
+    o['variables']['arm_fpu'] = 'vfpv3'
+    o['variables']['arm_neon'] = int(is_arm_neon())
     o['variables']['arm_version'] = '7'
-  elif is_arch_armv6():
-    o['variables']['arm_version'] = '6'
   else:
-    o['variables']['arm_version'] = 'default'
+    o['variables']['arm_fpu'] = 'vfpv2'
+    o['variables']['arm_neon'] = 0
+    o['variables']['arm_version'] = '6' if is_arch_armv6() else 'default'
 
-  o['variables']['arm_fpu'] = 'vfpv3'  # V8 3.18 no longer supports VFP2.
-  o['variables']['arm_neon'] = int(is_arm_neon())
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi
 

--- a/deps/v8/src/base/cpu.cc
+++ b/deps/v8/src/base/cpu.cc
@@ -438,13 +438,22 @@ CPU::CPU()
     //
     // See http://code.google.com/p/android/issues/detail?id=10812
     //
-    // We try to correct this by looking at the 'elf_format'
+    // We try to correct this by looking at the 'elf_platform'
     // field reported by the 'Processor' field, which is of the
     // form of "(v7l)" for an ARMv7-based CPU, and "(v6l)" for
     // an ARMv6-one. For example, the Raspberry Pi is one popular
     // ARMv6 device that reports architecture 7.
     if (architecture_ == 7) {
       char* processor = cpu_info.ExtractField("Processor");
+      if (HasListItem(processor, "(v6l)")) {
+        architecture_ = 6;
+      }
+      delete[] processor;
+    }
+
+    // elf_platform moved to the model name field in Linux v3.8.
+    if (architecture_ == 7) {
+      char* processor = cpu_info.ExtractField("model name");
       if (HasListItem(processor, "(v6l)")) {
         architecture_ = 6;
       }


### PR DESCRIPTION
The elf_platform suffix in /proc/cpuinfo moved to the model name field
in Linux 3.8.

Out-of-tree patch pending https://codereview.chromium.org/867713003/

Fixes: iojs#283

R=@indutny @silverwind @wilson0x4d

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/99/