### PR TITLE
benchmark: don't use template strings

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -27,7 +27,7 @@ if (module === require.main) {
     });
 
     if (filteredTests.length === 0) {
-      console.error(`${testFilter} is not found in \n ${tests.join('  \n')}`);
+      console.error('%s is not found in \n %j', testFilter, tests);
       return;
     }
     tests = filteredTests;


### PR DESCRIPTION
When running `benchmark/compare.js`, it is typical to run a version of
node that does not support template strings. This provides backwards
compatibility for comparing benchmarks using older versions of node.