### PR TITLE
docs: lower the maximum stability level to "stable"

### DIFF
--- a/doc/api/assert.markdown
+++ b/doc/api/assert.markdown
@@ -1,6 +1,6 @@
 # Assert
 
-    Stability: 5 - Locked
+    Stability: 3 - Stable
 
 This module is used for writing unit tests for your applications, you can
 access it with `require('assert')`.

--- a/doc/api/console.markdown
+++ b/doc/api/console.markdown
@@ -1,6 +1,6 @@
 # console
 
-    Stability: 4 - API Frozen
+    Stability: 3 - Stable
 
 * {Object}
 

--- a/doc/api/documentation.markdown
+++ b/doc/api/documentation.markdown
@@ -60,18 +60,6 @@ The API has proven satisfactory, but cleanup in the underlying
 code may cause minor changes.  Backwards-compatibility is guaranteed.
 ```
 
-```
-Stability: 4 - API Frozen
-This API has been tested extensively in production and is
-unlikely to ever have to change.
-```
-
-```
-Stability: 5 - Locked
-Unless serious bugs are found, this code will not ever
-change.  Please do not suggest changes in this area; they will be refused.
-```
-
 ## JSON Output
 
     Stability: 1 - Experimental

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -1,6 +1,6 @@
 # Events
 
-    Stability: 4 - API Frozen
+    Stability: 3 - Stable
 
 <!--type=module-->
 

--- a/doc/api/modules.markdown
+++ b/doc/api/modules.markdown
@@ -1,6 +1,6 @@
 # Modules
 
-    Stability: 5 - Locked
+    Stability: 3 - Stable
 
 <!--name=module-->
 

--- a/doc/api/os.markdown
+++ b/doc/api/os.markdown
@@ -1,6 +1,6 @@
 # os
 
-    Stability: 4 - API Frozen
+    Stability: 3 - Stable
 
 Provides a few basic operating-system related utility functions.
 

--- a/doc/api/timers.markdown
+++ b/doc/api/timers.markdown
@@ -1,6 +1,6 @@
 # Timers
 
-    Stability: 5 - Locked
+    Stability: 3 - Stable
 
 All of the timer functions are globals.  You do not need to `require()`
 this module in order to use them.

--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -1,6 +1,6 @@
 # util
 
-    Stability: 4 - API Frozen
+    Stability: 3 - Stable
 
 These functions are in the module `'util'`. Use `require('util')` to
 access them.
@@ -131,7 +131,7 @@ Highlighted styles and their default values are:
  * `special` - only function at this time (cyan)
  * `name` (intentionally no styling)
 
-Predefined color codes are: `white`, `grey`, `black`, `blue`, `cyan`, 
+Predefined color codes are: `white`, `grey`, `black`, `blue`, `cyan`,
 `green`, `magenta`, `red` and `yellow`.
 There are also `bold`, `italic`, `underline` and `inverse` codes.
 


### PR DESCRIPTION
personally never liked "frozen" or "locked" stability levels. although it makes sense from a maintainer's perspective, it somewhat alienates the community. i'd rather have maintainers destroy feature requests with reasoning instead of "the API is locked. this issue is closed". instead, i want the community to actively suggest ways to make iojs better, regardless of how much change it may introduce.

I also do not believe these stability levels to be true. 

- assert is probably going to change with https://github.com/iojs/io.js/pull/621
- with es6, modules are very likely to change (though we have no idea yet)
- timers have changed (in functionality, not necessarily API) almost every minor version of node/iojs
- `.getMaxListeners()` was recently added to events