### PR TITLE
stream: use nop as write() callback if omitted

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -13,6 +13,8 @@ const debug = util.debuglog('stream');
 
 util.inherits(Writable, Stream);
 
+function nop() {}
+
 function WriteReq(chunk, encoding, cb) {
   this.chunk = chunk;
   this.encoding = encoding;
@@ -189,7 +191,7 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     encoding = state.defaultEncoding;
 
   if (!util.isFunction(cb))
-    cb = function() {};
+    cb = nop;
 
   if (state.ended)
     writeAfterEnd(this, state, cb);


### PR DESCRIPTION
This commit introduces a nop function that is used as the `Writable.prototype.write()` callback when one is not provided. This saves on function and closure creation.