### PR TITLE
Fix regression in signal unlisten and document current EE behaviour

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -143,8 +143,11 @@ Return the number of listeners for a given event.
 * `event` {String} The event name
 * `listener` {Function} The event handler function
 
-This event is emitted any time a listener is added. When this event is triggered,
-the listener may not yet have been added to the array of listeners for the `event`.
+This event is emitted *before* a listener is added. When this event is
+triggered, the listener has not been added to the array of listeners for the
+`event`. Any listeners added to the event `name` in the newListener event
+callback will be added *before* the listener that is in the process of being
+added.
 
 
 ### Event: 'removeListener'
@@ -152,5 +155,6 @@ the listener may not yet have been added to the array of listeners for the `even
 * `event` {String} The event name
 * `listener` {Function} The event handler function
 
-This event is emitted any time someone removes a listener.  When this event is triggered,
-the listener may not yet have been removed from the array of listeners for the `event`.
+This event is emitted *after* a listener is removed.  When this event is
+triggered, the listener has been removed from the array of listeners for the
+`event`.

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -57,3 +57,15 @@ e3.on('removeListener', listener);
 // there exists a removeListener listener, but there exists
 // no listeners for the provided event type
 assert.doesNotThrow(e3.removeAllListeners.bind(e3, 'foo'));
+
+var e4 = new events.EventEmitter();
+var expectLength = 2;
+e4.on('removeListener', function(name, listener) {
+  assert.equal(expectLength--, this.listeners('baz').length);
+});
+e4.on('baz', function(){});
+e4.on('baz', function(){});
+e4.on('baz', function(){});
+assert.equal(e4.listeners('baz').length, expectLength+1);
+e4.removeAllListeners('baz');
+assert.equal(e4.listeners('baz').length, 0);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -45,12 +45,20 @@ assert.deepEqual([listener1], e2.listeners('hello'));
 var e3 = new events.EventEmitter();
 e3.on('hello', listener1);
 e3.on('hello', listener2);
-e3.on('removeListener', common.mustCall(function(name, cb) {
+e3.once('removeListener', common.mustCall(function(name, cb) {
   assert.equal(name, 'hello');
   assert.equal(cb, listener1);
+  assert.deepEqual([listener2], e3.listeners('hello'));
 }));
 e3.removeListener('hello', listener1);
 assert.deepEqual([listener2], e3.listeners('hello'));
+e3.once('removeListener', common.mustCall(function(name, cb) {
+  assert.equal(name, 'hello');
+  assert.equal(cb, listener2);
+  assert.deepEqual([], e3.listeners('hello'));
+}));
+e3.removeListener('hello', listener2);
+assert.deepEqual([], e3.listeners('hello'));
 
 var e4 = new events.EventEmitter();
 e4.on('removeListener', common.mustCall(function(name, cb) {
@@ -61,3 +69,21 @@ e4.on('removeListener', common.mustCall(function(name, cb) {
 e4.on('quux', remove1);
 e4.on('quux', remove2);
 e4.removeListener('quux', remove1);
+
+var e5 = new events.EventEmitter();
+e5.on('hello', listener1);
+e5.on('hello', listener2);
+e5.once('removeListener', common.mustCall(function(name, cb) {
+  assert.equal(name, 'hello');
+  assert.equal(cb, listener1);
+  assert.deepEqual([listener2], e5.listeners('hello'));
+  e5.once('removeListener', common.mustCall(function(name, cb) {
+    assert.equal(name, 'hello');
+    assert.equal(cb, listener2);
+    assert.deepEqual([], e5.listeners('hello'));
+  }));
+  e5.removeListener('hello', listener2);
+  assert.deepEqual([], e5.listeners('hello'));
+}));
+e5.removeListener('hello', listener1);
+assert.deepEqual([], e5.listeners('hello'));

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -1,0 +1,40 @@
+if (process.platform === 'win32') {
+  // Win32 doesn't have signals, just a kindof emulation, insufficient
+  // for this test to apply.
+  return;
+}
+
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var ok;
+
+if (process.argv[2] !== '--do-test') {
+  // We are the master, fork a child so we can verify it exits with correct
+  // status.
+  process.env.DOTEST = 'y';
+  var child = spawn(process.execPath, [__filename, '--do-test']);
+
+  child.once('exit', function(code, signal) {
+    assert.equal(signal, 'SIGINT');
+    ok = true;
+  });
+
+  process.on('exit', function() {
+    assert(ok);
+  });
+
+  return;
+}
+
+process.on('SIGINT', function() {
+  // Remove all handlers and kill ourselves. We should terminate by SIGINT
+  // now that we have no handlers.
+  process.removeAllListeners('SIGINT');
+  process.kill(process.pid, 'SIGINT');
+});
+
+// Signal handlers aren't sufficient to keep node alive, so resume stdin
+process.stdin.resume();
+
+// Demonstrate that signals are being handled
+process.kill(process.pid, 'SIGINT');


### PR DESCRIPTION
`process.removeAllListeners()` doesn't work for signals. It should, and it used to, prior to https://github.com/iojs/io.js/commit/56668f54d11225b0bcdf93dc2fba846febdbb19f

I originally PRed a fix for this in  https://github.com/joyent/node/pull/8953. That fix is a one-liner, wherein a subtle optimization in `EventEmitter.removeAllListeners()` is evaded by a seeming no-op `process.on('removeListener', function(){})`, which is pretty awful from a comprehensibility point of view.

`src/node.js` is simpler and more understandable if it just uses the new/remove listener events, but they are theoretically useless for this kind of use-case, since the documentation is officially weasely about whether they fire before or after the listener is actually added. see: https://github.com/joyent/node/issues/8853 and https://github.com/piscisaureus/io.js/commit/ff350f716971e0a7d93e7631d38891682a2da75b

I've never seen the new/remove listener used for any purpose other than what node itself could use it for: detecting whether there is indeed a listener for an event, and starting or stopping some processing accordingly. It should be easier to use the EE for this.

Even if you don't agree the indeterminancy in the EE API should be removed, node is free to depend on implementation details of itself, so 90a5e2b doesn't require c1d5fab. For node to assume that the EE behaves as it does seems better than my original fix/hack in https://github.com/sam-github/node/commit/06b6e75668ae9b4f57a61d5b48633ae7d3f8f434

R=@bnoordhuis 