### PR TITLE
deps: update libuv to 1.3.0

### DIFF
--- a/deps/uv/AUTHORS
+++ b/deps/uv/AUTHORS
@@ -178,3 +178,5 @@ Kenneth Perry <thothonegan@gmail.com>
 John Marino <marino@FreeBSD.org>
 Alexey Melnichuk <mimir@newmail.ru>
 Johan Bergström <bugs@bergstroem.nu>
+Alex Mo <almosnow@gmail.com>
+Luis Martinez de Bartolome <lasote@gmail.com>

--- a/deps/uv/ChangeLog
+++ b/deps/uv/ChangeLog
@@ -1,3 +1,51 @@
+2015.01.29, Version 1.3.0 (Stable), 165685b2a9a42cf96501d79cd6d48a18aaa16e3b
+
+Changes since version 1.2.1:
+
+* unix, windows: set non-block mode in uv_poll_init (Saúl Ibarra Corretgé)
+
+* doc: clarify which flags are supported in uv_fs_event_start (Saúl Ibarra
+  Corretgé)
+
+* win,unix: move loop functions which have identical implementations (Andrius
+  Bentkus)
+
+* doc: explain how the threadpool is allocated (Alex Mo)
+
+* doc: clarify uv_default_loop (Saúl Ibarra Corretgé)
+
+* unix: fix implicit declaration compiler warning (Ben Noordhuis)
+
+* unix: fix long line introduced in commit 94e628fa (Ben Noordhuis)
+
+* unix, win: add synchronous uv_get{addr,name}info (Saúl Ibarra Corretgé)
+
+* linux: fix epoll_pwait() regression with < 2.6.19 (Ben Noordhuis)
+
+* build: compile -D_GNU_SOURCE on linux (Ben Noordhuis)
+
+* build: use -fvisibility=hidden in autotools build (Ben Noordhuis)
+
+* fs, pipe: no trailing terminator in exact sized buffers (Andrius Bentkus)
+
+* style: rename buf to buffer and len to size for consistency (Andrius Bentkus)
+
+* test: fix test-spawn on MinGW32 (Luis Martinez de Bartolome)
+
+* win, pipe: fix assertion when destroying timer (Andrius Bentkus)
+
+* win, unix: add pipe_peername implementation (Andrius Bentkus)
+
+
+2015.01.29, Version 0.10.33 (Stable), 7a2253d33ad8215a26c1b34f1952aee7242dd687
+
+Changes since version 0.10.32:
+
+* linux: fix epoll_pwait() regression with < 2.6.19 (Ben Noordhuis)
+
+* test: back-port uv_loop_configure() test (Ben Noordhuis)
+
+
 2015.01.15, Version 1.2.1 (Stable), 4ca78e989062a1099dc4b9ad182a98e8374134b1
 
 Changes since version 1.2.0:

--- a/deps/uv/Makefile.am
+++ b/deps/uv/Makefile.am
@@ -303,6 +303,7 @@ endif
 
 if LINUX
 include_HEADERS += include/uv-linux.h
+libuv_la_CFLAGS += -D_GNU_SOURCE
 libuv_la_SOURCES += src/unix/linux-core.c \
                     src/unix/linux-inotify.c \
                     src/unix/linux-syscalls.c \

