### PR TITLE
http: replace util._extend() with Object.create()

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -22,7 +22,7 @@ function ClientRequest(options, cb) {
   if (util.isString(options)) {
     options = url.parse(options);
   } else {
-    options = util._extend({}, options);
+    options = Object.create(options);
   }
 
   var agent = options.agent;


### PR DESCRIPTION
`options` is never touched, so there's no need to make a copy. Anyways, a better alternative for making copies is to just `Object.create()` the object. An alternative solution is to not bother copying at all. 

This solves issues such as https://github.com/petkaantonov/urlparser/issues where the `options` object is created from a constructor.