### PR TITLE
util: use on-stack buffer for Utf8Value

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -16,15 +16,20 @@ Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
   // Allocate enough space to include the null terminator
   size_t len = StringBytes::StorageSize(val_, UTF8) + 1;
 
-  char* str = static_cast<char*>(calloc(1, len));
+  char* str;
+  if (len > kStorageSize)
+    str = static_cast<char*>(malloc(len));
+  else
+    str = str_st_;
+  CHECK_NE(str, NULL);
 
   int flags = WRITE_UTF8_FLAGS;
-  flags |= ~v8::String::NO_NULL_TERMINATION;
 
   length_ = val_->WriteUtf8(str,
                             len,
                             0,
                             flags);
+  str[length_] = '\0';
 
   str_ = reinterpret_cast<char*>(str);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -110,7 +110,8 @@ class Utf8Value {
     explicit Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value);
 
     ~Utf8Value() {
-      free(str_);
+      if (str_ != str_st_)
+        free(str_);
     }
 
     char* operator*() {
@@ -126,7 +127,9 @@ class Utf8Value {
     };
 
   private:
+    static const int kStorageSize = 1024;
     size_t length_;
+    char str_st_[kStorageSize];
     char* str_;
 };
 


### PR DESCRIPTION
Improves `crypto.createHash().update().digest()` performance by 10%.

cc @piscisaureus @bnoordhuis 