### PR TITLE
asyncwrap: fix constructor condition for early ret

### DIFF
--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -21,7 +21,9 @@ inline AsyncWrap::AsyncWrap(Environment* env,
       has_async_queue_(false),
       provider_type_(provider) {
   // Check user controlled flag to see if the init callback should run.
-  if (!env->call_async_init_hook())
+  if (!env->using_asyncwrap())
+    return;
+  if (!env->call_async_init_hook() && parent != nullptr)
     return;
 
   // TODO(trevnorris): Until it's verified all passed object's are not weak,

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -48,6 +48,8 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   env->set_async_hooks_init_function(args[1].As<Function>());
   env->set_async_hooks_pre_function(args[2].As<Function>());
   env->set_async_hooks_post_function(args[3].As<Function>());
+
+  env->set_using_asyncwrap(true);
 }
 
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -165,6 +165,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate(), loop)),
       using_smalloc_alloc_cb_(false),
       using_domains_(false),
+      using_asyncwrap_(false),
       printed_error_(false),
       debugger_agent_(this),
       context_(context->GetIsolate(), context) {
@@ -296,6 +297,14 @@ inline bool Environment::using_domains() const {
 
 inline void Environment::set_using_domains(bool value) {
   using_domains_ = value;
+}
+
+inline bool Environment::using_asyncwrap() const {
+  return using_asyncwrap_;
+}
+
+inline void Environment::set_using_asyncwrap(bool value) {
+  using_asyncwrap_ = value;
 }
 
 inline bool Environment::printed_error() const {

--- a/src/env.h
+++ b/src/env.h
@@ -395,6 +395,9 @@ class Environment {
   inline bool using_domains() const;
   inline void set_using_domains(bool value);
 
+  inline bool using_asyncwrap() const;
+  inline void set_using_asyncwrap(bool value);
+
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
@@ -479,6 +482,7 @@ class Environment {
   ares_task_list cares_task_list_;
   bool using_smalloc_alloc_cb_;
   bool using_domains_;
+  bool using_asyncwrap_;
   bool printed_error_;
   debugger::Agent debugger_agent_;
 


### PR DESCRIPTION
AsyncWrap should always properly propagate asynchronous calls to any
child that is created. Regardless whether kCallInitHook is currently
active. The previous logic would always return early if kCallInitHook
wasn't set.

R=@bnoordhuis