### PR TITLE
child_process: clone spawn options argument

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -931,6 +931,7 @@ function normalizeSpawnArguments(file /*, args, options*/) {
   else if (!util.isObject(options))
     throw new TypeError('options argument must be an object');
 
+  options = util._extend({}, options);
   args.unshift(file);
 
   var env = options.env || process.env;

--- a/test/common.js
+++ b/test/common.js
@@ -97,6 +97,17 @@ exports.spawnCat = function(options) {
 };
 
 
+exports.spawnSyncCat = function(options) {
+  var spawnSync = require('child_process').spawnSync;
+
+  if (process.platform === 'win32') {
+    return spawnSync('more', [], options);
+  } else {
+    return spawnSync('cat', [], options);
+  }
+};
+
+
 exports.spawnPwd = function(options) {
   var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -13,3 +13,7 @@ child = common.spawnPwd(options);
 
 assert.equal(child.stdout, null);
 assert.equal(child.stderr, null);
+
+options = {stdio: 'ignore'};
+child = common.spawnSyncCat(options);
+assert.deepEqual(options, {stdio: 'ignore'});


### PR DESCRIPTION
`spawnSync()` modifies the `options` argument. This commit makes a copy of `options` before any modifications occur. Fixes #576