--- a/deps/uv/configure.ac
+++ b/deps/uv/configure.ac
@@ -13,7 +13,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 AC_PREREQ(2.57)
-AC_INIT([libuv], [1.2.1], [https://github.com/libuv/libuv/issues])
+AC_INIT([libuv], [1.3.0], [https://github.com/libuv/libuv/issues])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/libuv-extra-automake-flags.m4])
 m4_include([m4/as_case.m4])
@@ -24,6 +24,7 @@ AC_ENABLE_SHARED
 AC_ENABLE_STATIC
 AC_PROG_CC
 AM_PROG_CC_C_O
+CC_CHECK_CFLAGS_APPEND([-fvisibility=hidden])
 CC_CHECK_CFLAGS_APPEND([-g])
 CC_CHECK_CFLAGS_APPEND([-std=gnu89])
 CC_CHECK_CFLAGS_APPEND([-pedantic])

--- a/deps/uv/docs/src/dns.rst
+++ b/deps/uv/docs/src/dns.rst
@@ -39,6 +39,13 @@ Public members
     Loop that started this getaddrinfo request and where completion will be
     reported. Readonly.
 
+.. c:member:: struct addrinfo* uv_getaddrinfo_t.addrinfo
+
+    Pointer to a `struct addrinfo` containing the result. Must be freed by the user
+    with :c:func:`uv_freeaddrinfo`.
+
+    .. versionchanged:: 1.3.0 the field is declared as public.
+
 .. c:member:: uv_loop_t* uv_getnameinfo_t.loop
 
     Loop that started this getnameinfo request and where completion will be
@@ -68,6 +75,9 @@ API
 
     Call :c:func:`uv_freeaddrinfo` to free the addrinfo structure.
 
+    .. versionchanged:: 1.3.0 the callback parameter is now allowed to be NULL,
+                        in which case the request will run **synchronously**.
+
 .. c:function:: void uv_freeaddrinfo(struct addrinfo* ai)
 
     Free the struct addrinfo. Passing NULL is allowed and is a no-op.
@@ -79,5 +89,8 @@ API
     Returns 0 on success or an error code < 0 on failure. If successful, the
     callback will get called sometime in the future with the lookup result.
     Consult `man -s 3 getnameinfo` for more details.
+
+    .. versionchanged:: 1.3.0 the callback parameter is now allowed to be NULL,
+                        in which case the request will run **synchronously**.
 
 .. seealso:: The :c:type:`uv_req_t` API functions also apply.

--- a/deps/uv/docs/src/fs_event.rst
+++ b/deps/uv/docs/src/fs_event.rst
@@ -87,16 +87,22 @@ API
     Start the handle with the given callback, which will watch the specified
     `path` for changes. `flags` can be an ORed mask of :c:type:`uv_fs_event_flags`.
 
+    .. note:: Currently the only supported flag is ``UV_FS_EVENT_RECURSIVE`` and
+              only on OSX.
+
 .. c:function:: int uv_fs_event_stop(uv_fs_event_t* handle)
 
     Stop the handle, the callback will no longer be called.
 
-.. c:function:: int uv_fs_event_getpath(uv_fs_event_t* handle, char* buf, size_t* len)
+.. c:function:: int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size)
 
     Get the path being monitored by the handle. The buffer must be preallocated
     by the user. Returns 0 on success or an error code < 0 in case of failure.
-    On success, `buf` will contain the path and `len` its length. If the buffer
+    On success, `buffer` will contain the path and `size` its length. If the buffer
     is not big enough UV_ENOBUFS will be returned and len will be set to the
     required size.
+
+    .. versionchanged:: 1.3.0 the returned length no longer includes the terminating null byte,
+                        and the buffer is not null terminated.
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/deps/uv/docs/src/fs_poll.rst
+++ b/deps/uv/docs/src/fs_poll.rst
@@ -58,12 +58,15 @@ API
 
     Stop the handle, the callback will no longer be called.
 
-.. c:function:: int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buf, size_t* len)
+.. c:function:: int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buffer, size_t* size)
 
     Get the path being monitored by the handle. The buffer must be preallocated
     by the user. Returns 0 on success or an error code < 0 in case of failure.
-    On success, `buf` will contain the path and `len` its length. If the buffer
+    On success, `buffer` will contain the path and `size` its length. If the buffer
     is not big enough UV_ENOBUFS will be returned and len will be set to the
     required size.
+
+    .. versionchanged:: 1.3.0 the returned length no longer includes the terminating null byte,
+                        and the buffer is not null terminated.
 
 .. seealso:: The :c:type:`uv_handle_t` API functions also apply.

--- a/deps/uv/docs/src/loop.rst
+++ b/deps/uv/docs/src/loop.rst
@@ -80,6 +80,12 @@ API
     Returns the initialized default loop. It may return NULL in case of
     allocation failure.
 
+    This function is just a convenient way for having a global loop throughout
+    an application, the default loop is in no way different than the ones
+    initialized with :c:func:`uv_loop_init`. As such, the default loop can (and
+    should) be closed with :c:func:`uv_loop_close` so the resources associated
+    with it are freed.
+
 .. c:function:: int uv_run(uv_loop_t* loop, uv_run_mode mode)
 
     This function runs the event loop. It will act differently depending on the

--- a/deps/uv/docs/src/pipe.rst
+++ b/deps/uv/docs/src/pipe.rst
@@ -56,14 +56,29 @@ API
         Paths on Unix get truncated to ``sizeof(sockaddr_un.sun_path)`` bytes, typically between
         92 and 108 bytes.
 
-.. c:function:: int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len)
+.. c:function:: int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size)
 
     Get the name of the Unix domain socket or the named pipe.
 
-    A preallocated buffer must be provided. The len parameter holds the length
+    A preallocated buffer must be provided. The size parameter holds the length
     of the buffer and it's set to the number of bytes written to the buffer on
     output. If the buffer is not big enough ``UV_ENOBUFS`` will be returned and
     len will contain the required size.
+
+    .. versionchanged:: 1.3.0 the returned length no longer includes the terminating null byte,
+                        and the buffer is not null terminated.
+
+.. c:function:: int uv_pipe_getpeername(const uv_pipe_t* handle, char* buffer, size_t* size)
+
+    Get the name of the Unix domain socket or the named pipe to which the handle
+    is connected.
+
+    A preallocated buffer must be provided. The size parameter holds the length
+    of the buffer and it's set to the number of bytes written to the buffer on
+    output. If the buffer is not big enough ``UV_ENOBUFS`` will be returned and
+    len will contain the required size.
+
+    .. versionadded:: 1.3.0
 
 .. c:function:: void uv_pipe_pending_instances(uv_pipe_t* handle, int count)
 

--- a/deps/uv/docs/src/poll.rst
+++ b/deps/uv/docs/src/poll.rst
@@ -70,10 +70,14 @@ API
 
     Initialize the handle using a file descriptor.
 
+    .. versionchanged:: 1.2.2 the file descriptor is set to non-blocking mode.
+
 .. c:function:: int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle, uv_os_sock_t socket)
 
     Initialize the handle using a socket descriptor. On Unix this is identical
     to :c:func:`uv_poll_init`. On windows it takes a SOCKET handle.
+
+    .. versionchanged:: 1.2.2 the socket is set to non-blocking mode.
 
 .. c:function:: int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb)
 

--- a/deps/uv/docs/src/threadpool.rst
+++ b/deps/uv/docs/src/threadpool.rst
@@ -12,7 +12,11 @@ Its default size is 4, but it can be changed at startup time by setting the
 ``UV_THREADPOOL_SIZE`` environment variable to any value (the absolute maximum
 is 128).
 
