### PR TITLE
Add NODE_DEBUG info to child_process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -6,6 +6,7 @@ const net = require('net');
 const dgram = require('dgram');
 const assert = require('assert');
 const util = require('util');
+const debug = util.debuglog('child_process');
 
 const Process = process.binding('process_wrap').Process;
 const WriteWrap = process.binding('stream_wrap').WriteWrap;
@@ -958,6 +959,8 @@ var spawn = exports.spawn = function(/*file, args, options*/) {
   var options = opts.options;
   var child = new ChildProcess();
 
+  debug('spawn', opts.args, options);
+
   child.spawn({
     file: opts.file,
     args: opts.args,
@@ -1035,6 +1038,7 @@ function ChildProcess() {
       if (self.spawnfile)
         err.path = self.spawnfile;
 
+      err.spawnargs = self.spawnargs.slice(1);
       self.emit('error', err);
     } else {
       self.emit('exit', self.exitCode, self.signalCode);
@@ -1097,6 +1101,7 @@ ChildProcess.prototype.spawn = function(options) {
   }
 
   this.spawnfile = options.file;
+  this.spawnargs = options.args;
 
   var err = this._handle.spawn(options);
 
@@ -1246,6 +1251,8 @@ function spawnSync(/*file, args, options*/) {
   options.args = opts.args;
   options.envPairs = opts.envPairs;
 
+  debug('spawnSync', opts.args, options);
+
   if (options.killSignal)
     options.killSignal = lookupSignal(options.killSignal);
 
@@ -1289,8 +1296,11 @@ function spawnSync(/*file, args, options*/) {
   result.stdout = result.output && result.output[1];
   result.stderr = result.output && result.output[2];
 
-  if (result.error)
-    result.error = errnoException(result.error, 'spawnSync');
+  if (result.error) {
+    result.error = errnoException(result.error, 'spawnSync ' + opts.file);
+    result.error.path = opts.file;
+    result.error.spawnargs = opts.args.slice(1);
+  }
 
   util._extend(result, opts);
 


### PR DESCRIPTION
Fixes GH-720. Also adds the arguments passed to the Error object.

Example:

```js
var spawn = require('child_process').spawn;
var path = require('path');

var child = spawn('fdjslkdf', ['--foo', 'bar'], {
  cwd: path.join(process.cwd(), './bat')
});

child.on('error', function (err) {
  throw err;
});

```

```
$ NODE_DEBUG=child_process ./iojs tmp.js
CHILD_PROCESS 72525: command: fdjslkdf
CHILD_PROCESS 72525: arguments: --foo,bar
CHILD_PROCESS 72525: options: {"cwd":"/Users/zach/Documents/github/remixz/io.js/bat"}
/Users/zach/Documents/github/remixz/io.js/tmp.js:9
  throw err;
        ^
Error: spawn fdjslkdf ENOENT
    at exports._errnoException (util.js:738:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1029:32)
    at child_process.js:1120:20
    at process._tickCallback (node.js:337:11)
    at Function.Module.runMain (module.js:489:11)
    at startup (node.js:111:16)
    at node.js:799:3
``` 