### PR TITLE
lib: fix max size check in Buffer constructor

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -31,7 +31,7 @@ function Buffer(subject, encoding) {
     return new Buffer(subject, encoding);
 
   if (util.isNumber(subject)) {
-    this.length = subject > 0 ? subject >>> 0 : 0;
+    this.length = +subject;
 
   } else if (util.isString(subject)) {
     if (!util.isString(encoding) || encoding.length === 0)
@@ -42,8 +42,7 @@ function Buffer(subject, encoding) {
   } else if (util.isObject(subject)) {
     if (subject.type === 'Buffer' && util.isArray(subject.data))
       subject = subject.data;
-    // Must use floor() because array length may be > kMaxLength.
-    this.length = +subject.length > 0 ? Math.floor(+subject.length) : 0;
+    this.length = +subject.length;
 
   } else {
     throw new TypeError('must start with number, buffer, array or string');
@@ -53,6 +52,11 @@ function Buffer(subject, encoding) {
     throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
                          'size: 0x' + kMaxLength.toString(16) + ' bytes');
   }
+
+  if (this.length < 0)
+    this.length = 0;
+  else
+    this.length >>>= 0;  // Coerce to uint32.
 
   this.parent = undefined;
   if (this.length <= (Buffer.poolSize >>> 1) && this.length > 0) {

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1163,3 +1163,6 @@ assert.throws(function() {
   var b = new Buffer(1);
   b.equals('abc');
 });
+
+// Regression test for https://github.com/iojs/io.js/issues/649.
+assert.throws(function() { Buffer(1422561062959).toString('utf8'); });


### PR DESCRIPTION
A logic error let buffer sizes larger than kMaxLength (0x3fffffff) slip
through.  The .toString() operation (and possibly others as well) then
blew up because the buffer was larger than it could reasonably handle.

Fixes the following run-time assert:

    #
    # Fatal error in ../deps/v8/src/handles.h, line 48
    # CHECK(location_ != NULL) failed
    #

    ==== C stack trace ===============================

     1: V8_Fatal
     2: v8::String::NewFromUtf8(v8::Isolate*, char const*, v8::String::NewStringType, int)
     3: node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding)
     4: node::Buffer::Utf8Slice(v8::FunctionCallbackInfo<v8::Value> const&)
     5: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&))
     6: ??
     7: ??

Fixes: https://github.com/iojs/io.js/issues/649

R=@trevnorris?