### PR TITLE
governance: simplified pure consensus seeking

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -71,10 +71,10 @@ make decisions efficiently.
 There is no specific set of requirements or qualifications for TC
 membership beyond these rules.
 
-The TC may add additional members to the TC by unanimous consensus.
+The TC may add additional members to the TC by a standard TC motion.
 
 A TC member may be removed from the TC by voluntary resignation, or by
-unanimous consensus of all other TC members.
+a standard TC motion.
 
 Changes to TC membership should be posted in the agenda, and may be
 suggested as any other agenda item (see "TC Meetings" below).


### PR DESCRIPTION
We should remove special cases where we break from consensus seeking in favor of pure consensus.

The reason the process has worked so well is the incentive to convince your peers which is not present in pure consensus. Breaking from it seems dangerous.