### PR TITLE
debugger: don't override `module` binding

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -4,8 +4,8 @@ const util = require('util');
 const path = require('path');
 const net = require('net');
 const vm = require('vm');
-const module = require('module');
-const repl = module.requireRepl();
+const Module = require('module');
+const repl = Module.requireRepl();
 const inherits = util.inherits;
 const assert = require('assert');
 const spawn = require('child_process').spawn;
@@ -1110,7 +1110,7 @@ Interface.prototype.list = function(delta) {
       if (lineno == 1) {
         // The first line needs to have the module wrapper filtered out of
         // it.
-        var wrapper = module.wrapper[0];
+        var wrapper = Module.wrapper[0];
         lines[i] = lines[i].slice(wrapper.length);
 
         client.currentSourceColumn -= wrapper.length;


### PR DESCRIPTION
Overriding `module` argument with `const` causes `SyntaxError`.

Apparently this is something you can't do:

```javascript
'use strict'

function test(module) {
  const module = {}
}

test({})
```

P.S.  `make test-debugger` hangs, someone has to look at it

R=@cjihrig 