### PR TITLE
Adds additional responsibilities to the website working group

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -28,7 +28,7 @@ Its responsibilities are:
 * Ensure the site is regularly updated with changes made to `io.js` like
 releases and features.
 * Documentation: maintain the docs build process and publish to `iojs.org`. See https://github.com/iojs/doc-tool (the source API docs are maintained and managed in core, not through this WG.)
-* General marketing and social media initiatives (proposed sub-WG)
+* General marketing and social media initiatives
 * Fostering io.js evangelism efforts (empowering speakers with materials, maintaining a list of interested speakers/interviewees, education, etc.)
 
 * Foster and enable a community of translators.

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -27,6 +27,10 @@ Its responsibilities are:
 * Develop and maintain a build and automation system for `iojs.org`.
 * Ensure the site is regularly updated with changes made to `io.js` like
 releases and features.
+* Documentation: maintain the docs build process and publish to `iojs.org`. See https://github.com/iojs/doc-tool (the source API docs are maintained and managed in core, not through this WG.)
+* General marketing and social media initiatives (proposed sub-WG)
+* Fostering io.js evangelism efforts (empowering speakers with materials, maintaining a list of interested speakers/interviewees, education, etc.)
+
 * Foster and enable a community of translators.
 
 The current members can be found in their


### PR DESCRIPTION
This might be a bit verbose as is, although I think the examples help clarify the intent.

- Reference to WG acceptance of "evangelism" efforts https://github.com/iojs/website/blob/master/wg-meetings/2015-01-19.md#matching-or-diverging-from-iojs-organizationally
- Social media and documentation were discussed/approved Feb 2 but the minutes from that meeting haven't been PR'd in yet. https://www.youtube.com/watch?v=SBJaXUA0lSY

Of course, pending general TC approval of the scope we've said we can take on / help develop.