### PR TITLE
lib: replace sprintf-like format to template string literal

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -20,7 +20,7 @@ exports.start = function start() {
 
   agent.listen(process._debugAPI.port, function() {
     var addr = this.address();
-    process._rawDebug('Debugger listening on port %d', addr.port);
+    process._rawDebug(`Debugger listening on port ${addr.port}`);
     process._debugAPI.notifyListen();
   });
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -317,7 +317,7 @@ function connectionListener(socket) {
 
   function socketOnData(d) {
     assert(!socket._paused);
-    debug('SERVER socketOnData %d', d.length);
+    debug(`SERVER socketOnData ${d.length}`);
     var ret = parser.execute(d);
     if (ret instanceof Error) {
       debug('parse error');
@@ -337,7 +337,7 @@ function connectionListener(socket) {
 
       var eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
       if (EventEmitter.listenerCount(self, eventName) > 0) {
-        debug('SERVER have listener for %s', eventName);
+        debug(`SERVER have listener for ${eventName}`);
         var bodyHead = d.slice(bytesParsed, d.length);
 
         // TODO(isaacs): Need a way to reset a stream to fresh state

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -157,10 +157,10 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
     // Write current buffer now
     var written;
     if (this === this.pair.cleartext) {
-      debug('cleartext.write called with %d bytes', data.length);
+      debug(`cleartext.write called with ${data.length} bytes`);
       written = this.pair.ssl.clearIn(data, 0, data.length);
     } else {
-      debug('encrypted.write called with %d bytes', data.length);
+      debug(`encrypted.write called with ${data.length} bytes`);
       written = this.pair.ssl.encIn(data, 0, data.length);
     }
 
@@ -215,9 +215,9 @@ CryptoStream.prototype._write = function write(data, encoding, cb) {
   this._pendingCallback = cb;
 
   if (this === this.pair.cleartext) {
-    debug('cleartext.write queued with %d bytes', data.length);
+    debug(`cleartext.write queued with ${data.length} bytes`);
   } else {
-    debug('encrypted.write queued with %d bytes', data.length);
+    debug(`encrypted.write queued with ${data.length} bytes`);
   }
 };
 
@@ -244,10 +244,10 @@ CryptoStream.prototype._read = function read(size) {
 
   var out;
   if (this === this.pair.cleartext) {
-    debug('cleartext.read called with %d bytes', size);
+    debug(`cleartext.read called with ${size} bytes`);
     out = this.pair.ssl.clearOut;
   } else {
-    debug('encrypted.read called with %d bytes', size);
+    debug(`encrypted.read called with ${size} bytes`);
     out = this.pair.ssl.encOut;
   }
 
@@ -282,9 +282,9 @@ CryptoStream.prototype._read = function read(size) {
   assert(bytesRead >= 0);
 
   if (this === this.pair.cleartext) {
-    debug('cleartext.read succeed with %d bytes', bytesRead);
+    debug(`cleartext.read succeed with ${bytesRead} bytes`);
   } else {
-    debug('encrypted.read succeed with %d bytes', bytesRead);
+    debug(`encrypted.read succeed with ${bytesRead} bytes`);
   }
 
   // Try writing pending data

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -1265,10 +1265,8 @@ function spawnSync(/*file, args, options*/) {
       else if (util.isString(input))
         pipe.input = new Buffer(input, options.encoding);
       else
-        throw new TypeError(util.format(
-            'stdio[%d] should be Buffer or string not %s',
-            i,
-            typeof input));
+        throw new TypeError(
+            `stdio[${i}] should be Buffer or string not ${typeof input}`);
     }
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -158,9 +158,9 @@ EventEmitter.prototype.addListener = function addListener(type, listener) {
     if (m && m > 0 && this._events[type].length > m) {
       this._events[type].warned = true;
       console.error('(node) warning: possible EventEmitter memory ' +
-                    'leak detected. %d %s listeners added. ' +
-                    'Use emitter.setMaxListeners() to increase limit.',
-                    this._events[type].length, type);
+                    `leak detected. ${this._events[type]} ${type} ` +
+                    'listeners added. ' +
+                    'Use emitter.setMaxListeners() to increase limit.');
       console.trace();
     }
   }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -56,17 +56,17 @@ function listOnTimeout() {
   var msecs = this.msecs;
   var list = this;
 
-  debug('timeout callback %d', msecs);
+  debug(`timeout callback ${msecs}`);
 
   var now = Timer.now();
-  debug('now: %s', now);
+  debug('now: ' + now);
 
   var diff, first, threw;
   while (first = L.peek(list)) {
     diff = now - first._idleStart;
     if (diff < msecs) {
       list.start(msecs - diff, 0);
-      debug('%d list wait because diff is %d', msecs, diff);
+      debug(`${msecs} list wait because diff is ${diff}`);
       return;
     } else {
       L.remove(first);
@@ -107,7 +107,7 @@ function listOnTimeout() {
     }
   }
 
-  debug('%d list empty', msecs);
+  debug(`${msecs} list empty`);
   assert(L.isEmpty(list));
   list.close();
   delete lists[msecs];

--- a/lib/util.js
+++ b/lib/util.js
@@ -598,7 +598,7 @@ function timestamp() {
 
 // log is just a thin wrapper to console.log that prepends a timestamp
 exports.log = function() {
-  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
+  console.log(`${timestamp()} - ${exports.format.apply(exports, arguments)}`);
 };
 
 


### PR DESCRIPTION
Template String Literal is faster than sprintf-like format string.

http://jsperf.com/template-literal-vs-string-plus/2
![2015-02-03 1 33 05](https://cloud.githubusercontent.com/assets/555645/6004240/a71bdab4-ab44-11e4-897d-5bf0d2ffb18c.png)

And, I think template string literal is easier to understand than sprintf.
