### PR TITLE
http: remove benchmark spacing hack

### DIFF
--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -7,7 +7,7 @@ var bench = common.createBenchmark(main, {
   dur: [5],
   type: ['asc', 'utf', 'buf'],
   bytes: [32, 256, 1024],
-  method: ['write', 'end  '] // two spaces added to line up each row
+  method: ['write', 'end']
 });
 
 function main(conf) {

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -14,7 +14,7 @@ var bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   kb: [64, 128, 256, 1024],
   c: [100],
-  method: ['write', 'end  '] // two spaces added to line up each row
+  method: ['write', 'end']
 });
 
 function main(conf) {


### PR DESCRIPTION
This commit removes the benchmark spacing modification in
`client-request-body.js` and `end-vs-write-end.js` which adds two spaces
to the end of some variables to make sure the lines line up.

The reason behind this is that its totally pointless (the lines don't
actually line up with it) and it disallows you to parse the output with
a tool like awk, or at least makes it a lot harder.