### PR TITLE
make: Add benchmark make bench-url target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,10 @@ bench-buffer: all
 bench-url: all
 	@$(NODE) benchmark/common.js url
 
-bench-all: bench bench-misc bench-array bench-buffer bench-url
+bench-events: all
+	@$(NODE) benchmark/common.js events
+
+bench-all: bench bench-misc bench-array bench-buffer bench-url bench-events
 
 bench: bench-net bench-http bench-fs bench-tls
 

--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,10 @@ bench-array: all
 bench-buffer: all
 	@$(NODE) benchmark/common.js buffers
 
-bench-all: bench bench-misc bench-array bench-buffer
+bench-url: all
+	@$(NODE) benchmark/common.js url
+
+bench-all: bench bench-misc bench-array bench-buffer bench-url
 
 bench: bench-net bench-http bench-fs bench-tls
 


### PR DESCRIPTION
I found new benchmark script(https://github.com/iojs/io.js/pull/184), However the script are not added in Makefile.
