### PR TITLE
crypto: remove use of this._readableState

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -86,8 +86,7 @@ Hash.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Hash.prototype._flush = function(callback) {
-  var encoding = this._readableState.encoding || 'buffer';
-  this.push(this._handle.digest(encoding), encoding);
+  this.push(this._handle.digest());
   callback();
 };
 


### PR DESCRIPTION
Per #445 this removes a reference to this._readableState in hash._flush. It was
used to get the encoding on the readable side to pass to the writable side but
omiting it just causes the stream to handle the encoding issues.