### PR TITLE
Dtrace: fix removal of unused probes

### DIFF
--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -257,8 +257,6 @@ bool NODE_HTTP_CLIENT_REQUEST_ENABLED() { return events_enabled > 0; }
 bool NODE_HTTP_CLIENT_RESPONSE_ENABLED() { return events_enabled > 0; }
 bool NODE_NET_SERVER_CONNECTION_ENABLED() { return events_enabled > 0; }
 bool NODE_NET_STREAM_END_ENABLED() { return events_enabled > 0; }
-bool NODE_NET_SOCKET_READ_ENABLED() { return events_enabled > 0; }
-bool NODE_NET_SOCKET_WRITE_ENABLED() { return events_enabled > 0; }
 bool NODE_V8SYMBOL_ENABLED() { return events_enabled > 0; }
 
 }  // namespace node


### PR DESCRIPTION
This is a fix for #698, which I introduced in #694.