### PR TITLE
benchmark: clean up common.js

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -1,5 +1,8 @@
 var assert = require('assert');
+var fs = require('fs');
 var path = require('path');
+var spawn = require('child_process').spawn;
+
 var silent = +process.env.NODE_BENCH_SILENT;
 
 exports.PORT = process.env.PORT || 12346;
@@ -13,10 +16,8 @@ if (module === require.main) {
     process.exit(1);
   }
 
-  var fs = require('fs');
   var dir = path.join(__dirname, type);
   var tests = fs.readdirSync(dir);
-  var spawn = require('child_process').spawn;
 
   if (testFilter) {
     var filteredTests = tests.filter(function(item){
@@ -24,6 +25,7 @@ if (module === require.main) {
         return item;
       }
     });
+
     if (filteredTests.length === 0) {
       console.error(`${testFilter} is not found in \n ${tests.join('  \n')}`);
       return;
@@ -48,9 +50,9 @@ function runBenchmarks() {
   var a = (process.execArgv || []).concat(test);
   var child = spawn(process.execPath, a, { stdio: 'inherit' });
   child.on('close', function(code) {
-    if (code)
+    if (code) {
       process.exit(code);
-    else {
+    } else {
       console.log('');
       runBenchmarks();
     }
@@ -79,7 +81,6 @@ Benchmark.prototype.http = function(p, args, cb) {
   var self = this;
   var wrk = path.resolve(__dirname, '..', 'tools', 'wrk', 'wrk');
   var regexp = /Requests\/sec:[ \t]+([0-9\.]+)/;
-  var spawn = require('child_process').spawn;
   var url = 'http://127.0.0.1:' + exports.PORT + p;
 
   args = args.concat(url);
@@ -101,8 +102,8 @@ Benchmark.prototype.http = function(p, args, cb) {
       console.error('wrk failed with ' + code);
       process.exit(code)
     }
-    var m = out.match(regexp);
-    var qps = m && +m[1];
+    var match = out.match(regexp);
+    var qps = match && +match[1];
     if (!qps) {
       console.error('%j', out);
       console.error('wrk produced strange output');
@@ -138,7 +139,6 @@ Benchmark.prototype._run = function() {
     return newSet;
   }, [[main]]);
 
-  var spawn = require('child_process').spawn;
   var node = process.execPath;
   var i = 0;
   function run() {
@@ -163,11 +163,11 @@ function parseOpts(options) {
   var num = keys.length;
   var conf = {};
   for (var i = 2; i < process.argv.length; i++) {
-    var m = process.argv[i].match(/^(.+)=(.+)$/);
-    if (!m || !m[1] || !m[2] || !options[m[1]])
+    var match = process.argv[i].match(/^(.+)=(.+)$/);
+    if (!match || !match[1] || !match[2] || !options[match[1]]) {
       return null;
-    else {
-      conf[m[1]] = isFinite(m[2]) ? +m[2] : m[2]
+    } else {
+      conf[match[1]] = isFinite(match[2]) ? +match[2] : match[2]
       num--;
     }
   }
@@ -183,16 +183,19 @@ function parseOpts(options) {
 Benchmark.prototype.start = function() {
   if (this._started)
     throw new Error('Called start more than once in a single benchmark');
+
   this._started = true;
   this._start = process.hrtime();
 };
 
 Benchmark.prototype.end = function(operations) {
   var elapsed = process.hrtime(this._start);
+
   if (!this._started)
     throw new Error('called end without start');
   if (typeof operations !== 'number')
     throw new Error('called end() without specifying operation count');
+
   var time = elapsed[0] + elapsed[1]/1e9;
   var rate = operations/time;
   this.report(rate);
@@ -202,6 +205,7 @@ Benchmark.prototype.report = function(value) {
   var heading = this.getHeading();
   if (!silent)
     console.log('%s: %s', heading, value.toFixed(5));
+
   process.exit(0);
 };
 
@@ -210,4 +214,4 @@ Benchmark.prototype.getHeading = function() {
   return this._name + ' ' + Object.keys(conf).map(function(key) {
     return key + '=' + conf[key];
   }).join(' ');
-}
+};


### PR DESCRIPTION
This commit cleans up `benchmark/common.js` with a few generic changes
such as the following:

- declare all `require()`'d libraries at the top instead of in the
  middle
- add some empty whitespace where it helps readability
- changes ambiguous variable names
- standardizes most if / else blocks
- missing semicolons

This is sort of the prep for an up and coming PR I'm writing, but I just couldn't work with the code as it was.