-The threadpool is global and shared across all event loops.
+The threadpool is global and shared across all event loops. When a particular
+function makes use of the threadpool (i.e. when using :c:func:`uv_queue_work`)
+libuv preallocates and initializes the maximum number of threads allowed by
+``UV_THREADPOOL_SIZE``. This causes a relatively minor memory overhead
+(~1MB for 128 threads) but increases the performance of threading at runtime.
 
 
 Data types

--- a/deps/uv/include/uv-unix.h
+++ b/deps/uv/include/uv-unix.h
@@ -326,7 +326,7 @@ typedef struct {
   struct addrinfo* hints;                                                     \
   char* hostname;                                                             \
   char* service;                                                              \
-  struct addrinfo* res;                                                       \
+  struct addrinfo* addrinfo;                                                  \
   int retcode;
 
 #define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \

--- a/deps/uv/include/uv-version.h
+++ b/deps/uv/include/uv-version.h
@@ -31,8 +31,8 @@
  */
 
 #define UV_VERSION_MAJOR 1
-#define UV_VERSION_MINOR 2
-#define UV_VERSION_PATCH 1
+#define UV_VERSION_MINOR 3
+#define UV_VERSION_PATCH 0
 #define UV_VERSION_IS_RELEASE 1
 #define UV_VERSION_SUFFIX ""
 

--- a/deps/uv/include/uv-win.h
+++ b/deps/uv/include/uv-win.h
@@ -565,8 +565,11 @@ RB_HEAD(uv_timer_tree_s, uv_timer_s);
   void* alloc;                                                                \
   WCHAR* node;                                                                \
   WCHAR* service;                                                             \
-  struct addrinfoW* hints;                                                    \
-  struct addrinfoW* res;                                                      \
+  /* The addrinfoW field is used to store a pointer to the hints, and    */   \
+  /* later on to store the result of GetAddrInfoW. The final result will */   \
+  /* be converted to struct addrinfo* and stored in the addrinfo field.  */   \
+  struct addrinfoW* addrinfow;                                                \
+  struct addrinfo* addrinfo;                                                  \
   int retcode;
 
 #define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \

--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -675,8 +675,11 @@ UV_EXTERN void uv_pipe_connect(uv_connect_t* req,
                                const char* name,
                                uv_connect_cb cb);
 UV_EXTERN int uv_pipe_getsockname(const uv_pipe_t* handle,
-                                  char* buf,
-                                  size_t* len);
+                                  char* buffer,
+                                  size_t* size);
+UV_EXTERN int uv_pipe_getpeername(const uv_pipe_t* handle,
+                                  char* buffer,
+                                  size_t* size);
 UV_EXTERN void uv_pipe_pending_instances(uv_pipe_t* handle, int count);
 UV_EXTERN int uv_pipe_pending_count(uv_pipe_t* handle);
 UV_EXTERN uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle);
@@ -772,6 +775,7 @@ struct uv_getaddrinfo_s {
   UV_REQ_FIELDS
   /* read-only */
   uv_loop_t* loop;
+  /* struct addrinfo* addrinfo is marked as private, but it really isn't. */
   UV_GETADDRINFO_PRIVATE_FIELDS
 };
 
@@ -1260,7 +1264,9 @@ UV_EXTERN int uv_fs_poll_start(uv_fs_poll_t* handle,
                                const char* path,
                                unsigned int interval);
 UV_EXTERN int uv_fs_poll_stop(uv_fs_poll_t* handle);
-UV_EXTERN int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buf, size_t* len);
+UV_EXTERN int uv_fs_poll_getpath(uv_fs_poll_t* handle,
+                                 char* buffer,
+                                 size_t* size);
 
 
 struct uv_signal_s {
@@ -1317,8 +1323,8 @@ UV_EXTERN int uv_fs_event_start(uv_fs_event_t* handle,
                                 unsigned int flags);
 UV_EXTERN int uv_fs_event_stop(uv_fs_event_t* handle);
 UV_EXTERN int uv_fs_event_getpath(uv_fs_event_t* handle,
-                                  char* buf,
-                                  size_t* len);
+                                  char* buffer,
+                                  size_t* size);
 
 UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr);
 UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr);

--- a/deps/uv/src/fs-poll.c
+++ b/deps/uv/src/fs-poll.c
@@ -125,26 +125,26 @@ int uv_fs_poll_stop(uv_fs_poll_t* handle) {
 }
 
 
