### PR TITLE
streams: make streams lazy by default

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -27,6 +27,8 @@ function Duplex(options) {
   Readable.call(this, options);
   Writable.call(this, options);
 
+  this._options = this._options;
+
   if (options && options.readable === false)
     this.readable = false;
 
@@ -39,6 +41,23 @@ function Duplex(options) {
 
   this.once('end', onend);
 }
+
+Object.defineProperty(Duplex.prototype, '_writableState', {
+  get: function() {
+    this._writableState = new Writable.WritableState(this._options, this);
+    return this._writableState;
+  },
+  set: function(val) {
+    Object.defineProperty(this, '_writableState', {
+      value: val,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  },
+  configurable: true,
+  enumerable: false
+});
 
 // the no-half-open enforcer
 function onend() {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -80,13 +80,30 @@ function Readable(options) {
   if (!(this instanceof Readable))
     return new Readable(options);
 
-  this._readableState = new ReadableState(options, this);
+  this._options = options;
 
   // legacy
   this.readable = true;
 
   Stream.call(this);
 }
+
+Object.defineProperty(Readable.prototype, '_readableState', {
+  get: function() {
+    this._readableState = new ReadableState(this._options, this);
+    return this._readableState;
+  },
+  set: function(val) {
+    Object.defineProperty(this, '_readableState', {
+      value: val,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  },
+  configurable: true,
+  enumerable: true
+});
 
 // Manually shove something into the read() buffer.
 // This returns true if the highWaterMark has not been hit yet,

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -115,6 +115,22 @@ function Transform(options) {
   });
 }
 
+Object.defineProperty(Transform.prototype, '_transformState', {
+  get: function() {
+    this._transformState = new TransformState(this);
+    return this._transformState;
+  },
+  set: function(val) {
+    Object.defineProperty(this, '_transformState', {
+      value: val,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  },
+  configurable: true,
+  enumerable: true
+});
 Transform.prototype.push = function(chunk, encoding) {
   this._transformState.needTransform = false;
   return Duplex.prototype.push.call(this, chunk, encoding);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -132,13 +132,31 @@ function Writable(options) {
   if (!(this instanceof Writable) && !(this instanceof Stream.Duplex))
     return new Writable(options);
 
-  this._writableState = new WritableState(options, this);
+  this._options = options;
 
   // legacy.
   this.writable = true;
 
   Stream.call(this);
 }
+
+
+Object.defineProperty(Writable.prototype, '_writableState', {
+  get: function() {
+    this._writableState = new WritableState(this._options, this);
+    return this._writableState;
+  },
+  set: function(val) {
+    Object.defineProperty(this, '_writableState', {
+      value: val,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  },
+  configurable: true,
+  enumerable: false
+});
 
 // Otherwise people can pipe Writable streams, which is just wrong.
 Writable.prototype.pipe = function() {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -40,34 +40,12 @@ const StringDecoder = require('string_decoder').StringDecoder;
 
 
 function LazyTransform(options) {
-  this._options = options;
+  options = options || {};
+  options.defaultEncoding = 'binary';
+  options.decodeStrings = false;
+  stream.Transform.call(this, options);
 }
 util.inherits(LazyTransform, stream.Transform);
-
-[
-  '_readableState',
-  '_writableState',
-  '_transformState'
-].forEach(function(prop, i, props) {
-  Object.defineProperty(LazyTransform.prototype, prop, {
-    get: function() {
-      stream.Transform.call(this, this._options);
-      this._writableState.decodeStrings = false;
-      this._writableState.defaultEncoding = 'binary';
-      return this[prop];
-    },
-    set: function(val) {
-      Object.defineProperty(this, prop, {
-        value: val,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    },
-    configurable: true,
-    enumerable: true
-  });
-});
 
 
 exports.createHash = exports.Hash = Hash;


### PR DESCRIPTION
Makes streams lazy by default so crypto does not need to monky patch them in
order to get good performance. This helps the state objects become part of the
private api in #445.

Other discussion at iojs/readable-stream#109

Ran the bench marks on crypto and they seemed to be compatible (unlike my first attempt) somebody should definitely check me on that.