### PR TITLE
assert: don't compare object `prototype` property

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -186,8 +186,6 @@ function isArguments(object) {
 function objEquiv(a, b) {
   if (a === null || a === undefined || b === null || b === undefined)
     return false;
-  // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) return false;
   // if one is a primitive, the other must be same
   if (util.isPrimitive(a) || util.isPrimitive(b))
     return a === b;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -130,7 +130,7 @@ assert.doesNotThrow(makeBlock(a.deepEqual, nb1, nb2));
 
 nameBuilder2.prototype = Object;
 nb2 = new nameBuilder2('Ryan', 'Dahl');
-assert.throws(makeBlock(a.deepEqual, nb1, nb2), a.AssertionError);
+assert.doesNotThrow(makeBlock(a.deepEqual, nb1, nb2));
 
 // primitives and object
 assert.throws(makeBlock(a.deepEqual, null, {}), a.AssertionError);


### PR DESCRIPTION
All own enumerable properties are compared already. Comparing `prototype` property specifically can cause weird behaviour.

an alternative to #621

Example:

```javascript
var assert = require('assert');
assert.deepEqual(Object.create({ a: 1 }), Object.create({ b: 2 }));
assert.deepEqual(Object.create({ prototype: 1 }), Object.create({ prototype: 2 }));
```

The first assertion is ok, the second throws. It is unexpected and has no logical explanation.

Changed test was failing because of the following `nameBuilder2.prototype = Object;`. Not sure if it is a mistake, or a test for CommonJS bug.

R=@iojs/collaborators 