-int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buf, size_t* len) {
+int uv_fs_poll_getpath(uv_fs_poll_t* handle, char* buffer, size_t* size) {
   struct poll_ctx* ctx;
   size_t required_len;
 
   if (!uv__is_active(handle)) {
-    *len = 0;
+    *size = 0;
     return UV_EINVAL;
   }
 
   ctx = handle->poll_ctx;
   assert(ctx != NULL);
 
-  required_len = strlen(ctx->path) + 1;
-  if (required_len > *len) {
-    *len = required_len;
+  required_len = strlen(ctx->path);
+  if (required_len > *size) {
+    *size = required_len;
     return UV_ENOBUFS;
   }
 
-  memcpy(buf, ctx->path, required_len);
-  *len = required_len;
+  memcpy(buffer, ctx->path, required_len);
+  *size = required_len;
 
   return 0;
 }

--- a/deps/uv/src/unix/aix.c
+++ b/deps/uv/src/unix/aix.c
@@ -61,7 +61,7 @@
 #define RDWR_BUF_SIZE   4096
 #define EQ(a,b)         (strcmp(a,b) == 0)
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   loop->fs_fd = -1;
 
   /* Passing maxfd of -1 should mean the limit is determined

--- a/deps/uv/src/unix/darwin-proctitle.c
+++ b/deps/uv/src/unix/darwin-proctitle.c
@@ -21,6 +21,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <TargetConditionals.h>
 
@@ -36,7 +37,9 @@ static int uv__pthread_setname_np(const char* name) {
   int err;
 
   /* pthread_setname_np() first appeared in OS X 10.6 and iOS 3.2. */
-  *(void **)(&dynamic_pthread_setname_np) = dlsym(RTLD_DEFAULT, "pthread_setname_np");
+  *(void **)(&dynamic_pthread_setname_np) =
+      dlsym(RTLD_DEFAULT, "pthread_setname_np");
+
   if (dynamic_pthread_setname_np == NULL)
     return -ENOSYS;
 

--- a/deps/uv/src/unix/darwin.c
+++ b/deps/uv/src/unix/darwin.c
@@ -37,7 +37,7 @@
 #include <unistd.h>  /* sysconf */
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   loop->cf_state = NULL;
 
   if (uv__kqueue_init(loop))

--- a/deps/uv/src/unix/freebsd.c
+++ b/deps/uv/src/unix/freebsd.c
@@ -58,7 +58,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/deps/uv/src/unix/getnameinfo.c
+++ b/deps/uv/src/unix/getnameinfo.c
@@ -69,7 +69,8 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
     service = req->service;
   }
 
-  req->getnameinfo_cb(req, req->retcode, host, service);
+  if (req->getnameinfo_cb)
+    req->getnameinfo_cb(req, req->retcode, host, service);
 }
 
 /*
@@ -82,7 +83,7 @@ int uv_getnameinfo(uv_loop_t* loop,
                    uv_getnameinfo_cb getnameinfo_cb,
                    const struct sockaddr* addr,
                    int flags) {
-  if (req == NULL || getnameinfo_cb == NULL || addr == NULL)
+  if (req == NULL || addr == NULL)
     return UV_EINVAL;
 
   if (addr->sa_family == AF_INET) {
@@ -105,10 +106,15 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->loop = loop;
   req->retcode = 0;
 
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getnameinfo_work,
-                  uv__getnameinfo_done);
-
-  return 0;
+  if (getnameinfo_cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getnameinfo_work,
+                    uv__getnameinfo_done);
+    return 0;
+  } else {
+    uv__getnameinfo_work(&req->work_req);
+    uv__getnameinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 }

--- a/deps/uv/src/unix/internal.h
+++ b/deps/uv/src/unix/internal.h
@@ -221,7 +221,7 @@ void uv__signal_loop_cleanup(uv_loop_t* loop);
 /* platform specific */
 uint64_t uv__hrtime(uv_clocktype_t type);
 int uv__kqueue_init(uv_loop_t* loop);
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop);
+int uv__platform_loop_init(uv_loop_t* loop);
 void uv__platform_loop_delete(uv_loop_t* loop);
 void uv__platform_invalidate_fd(uv_loop_t* loop, int fd);
 

--- a/deps/uv/src/unix/netbsd.c
+++ b/deps/uv/src/unix/netbsd.c
@@ -49,7 +49,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/deps/uv/src/unix/openbsd.c
+++ b/deps/uv/src/unix/openbsd.c
@@ -47,7 +47,7 @@
 static char *process_title;
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   return uv__kqueue_init(loop);
 }
 

--- a/deps/uv/src/unix/pipe.c
+++ b/deps/uv/src/unix/pipe.c
@@ -206,35 +206,53 @@ out:
 }
 
 
-int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
+typedef int (*uv__peersockfunc)(int, struct sockaddr*, socklen_t*);
+
+
+static int uv__pipe_getsockpeername(const uv_pipe_t* handle,
+                                    uv__peersockfunc func,
+                                    char* buffer,
+                                    size_t* size) {
   struct sockaddr_un sa;
   socklen_t addrlen;
   int err;
 
   addrlen = sizeof(sa);
   memset(&sa, 0, addrlen);
-  err = getsockname(uv__stream_fd(handle), (struct sockaddr*) &sa, &addrlen);
+  err = func(uv__stream_fd(handle), (struct sockaddr*) &sa, &addrlen);
   if (err < 0) {
-    *len = 0;
+    *size = 0;
     return -errno;
   }
 
+#if defined(__linux__)
   if (sa.sun_path[0] == 0)
     /* Linux abstract namespace */
     addrlen -= offsetof(struct sockaddr_un, sun_path);
   else
-    addrlen = strlen(sa.sun_path) + 1;
+#endif
+    addrlen = strlen(sa.sun_path);
 
 
-  if (addrlen > *len) {
-    *len = addrlen;
+  if (addrlen > *size) {
+    *size = addrlen;
     return UV_ENOBUFS;
   }
 
-  memcpy(buf, sa.sun_path, addrlen);
-  *len = addrlen;
+  memcpy(buffer, sa.sun_path, addrlen);
+  *size = addrlen;
 
   return 0;
+}
+
+
+int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size) {
+  return uv__pipe_getsockpeername(handle, getsockname, buffer, size);
+}
+
+
+int uv_pipe_getpeername(const uv_pipe_t* handle, char* buffer, size_t* size) {
+  return uv__pipe_getsockpeername(handle, getpeername, buffer, size);
 }
 
 

