### PR TITLE
console: allow custom messages for `console.timeEnd`

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -79,13 +79,13 @@ Console.prototype.time = function(label) {
 };
 
 
-Console.prototype.timeEnd = function(label) {
-  var time = this._times[label];
+Console.prototype.timeEnd = function(label, format) {
+  let time = this._times[label];
   if (!time) {
     throw new Error('No such label: ' + label);
   }
-  var duration = Date.now() - time;
-  this.log('%s: %dms', label, duration);
+  let duration = Date.now() - time;
+  this.log(format || '%s: %dms', label, duration);
 };
 
 


### PR DESCRIPTION
Greetings, 

had the ability to customize the message printed by `console.timeEnd`.

Before:
```js
console.time('test');
console.timeEnd('test'); // test: 100ms
```
After:
```js
console.time('test');
console.timeEnd('test', 'Target %s executed in %dms !'); // Target test executed in 100ms !
```


I'm writings tests but currently hitting a few issues, if someone could enlighten me ?

1. Without any changes `node test/simple/test-console.js` fails. Choking on `console.dir` tests.
2. The changes I made in `lib/console.js` does not seem to be applied anyway, is there a build step or something ?



