### PR TITLE
docs: Include mention of new crypto methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * debug: fix v8 post-mortem debugging.
 * crypto: publicEncrypt now supports password-protected private keys.
 * crypto: ~30% speedup on hashing functions.
+* crypto: added privateEncrypt/publicDecrypt functions.
 * errors
   - better formatting via util.inspect
   - more descriptive errors from fs. This necessitated a `NODE_MODULE_VERSION` bump.


### PR DESCRIPTION
includes mention of  privateEncrypt and publicDecrypt in changelog