--- a/deps/uv/src/unix/poll.c
+++ b/deps/uv/src/unix/poll.c
@@ -51,6 +51,12 @@ static void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
 
 
 int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
+  int err;
+
+  err = uv__nonblock(fd, 1);
+  if (err)
+    return err;
+
   uv__handle_init(loop, (uv_handle_t*) handle, UV_POLL);
   uv__io_init(&handle->io_watcher, uv__poll_io, fd);
   handle->poll_cb = NULL;

--- a/deps/uv/src/unix/sunos.c
+++ b/deps/uv/src/unix/sunos.c
@@ -62,7 +62,7 @@
 #endif
 
 
-int uv__platform_loop_init(uv_loop_t* loop, int default_loop) {
+int uv__platform_loop_init(uv_loop_t* loop) {
   int err;
   int fd;
 

--- a/deps/uv/src/uv-common.h
+++ b/deps/uv/src/uv-common.h
@@ -65,6 +65,8 @@ enum {
 
 int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
 
+void uv__loop_close(uv_loop_t* loop);
+
 int uv__tcp_bind(uv_tcp_t* tcp,
                  const struct sockaddr* addr,
                  unsigned int addrlen,

--- a/deps/uv/src/win/getaddrinfo.c
+++ b/deps/uv/src/win/getaddrinfo.c
@@ -77,10 +77,13 @@ int uv__getaddrinfo_translate_error(int sys_err) {
 
 static void uv__getaddrinfo_work(struct uv__work* w) {
   uv_getaddrinfo_t* req;
+  struct addrinfoW* hints;
   int err;
 
   req = container_of(w, uv_getaddrinfo_t, work_req);
-  err = GetAddrInfoW(req->node, req->service, req->hints, &req->res);
+  hints = req->addrinfow;
+  req->addrinfow = NULL;
+  err = GetAddrInfoW(req->node, req->service, hints, &req->addrinfow);
   req->retcode = uv__getaddrinfo_translate_error(err);
 }
 
@@ -115,17 +118,13 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
   if (status == UV_ECANCELED) {
     assert(req->retcode == 0);
     req->retcode = UV_EAI_CANCELED;
-    if (req->res != NULL) {
-        FreeAddrInfoW(req->res);
-        req->res = NULL;
-    }
     goto complete;
   }
 
   if (req->retcode == 0) {
     /* convert addrinfoW to addrinfo */
     /* first calculate required length */
-    addrinfow_ptr = req->res;
+    addrinfow_ptr = req->addrinfow;
     while (addrinfow_ptr != NULL) {
       addrinfo_len += addrinfo_struct_len +
           ALIGNED_SIZE(addrinfow_ptr->ai_addrlen);
@@ -146,7 +145,7 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
     /* do conversions */
     if (alloc_ptr != NULL) {
       cur_ptr = alloc_ptr;
-      addrinfow_ptr = req->res;
+      addrinfow_ptr = req->addrinfow;
 
       while (addrinfow_ptr != NULL) {
         /* copy addrinfo struct data */
@@ -196,22 +195,24 @@ static void uv__getaddrinfo_done(struct uv__work* w, int status) {
           addrinfo_ptr->ai_next = (struct addrinfo*)cur_ptr;
         }
       }
+      req->addrinfo = (struct addrinfo*)alloc_ptr;
     } else {
       req->retcode = UV_EAI_MEMORY;
     }
   }
 
   /* return memory to system */
-  if (req->res != NULL) {
-    FreeAddrInfoW(req->res);
-    req->res = NULL;
+  if (req->addrinfow != NULL) {
+    FreeAddrInfoW(req->addrinfow);
+    req->addrinfow = NULL;
   }
 
 complete:
   uv__req_unregister(req->loop, req);
 
   /* finally do callback with converted result */
-  req->getaddrinfo_cb(req, req->retcode, (struct addrinfo*)alloc_ptr);
+  if (req->getaddrinfo_cb)
+    req->getaddrinfo_cb(req, req->retcode, req->addrinfo);
 }
 
 
@@ -250,8 +251,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   char* alloc_ptr = NULL;
   int err;
 
-  if (req == NULL || getaddrinfo_cb == NULL ||
-     (node == NULL && service == NULL)) {
+  if (req == NULL || (node == NULL && service == NULL)) {
     err = WSAEINVAL;
     goto error;
   }
@@ -259,7 +259,7 @@ int uv_getaddrinfo(uv_loop_t* loop,
   uv_req_init(loop, (uv_req_t*)req);
 
   req->getaddrinfo_cb = getaddrinfo_cb;
-  req->res = NULL;
+  req->addrinfo = NULL;
   req->type = UV_GETADDRINFO;
   req->loop = loop;
   req->retcode = 0;
@@ -327,27 +327,32 @@ int uv_getaddrinfo(uv_loop_t* loop,
 
   /* copy hints to allocated memory and save pointer in req */
   if (hints != NULL) {
-    req->hints = (struct addrinfoW*)alloc_ptr;
-    req->hints->ai_family = hints->ai_family;
-    req->hints->ai_socktype = hints->ai_socktype;
-    req->hints->ai_protocol = hints->ai_protocol;
-    req->hints->ai_flags = hints->ai_flags;
-    req->hints->ai_addrlen = 0;
-    req->hints->ai_canonname = NULL;
-    req->hints->ai_addr = NULL;
-    req->hints->ai_next = NULL;
+    req->addrinfow = (struct addrinfoW*)alloc_ptr;
+    req->addrinfow->ai_family = hints->ai_family;
+    req->addrinfow->ai_socktype = hints->ai_socktype;
+    req->addrinfow->ai_protocol = hints->ai_protocol;
+    req->addrinfow->ai_flags = hints->ai_flags;
+    req->addrinfow->ai_addrlen = 0;
+    req->addrinfow->ai_canonname = NULL;
+    req->addrinfow->ai_addr = NULL;
+    req->addrinfow->ai_next = NULL;
   } else {
-    req->hints = NULL;
+    req->addrinfow = NULL;
   }
-
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getaddrinfo_work,
-                  uv__getaddrinfo_done);
 
   uv__req_register(loop, req);
 
-  return 0;
+  if (getaddrinfo_cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getaddrinfo_work,
+                    uv__getaddrinfo_done);
+    return 0;
+  } else {
+    uv__getaddrinfo_work(&req->work_req);
+    uv__getaddrinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 
 error:
   if (req != NULL && req->alloc != NULL) {

--- a/deps/uv/src/win/getnameinfo.c
+++ b/deps/uv/src/win/getnameinfo.c
@@ -98,7 +98,8 @@ static void uv__getnameinfo_done(struct uv__work* w, int status) {
     service = req->service;
   }
 
-  req->getnameinfo_cb(req, req->retcode, host, service);
+  if (req->getnameinfo_cb)
+    req->getnameinfo_cb(req, req->retcode, host, service);
 }
 
 
@@ -112,7 +113,7 @@ int uv_getnameinfo(uv_loop_t* loop,
                    uv_getnameinfo_cb getnameinfo_cb,
                    const struct sockaddr* addr,
                    int flags) {
-  if (req == NULL || getnameinfo_cb == NULL || addr == NULL)
+  if (req == NULL || addr == NULL)
     return UV_EINVAL;
 
   if (addr->sa_family == AF_INET) {
@@ -136,10 +137,15 @@ int uv_getnameinfo(uv_loop_t* loop,
   req->loop = loop;
   req->retcode = 0;
 
-  uv__work_submit(loop,
-                  &req->work_req,
-                  uv__getnameinfo_work,
-                  uv__getnameinfo_done);
-
-  return 0;
+  if (getnameinfo_cb) {
+    uv__work_submit(loop,
+                    &req->work_req,
+                    uv__getnameinfo_work,
+                    uv__getnameinfo_done);
+    return 0;
+  } else {
+    uv__getnameinfo_work(&req->work_req);
+    uv__getnameinfo_done(&req->work_req, 0);
+    return req->retcode;
+  }
 }

--- a/deps/uv/src/win/pipe.c
+++ b/deps/uv/src/win/pipe.c
@@ -1848,7 +1848,7 @@ static void eof_timer_cb(uv_timer_t* timer) {
 
 
 static void eof_timer_destroy(uv_pipe_t* pipe) {
-  assert(pipe->flags && UV_HANDLE_CONNECTION);
+  assert(pipe->flags & UV_HANDLE_CONNECTION);
 
   if (pipe->eof_timer) {
     uv_close((uv_handle_t*) pipe->eof_timer, eof_timer_close_cb);
@@ -1910,7 +1910,7 @@ int uv_pipe_open(uv_pipe_t* pipe, uv_file file) {
 }
 
 
-int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
+static int uv__pipe_getname(const uv_pipe_t* handle, char* buffer, size_t* size) {
   NTSTATUS nt_status;
   IO_STATUS_BLOCK io_status;
   FILE_NAME_INFORMATION tmp_name_info;
@@ -1924,7 +1924,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
   name_info = NULL;
 
   if (handle->handle == INVALID_HANDLE_VALUE) {
-    *len = 0;
+    *size = 0;
     return UV_EINVAL;
   }
 
@@ -1939,7 +1939,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
     name_size = sizeof(*name_info) + tmp_name_info.FileNameLength;
     name_info = malloc(name_size);
     if (!name_info) {
-      *len = 0;
+      *size = 0;
       err = UV_ENOMEM;
       goto cleanup;
     }
@@ -1952,7 +1952,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
   }
 
   if (nt_status != STATUS_SUCCESS) {
-    *len = 0;
+    *size = 0;
     err = uv_translate_sys_error(pRtlNtStatusToDosError(nt_status));
     goto error;
   }
@@ -1967,7 +1967,7 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
   }
 
   if (name_len == 0) {
-    *len = 0;
+    *size = 0;
     err = 0;
     goto error;
   }
@@ -1984,34 +1984,33 @@ int uv_pipe_getsockname(const uv_pipe_t* handle, char* buf, size_t* len) {
                                 NULL,
                                 NULL);
   if (!addrlen) {
-    *len = 0;
+    *size = 0;
     err = uv_translate_sys_error(GetLastError());
     goto error;
-  } else if (pipe_prefix_len + addrlen + 1 > *len) {
-    /* "\\\\.\\pipe" + name + '\0' */
-    *len = pipe_prefix_len + addrlen + 1;
+  } else if (pipe_prefix_len + addrlen > *size) {
+    /* "\\\\.\\pipe" + name */
+    *size = pipe_prefix_len + addrlen;
     err = UV_ENOBUFS;
     goto error;
   }
 
-  memcpy(buf, pipe_prefix, pipe_prefix_len);
+  memcpy(buffer, pipe_prefix, pipe_prefix_len);
   addrlen = WideCharToMultiByte(CP_UTF8,
                                 0,
                                 name_buf,
                                 name_len,
-                                buf+pipe_prefix_len,
-                                *len-pipe_prefix_len,
+                                buffer+pipe_prefix_len,
+                                *size-pipe_prefix_len,
                                 NULL,
                                 NULL);
   if (!addrlen) {
-    *len = 0;
+    *size = 0;
     err = uv_translate_sys_error(GetLastError());
     goto error;
   }
 
   addrlen += pipe_prefix_len;
-  buf[addrlen++] = '\0';
-  *len = addrlen;
+  *size = addrlen;
 
   err = 0;
   goto cleanup;
@@ -2029,6 +2028,32 @@ int uv_pipe_pending_count(uv_pipe_t* handle) {
   if (!handle->ipc)
     return 0;
   return handle->pending_ipc_info.queue_len;
+}
+
+
+int uv_pipe_getsockname(const uv_pipe_t* handle, char* buffer, size_t* size) {
+  if (handle->flags & UV_HANDLE_BOUND)
+    return uv__pipe_getname(handle, buffer, size);
+
+  if (handle->flags & UV_HANDLE_CONNECTION ||
+      handle->handle != INVALID_HANDLE_VALUE) {
+    *size = 0;
+    return 0;
+  }
+
+  return UV_EBADF;
+}
+
+
+int uv_pipe_getpeername(const uv_pipe_t* handle, char* buffer, size_t* size) {
+  /* emulate unix behaviour */
+  if (handle->flags & UV_HANDLE_BOUND)
+    return UV_ENOTCONN;
+
+  if (handle->handle != INVALID_HANDLE_VALUE)
+    return uv__pipe_getname(handle, buffer, size);
+
+  return UV_EBADF;
 }
 
 

--- a/deps/uv/src/win/poll.c
+++ b/deps/uv/src/win/poll.c
@@ -505,6 +505,11 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
   int len;
   SOCKET peer_socket, base_socket;
   DWORD bytes;
+  DWORD yes = 1;
+
+  /* Set the socket to nonblocking mode */
+  if (ioctlsocket(socket, FIONBIO, &yes) == SOCKET_ERROR)
+    return uv_translate_sys_error(WSAGetLastError());
 
   /* Try to obtain a base handle for the socket. This increases this chances */
   /* that we find an AFD handle and are able to use the fast poll mechanism. */

--- a/deps/uv/test/test-fs-event.c
+++ b/deps/uv/test/test-fs-event.c
@@ -642,6 +642,7 @@ TEST_IMPL(fs_event_getpath) {
   len = sizeof buf;
   r = uv_fs_event_getpath(&fs_event, buf, &len);
   ASSERT(r == 0);
+  ASSERT(buf[len - 1] != 0);
   ASSERT(memcmp(buf, "watch_dir", len) == 0);
   r = uv_fs_event_stop(&fs_event);
   ASSERT(r == 0);

--- a/deps/uv/test/test-fs-poll.c
+++ b/deps/uv/test/test-fs-poll.c
@@ -172,6 +172,7 @@ TEST_IMPL(fs_poll_getpath) {
   ASSERT(0 == uv_fs_poll_start(&poll_handle, poll_cb_fail, FIXTURE, 100));
   len = sizeof buf;
   ASSERT(0 == uv_fs_poll_getpath(&poll_handle, buf, &len));
+  ASSERT(buf[len - 1] != 0);
   ASSERT(0 == memcmp(buf, FIXTURE, len));
 
   uv_close((uv_handle_t*) &poll_handle, close_cb);

--- a/deps/uv/test/test-getaddrinfo.c
+++ b/deps/uv/test/test-getaddrinfo.c
@@ -97,6 +97,22 @@ TEST_IMPL(getaddrinfo_fail) {
 }
 
 
+TEST_IMPL(getaddrinfo_fail_sync) {
+  uv_getaddrinfo_t req;
+
+  ASSERT(0 > uv_getaddrinfo(uv_default_loop(),
+                            &req,
+                            NULL,
+                            "xyzzy.xyzzy.xyzzy",
+                            NULL,
+                            NULL));
+  uv_freeaddrinfo(req.addrinfo);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
 TEST_IMPL(getaddrinfo_basic) {
   int r;
   getaddrinfo_handle = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
@@ -112,6 +128,22 @@ TEST_IMPL(getaddrinfo_basic) {
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   ASSERT(getaddrinfo_cbs == 1);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
+
+TEST_IMPL(getaddrinfo_basic_sync) {
+  uv_getaddrinfo_t req;
+
+  ASSERT(0 == uv_getaddrinfo(uv_default_loop(),
+                             &req,
+                             NULL,
+                             name,
+                             NULL,
+                             NULL));
+  uv_freeaddrinfo(req.addrinfo);
 
   MAKE_VALGRIND_HAPPY();
   return 0;

--- a/deps/uv/test/test-getnameinfo.c
+++ b/deps/uv/test/test-getnameinfo.c
@@ -44,6 +44,7 @@ static void getnameinfo_req(uv_getnameinfo_t* handle,
   ASSERT(service != NULL);
 }
 
+
 TEST_IMPL(getnameinfo_basic_ip4) {
   int r;
 
@@ -62,6 +63,23 @@ TEST_IMPL(getnameinfo_basic_ip4) {
   MAKE_VALGRIND_HAPPY();
   return 0;
 }
+
+
+TEST_IMPL(getnameinfo_basic_ip4_sync) {
+  ASSERT(0 == uv_ip4_addr(address_ip4, port, &addr4));
+
+  ASSERT(0 == uv_getnameinfo(uv_default_loop(),
+                             &req,
+                             NULL,
+                             (const struct sockaddr*)&addr4,
+                             0));
+  ASSERT(req.host != NULL);
+  ASSERT(req.service != NULL);
+
+  MAKE_VALGRIND_HAPPY();
+  return 0;
+}
+
 
 TEST_IMPL(getnameinfo_basic_ip6) {
   int r;

--- a/deps/uv/test/test-list.h
+++ b/deps/uv/test/test-list.h
@@ -180,9 +180,12 @@ TEST_DECLARE   (get_memory)
 TEST_DECLARE   (handle_fileno)
 TEST_DECLARE   (hrtime)
 TEST_DECLARE   (getaddrinfo_fail)
+TEST_DECLARE   (getaddrinfo_fail_sync)
 TEST_DECLARE   (getaddrinfo_basic)
+TEST_DECLARE   (getaddrinfo_basic_sync)
 TEST_DECLARE   (getaddrinfo_concurrent)
 TEST_DECLARE   (getnameinfo_basic_ip4)
+TEST_DECLARE   (getnameinfo_basic_ip4_sync)
 TEST_DECLARE   (getnameinfo_basic_ip6)
 TEST_DECLARE   (getsockname_tcp)
 TEST_DECLARE   (getsockname_udp)
@@ -524,11 +527,14 @@ TASK_LIST_START
   TEST_ENTRY  (hrtime)
 
   TEST_ENTRY_CUSTOM (getaddrinfo_fail, 0, 0, 10000)
+  TEST_ENTRY  (getaddrinfo_fail_sync)
 
   TEST_ENTRY  (getaddrinfo_basic)
+  TEST_ENTRY  (getaddrinfo_basic_sync)
   TEST_ENTRY  (getaddrinfo_concurrent)
 
   TEST_ENTRY  (getnameinfo_basic_ip4)
+  TEST_ENTRY  (getnameinfo_basic_ip4_sync)
   TEST_ENTRY  (getnameinfo_basic_ip6)
 
   TEST_ENTRY  (getsockname_tcp)

--- a/deps/uv/test/test-poll.c
+++ b/deps/uv/test/test-poll.c
@@ -22,7 +22,6 @@
 #include <errno.h>
 
 #ifndef _WIN32
-# include <fcntl.h>
 # include <sys/socket.h>
 # include <unistd.h>
 #endif
@@ -86,23 +85,7 @@ static int got_eagain(void) {
 }
 
 
-static void set_nonblocking(uv_os_sock_t sock) {
-  int r;
-#ifdef _WIN32
-  unsigned long on = 1;
-  r = ioctlsocket(sock, FIONBIO, &on);
-  ASSERT(r == 0);
-#else
-  int flags = fcntl(sock, F_GETFL, 0);
-  ASSERT(flags >= 0);
-  r = fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-  ASSERT(r >= 0);
-#endif
-}
-
-
-static uv_os_sock_t create_nonblocking_bound_socket(
-    struct sockaddr_in bind_addr) {
+static uv_os_sock_t create_bound_socket (struct sockaddr_in bind_addr) {
   uv_os_sock_t sock;
   int r;
 
@@ -112,8 +95,6 @@ static uv_os_sock_t create_nonblocking_bound_socket(
 #else
   ASSERT(sock >= 0);
 #endif
-
-  set_nonblocking(sock);
 
 #ifndef _WIN32
   {
@@ -479,8 +460,6 @@ static void server_poll_cb(uv_poll_t* handle, int status, int events) {
   ASSERT(sock >= 0);
 #endif
 
-  set_nonblocking(sock);
-
   connection_context = create_connection_context(sock, 1);
   connection_context->events = UV_READABLE | UV_WRITABLE;
   r = uv_poll_start(&connection_context->poll_handle,
@@ -502,7 +481,7 @@ static void start_server(void) {
   int r;
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &addr));
-  sock = create_nonblocking_bound_socket(addr);
+  sock = create_bound_socket(addr);
   context = create_server_context(sock);
 
   r = listen(sock, 100);
@@ -523,7 +502,7 @@ static void start_client(void) {
   ASSERT(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &server_addr));
   ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &addr));
 
-  sock = create_nonblocking_bound_socket(addr);
+  sock = create_bound_socket(addr);
   context = create_connection_context(sock, 0);
 
   context->events = UV_READABLE | UV_WRITABLE;

--- a/deps/uv/test/test-spawn.c
+++ b/deps/uv/test/test-spawn.c
@@ -988,7 +988,8 @@ TEST_IMPL(environment_creation) {
       }
     }
     if (prev) { /* verify sort order -- requires Vista */
-#if _WIN32_WINNT >= 0x0600
+#if _WIN32_WINNT >= 0x0600 && \
+    (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
       ASSERT(CompareStringOrdinal(prev, -1, str, -1, TRUE) == 1);
 #endif
     }

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -195,6 +195,7 @@
           'cflags': [ '-Wstrict-aliasing' ],
         }],
         [ 'OS=="linux"', {
+          'defines': [ '_GNU_SOURCE' ],
           'sources': [
             'src/unix/linux-core.c',
             'src/unix/linux-inotify.c',


### PR DESCRIPTION
This release contains a regression fix for old Linux kernels which lack epoll_pwait, amongst other things :-)

R=@bnoordhuis

Jenkins at work: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/121/