### PR TITLE
doc: update "net" section in "node to io.js" changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,12 @@ https://iojs.org/api/http.html
 - Added `rawHeaders` and `rawTrailers` members on incoming message.
 - Removed default chunked encoding on `DELETE` and `OPTIONS`.
 
+### net
+
+https://iojs.org/api/net.html
+
+- Changed `net.Server.listen` such that, when the bind address is omitted, IPv6 is tried first, and IPv4 is used as a fallback.
+
 ### os
 
 https://iojs.org/api/os.html


### PR DESCRIPTION
Mention https://github.com/iojs/io.js/commit/2272052461445dfcae729cc6420a3d3229362158 in the "Summary of changes from Node.js v0.10.35 to io.js v1.0.0" section. See https://github.com/iojs/io.js/pull/503

/cc: @rvagg 