### PR TITLE
buffer: add indexOf() method

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -392,6 +392,19 @@ byte from the original Buffer.
     // abc
     // !bc
 
+
+### buf.indexOf(value[, byteOffset])
+
+* `value` String, Buffer or Number
+* `byteOffset` Number, Optional, Default: 0
+* Return: Number
+
+Operates similar to
+[Array#indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf).
+Accepts a String, Buffer or Number. Strings are interpreted as UTF8. Buffers
+will use the entire buffer. So in order to compare a partial Buffer use
+`Buffer#slice()`. Numbers can range from 0 to 255.
+
 ### buf.readUInt8(offset[, noAssert])
 
 * `offset` Number

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -303,6 +303,24 @@ Buffer.prototype.compare = function compare(b) {
 };
 
 
+Buffer.prototype.indexOf = function indexOf(val, byteOffset) {
+  if (byteOffset > 0x7fffffff)
+    byteOffset = 0x7fffffff;
+  else if (byteOffset < -0x80000000)
+    byteOffset = -0x80000000;
+  byteOffset >>= 0;
+
+  if (typeof val === 'string')
+    return binding.indexOfString(this, val, byteOffset);
+  if (val instanceof Buffer)
+    return binding.indexOfBuffer(this, val, byteOffset);
+  if (typeof val === 'number')
+    return binding.indexOfNumber(this, val, byteOffset);
+
+  throw new TypeError('val must be string, number or Buffer');
+};
+
+
 Buffer.prototype.fill = function fill(val, start, end) {
   start = start >> 0;
   end = (end === undefined) ? this.length : end >> 0;

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -1,0 +1,75 @@
+var common = require('../common');
+var assert = require('assert');
+
+var Buffer = require('buffer').Buffer;
+
+var b = new Buffer('abcdef');
+var buf_a = new Buffer('a');
+var buf_bc = new Buffer('bc');
+var buf_f = new Buffer('f');
+var buf_z = new Buffer('z');
+var buf_empty = new Buffer('');
+
+assert.equal(b.indexOf('a'), 0);
+assert.equal(b.indexOf('a', 1), -1);
+assert.equal(b.indexOf('a', -1), -1);
+assert.equal(b.indexOf('a', -4), -1);
+assert.equal(b.indexOf('a', -b.length), 0);
+assert.equal(b.indexOf('a', NaN), 0);
+assert.equal(b.indexOf('a', -Infinity), 0);
+assert.equal(b.indexOf('a', Infinity), -1);
+assert.equal(b.indexOf('bc'), 1);
+assert.equal(b.indexOf('bc', 2), -1);
+assert.equal(b.indexOf('bc', -1), -1);
+assert.equal(b.indexOf('bc', -3), -1);
+assert.equal(b.indexOf('bc', -5), 1);
+assert.equal(b.indexOf('bc', NaN), 1);
+assert.equal(b.indexOf('bc', -Infinity), 1);
+assert.equal(b.indexOf('bc', Infinity), -1);
+assert.equal(b.indexOf('f'), b.length - 1);
+assert.equal(b.indexOf('z'), -1);
+assert.equal(b.indexOf(''), -1);
+assert.equal(b.indexOf('', 1), -1);
+assert.equal(b.indexOf('', b.length + 1), -1);
+assert.equal(b.indexOf('', Infinity), -1);
+assert.equal(b.indexOf(buf_a), 0);
+assert.equal(b.indexOf(buf_a, 1), -1);
+assert.equal(b.indexOf(buf_a, -1), -1);
+assert.equal(b.indexOf(buf_a, -4), -1);
+assert.equal(b.indexOf(buf_a, -b.length), 0);
+assert.equal(b.indexOf(buf_a, NaN), 0);
+assert.equal(b.indexOf(buf_a, -Infinity), 0);
+assert.equal(b.indexOf(buf_a, Infinity), -1);
+assert.equal(b.indexOf(buf_bc), 1);
+assert.equal(b.indexOf(buf_bc, 2), -1);
+assert.equal(b.indexOf(buf_bc, -1), -1);
+assert.equal(b.indexOf(buf_bc, -3), -1);
+assert.equal(b.indexOf(buf_bc, -5), 1);
+assert.equal(b.indexOf(buf_bc, NaN), 1);
+assert.equal(b.indexOf(buf_bc, -Infinity), 1);
+assert.equal(b.indexOf(buf_bc, Infinity), -1);
+assert.equal(b.indexOf(buf_f), b.length - 1);
+assert.equal(b.indexOf(buf_z), -1);
+assert.equal(b.indexOf(buf_empty), -1);
+assert.equal(b.indexOf(buf_empty, 1), -1);
+assert.equal(b.indexOf(buf_empty, b.length + 1), -1);
+assert.equal(b.indexOf(buf_empty, Infinity), -1);
+assert.equal(b.indexOf(0x61), 0);
+assert.equal(b.indexOf(0x61, 1), -1);
+assert.equal(b.indexOf(0x61, -1), -1);
+assert.equal(b.indexOf(0x61, -4), -1);
+assert.equal(b.indexOf(0x61, -b.length), 0);
+assert.equal(b.indexOf(0x61, NaN), 0);
+assert.equal(b.indexOf(0x61, -Infinity), 0);
+assert.equal(b.indexOf(0x61, Infinity), -1);
+assert.equal(b.indexOf(0x0), -1);
+
+assert.throws(function() {
+  b.indexOf(function() { });
+});
+assert.throws(function() {
+  b.indexOf({});
+});
+assert.throws(function() {
+  b.indexOf([]);
+});


### PR DESCRIPTION
Add Buffer#indexOf(). Support strings, numbers and other Buffers. This
is more support than String#indexOf() gives, but the increased
versatility should be helpful.

Special thanks to Sam Rijs for first proposing this
change.

R=@bnoordhuis

This is a re-hash of https://github.com/iojs/io.js/pull/160. Done this way so future support can include regexp's and arrays.