### PR TITLE
docs: add note about default padding for publicDecrypt/privateEncrypt

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -710,10 +710,12 @@ NOTE: All paddings are defined in `constants` module.
 ## crypto.privateEncrypt(private_key, buffer)
 
 See above for details. Has the same API as `crypto.privateDecrypt`.
+Default padding is `RSA_PKCS1_PADDING`.
 
 ## crypto.publicDecrypt(public_key, buffer)
 
-See above for details. Has the same API as `crypto.publicEncrypt`.
+See above for details. Has the same API as `crypto.publicEncrypt`. Default
+padding is `RSA_PKCS1_PADDING`.
 
 ## crypto.DEFAULT_ENCODING
 


### PR DESCRIPTION
Adds a note that the default padding for publicDecrypt/privateEncrypt
is RSA_PKCS1_PADDING instead of RSA_PKCS1_OAEP_PADDING as it is for
privateDecrypt/publicEncrypt.