### PR TITLE
http: don't bother making a copy of the options

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -21,8 +21,6 @@ function ClientRequest(options, cb) {
 
   if (util.isString(options)) {
     options = url.parse(options);
-  } else {
-    options = util._extend({}, options);
   }
 
   var agent = options.agent;


### PR DESCRIPTION
Alternative to https://github.com/iojs/io.js/pull/592. The `options` object is never overwritten, so making a copy is not necessary.

This solves issues such as https://github.com/petkaantonov/urlparser/issues where the options object is created from a constructor.