### PR TITLE
build: disable v8 snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,10 +266,10 @@ pkg: $(PKG)
 $(PKG): release-only
 	rm -rf $(PKGDIR)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=ia32 --tag=$(TAG)
+	$(PYTHON) ./configure --dest-cpu=ia32 --tag=$(TAG)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)/32
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --without-snapshot --dest-cpu=x64 --tag=$(TAG)
+	$(PYTHON) ./configure --dest-cpu=x64 --tag=$(TAG)
 	$(MAKE) install V=$(V) DESTDIR=$(PKGDIR)
 	SIGN="$(APP_SIGN)" PKGDIR="$(PKGDIR)" bash tools/osx-codesign.sh
 	lipo $(PKGDIR)/32/usr/local/bin/iojs \
@@ -307,7 +307,7 @@ tar: $(TARBALL)
 $(BINARYTAR): release-only
 	rm -rf $(BINARYNAME)
 	rm -rf out/deps out/Release
-	$(PYTHON) ./configure --prefix=/ --without-snapshot --dest-cpu=$(DESTCPU) --tag=$(TAG) $(CONFIG_FLAGS)
+	$(PYTHON) ./configure --prefix=/ --dest-cpu=$(DESTCPU) --tag=$(TAG) $(CONFIG_FLAGS)
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
 	cp README.md $(BINARYNAME)
 	cp LICENSE $(BINARYNAME)
@@ -324,7 +324,7 @@ binary: $(BINARYTAR)
 
 $(PKGSRC): release-only
 	rm -rf dist out
-	$(PYTHON) configure --prefix=/ --without-snapshot \
+	$(PYTHON) configure --prefix=/ \
 		--dest-cpu=$(DESTCPU) --tag=$(TAG) $(CONFIG_FLAGS)
 	$(MAKE) install DESTDIR=dist
 	(cd dist; find * -type f | sort) > packlist

--- a/android-configure
+++ b/android-configure
@@ -14,6 +14,5 @@ export CXX=arm-linux-androideabi-g++
 export LINK=arm-linux-androideabi-g++
 
 ./configure \
-    --without-snapshot \
     --dest-cpu=arm \
     --dest-os=android

--- a/configure
+++ b/configure
@@ -269,11 +269,16 @@ parser.add_option('--without-perfctr',
     dest='without_perfctr',
     help='build without performance counters')
 
+parser.add_option('--with-snapshot',
+    action='store_true',
+    dest='with_snapshot',
+    help=optparse.SUPPRESS_HELP)
+
+# Dummy option for backwards compatibility.
 parser.add_option('--without-snapshot',
     action='store_true',
-    dest='without_snapshot',
-    help='build without snapshotting V8 libraries. You might want to set'
-         ' this for cross-compiling. [Default: False]')
+    dest='unused_without_snapshot',
+    help=optparse.SUPPRESS_HELP)
 
 parser.add_option('--without-ssl',
     action='store_true',
@@ -289,6 +294,12 @@ parser.add_option('--xcode',
 
 # set up auto-download list
 auto_downloads = nodedownload.parse(options.download_list)
+
+
+def warn(msg):
+  prefix = '\033[1m\033[91mWARNING\033[0m' if os.isatty(1) else 'WARNING'
+  print('%s: %s' % (prefix, msg))
+
 
 def b(value):
   """Returns the string 'true' if value is truthy, 'false' otherwise."""
@@ -337,10 +348,6 @@ def try_check_compiler(cc, lang):
 def check_compiler():
   if sys.platform == 'win32':
     return
-
-  def warn(msg):
-    prefix = '\033[1m\033[91mWARNING\033[0m' if os.isatty(1) else 'WARNING'
-    print('%s: %s' % (prefix, msg))
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
   if not ok:
@@ -473,8 +480,8 @@ def configure_arm(o):
   o['variables']['arm_float_abi'] = arm_float_abi
 
   # Print warning when snapshot is enabled and building on armv6
-  if is_arch_armv6() and not options.without_snapshot:
-    print '\033[1;33mWarning!! When building on ARMv6 use --without-snapshot\033[1;m'
+  if is_arch_armv6() and options.with_snapshot:
+    warn('when building on ARMv6, don\'t use --with-snapshot')
 
 
 def configure_node(o):
@@ -489,7 +496,7 @@ def configure_node(o):
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
 
-  if target_arch != host_arch and not options.without_snapshot:
+  if target_arch != host_arch and options.with_snapshot:
     o['variables']['want_separate_host_toolset'] = 1
   else:
     o['variables']['want_separate_host_toolset'] = 0
@@ -601,7 +608,7 @@ def configure_v8(o):
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
-  o['variables']['v8_use_snapshot'] = b(not options.without_snapshot)
+  o['variables']['v8_use_snapshot'] = b(options.with_snapshot)
 
   # assume shared_v8 if one of these is set?
   if options.shared_v8_libpath:

--- a/node.gyp
+++ b/node.gyp
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'v8_use_snapshot%': 'true',
+    'v8_use_snapshot%': 'false',
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -17,11 +17,11 @@ set msiplatform=x86
 set target=Build
 set target_arch=ia32
 set debug_arg=
-set nosnapshot_arg=
+set snapshot_arg=
 set noprojgen=
 set nobuild=
 set nosign=
-set nosnapshot=
+set snapshot=
 set test=
 set test_args=
 set msi=
@@ -48,7 +48,7 @@ if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
 if /i "%1"=="nosign"        set nosign=1&goto arg-ok
-if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
+if /i "%1"=="snapshot"      set snapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
@@ -79,7 +79,7 @@ if defined jslint goto jslint
 
 if "%config%"=="Debug" set debug_arg=--debug
 if "%target_arch%"=="x64" set msiplatform=x64
-if defined nosnapshot set nosnapshot_arg=--without-snapshot
+if defined snapshot set snapshot_arg=--with-snapshot
 if defined noetw set noetw_arg=--without-etw& set noetw_msi_arg=/p:NoETW=1
 if defined noperfctr set noperfctr_arg=--without-perfctr& set noperfctr_msi_arg=/p:NoPerfCtr=1
 
@@ -96,7 +96,7 @@ if defined NIGHTLY set TAG=nightly-%NIGHTLY%
 @rem Generate the VS project.
 SETLOCAL
   if defined VS100COMNTOOLS call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
-  python configure %download_arg% %i18n_arg% %debug_arg% %nosnapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
+  python configure %download_arg% %i18n_arg% %debug_arg% %snapshot_arg% %noetw_arg% %noperfctr_arg% --dest-cpu=%target_arch% --tag=%TAG%
   if errorlevel 1 goto create-msvs-files-failed
   if not exist node.sln goto create-msvs-files-failed
   echo Project files generated.


### PR DESCRIPTION
Snapshots speed up start-up by a few milliseconds but are potentially
dangerous because of the fixed hash seed that is used for strings and
dictionaries, making collision denial-of-service attacks possible.

Release builds on iojs.org have snapshots disabled but source builds
did not, until now.

The risk for individual source builds is low; the binary gets a random
32 bits hash seed that should be hard to guess by an external attacker.

It's when binaries are distributed by, for example, a distro vendor
that the fixed hash seed becomes a vulnerability, because then it's
possible to target a large group of people at once.

People that really need the faster start-up time can use the new
--with-snapshot configure flag.

R=@piscisaureus

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/106/