### PR TITLE
http: remove unnecessary util._extend()

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -8,7 +8,7 @@ exports.IncomingMessage = require('_http_incoming').IncomingMessage;
 
 
 const common = require('_http_common');
-exports.METHODS = util._extend([], common.methods).sort();
+exports.METHODS = common.methods.slice().sort();
 
 
 exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;


### PR DESCRIPTION
on a mission to remove all instances of `util._extend()` and I found this. AFAIK, this is unnecessary. https://github.com/iojs/io.js/commit/610022851aaeff7a96518a8ee04826547dc33969#diff-1c0f1c434b17b7f8795d44a51a14320aR31 

/cc @bnoordhuis 