### PR TITLE
fs: improve error messages

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -377,9 +377,10 @@ inline void Environment::ThrowErrnoException(int errorno,
 inline void Environment::ThrowUVException(int errorno,
                                           const char* syscall,
                                           const char* message,
-                                          const char* path) {
+                                          const char* path,
+                                          const char* dest) {
   isolate()->ThrowException(
-      UVException(isolate(), errorno, syscall, message, path));
+      UVException(isolate(), errorno, syscall, message, path, dest));
 }
 
 inline v8::Local<v8::FunctionTemplate>

--- a/src/env.h
+++ b/src/env.h
@@ -61,6 +61,7 @@ namespace node {
   V(cwd_string, "cwd")                                                        \
   V(debug_port_string, "debugPort")                                           \
   V(debug_string, "debug")                                                    \
+  V(dest_string, "dest")                                                      \
   V(detached_string, "detached")                                              \
   V(dev_string, "dev")                                                        \
   V(disposed_string, "_disposed")                                             \
@@ -407,7 +408,8 @@ class Environment {
   inline void ThrowUVException(int errorno,
                                const char* syscall = nullptr,
                                const char* message = nullptr,
-                               const char* path = nullptr);
+                               const char* path = nullptr,
+                               const char* dest = nullptr);
 
   // Convenience methods for contextify
   inline static void ThrowError(v8::Isolate* isolate, const char* errmsg);

--- a/src/node.h
+++ b/src/node.h
@@ -59,6 +59,12 @@ NODE_EXTERN v8::Local<v8::Value> UVException(v8::Isolate* isolate,
                                              const char* syscall = NULL,
                                              const char* message = NULL,
                                              const char* path = NULL);
+NODE_EXTERN v8::Local<v8::Value> UVException(v8::Isolate* isolate,
+                                             int errorno,
+                                             const char* syscall,
+                                             const char* message,
+                                             const char* path,
+                                             const char* dest);
 
 NODE_DEPRECATED("Use UVException(isolate, ...)",
                 inline v8::Local<v8::Value> ErrnoException(

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -160,7 +160,8 @@ void ThrowUVException(v8::Isolate* isolate,
                       int errorno,
                       const char* syscall = nullptr,
                       const char* message = nullptr,
-                      const char* path = nullptr);
+                      const char* path = nullptr,
+                      const char* dest = nullptr);
 
 NODE_DEPRECATED("Use ThrowError(isolate)",
                 inline void ThrowError(const char* errmsg) {

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -48,7 +48,7 @@ d.on('error', function(er) {
       assert.equal(er.domainThrown, true);
       break;
 
-    case "ENOENT, open 'this file does not exist'":
+    case "ENOENT: no such file or directory, open 'this file does not exist'":
       assert.equal(er.domain, d);
       assert.equal(er.domainThrown, false);
       assert.equal(typeof er.domainBound, 'function');
@@ -58,7 +58,7 @@ d.on('error', function(er) {
       assert.equal(typeof er.errno, 'number');
       break;
 
-    case "ENOENT, open 'stream for nonexistent file'":
+    case "ENOENT: no such file or directory, open 'stream for nonexistent file'":
       assert.equal(typeof er.errno, 'number');
       assert.equal(er.code, 'ENOENT');
       assert.equal(er_path, 'stream for nonexistent file');

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -29,10 +29,12 @@ fs.link(fn, 'foo', function(err) {
 });
 
 fs.link(existingFile, existingFile2, function(err) {
+  assert.ok(0 <= err.message.indexOf(existingFile));
   assert.ok(0 <= err.message.indexOf(existingFile2));
 });
 
 fs.symlink(existingFile, existingFile2, function(err) {
+  assert.ok(0 <= err.message.indexOf(existingFile));
   assert.ok(0 <= err.message.indexOf(existingFile2));
 });
 
@@ -45,6 +47,7 @@ fs.rename(fn, 'foo', function(err) {
 });
 
 fs.rename(existingDir, existingDir2, function(err) {
+  assert.ok(0 <= err.message.indexOf(existingDir));
   assert.ok(0 <= err.message.indexOf(existingDir2));
 });
 
@@ -130,6 +133,7 @@ try {
   fs.linkSync(existingFile, existingFile2);
 } catch (err) {
   errors.push('link');
+  assert.ok(0 <= err.message.indexOf(existingFile));
   assert.ok(0 <= err.message.indexOf(existingFile2));
 }
 
@@ -138,6 +142,7 @@ try {
   fs.symlinkSync(existingFile, existingFile2);
 } catch (err) {
   errors.push('symlink');
+  assert.ok(0 <= err.message.indexOf(existingFile));
   assert.ok(0 <= err.message.indexOf(existingFile2));
 }
 
@@ -186,6 +191,7 @@ try {
   fs.renameSync(existingDir, existingDir2);
 } catch (err) {
   errors.push('rename');
+  assert.ok(0 <= err.message.indexOf(existingDir));
   assert.ok(0 <= err.message.indexOf(existingDir2));
 }
 


### PR DESCRIPTION
* Include a description for the error message
* For rename, link, and symlink, include both the source and destination
  path in the error message.
* Expose the destination path as the `dest` property on the error object.

API impact:
* The public node::UVException() function now takes 6 arguments.

This is an alternative for #293 
R=@iojs/tc