### PR TITLE
test: accept EPROTONOSUPPORT ipv6 error

### DIFF
--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -24,12 +24,12 @@ var family_ipv6 = 'IPv6';
 socket_ipv6.on('listening', assert.fail);
 
 socket_ipv6.on('error', common.mustCall(function(e) {
-  // EAFNOSUPPORT means IPv6 is disabled on this system.
-  var code = (e.code === 'EADDRNOTAVAIL' ? e.code : 'EAFNOSUPPORT');
-  assert.equal(e.message, 'bind ' + code + ' 111::1:' + common.PORT);
+  // EAFNOSUPPORT or EPROTONOSUPPORT means IPv6 is disabled on this system.
+  var allowed = ['EADDRNOTAVAIL', 'EAFNOSUPPORT', 'EPROTONOSUPPORT'];
+  assert.notEqual(allowed.indexOf(e.code), -1);
+  assert.equal(e.message, 'bind ' + e.code + ' 111::1:' + common.PORT);
   assert.equal(e.address, '111::1');
   assert.equal(e.port, common.PORT);
-  assert.equal(e.code, code);
   socket_ipv6.close();
 }));
 


### PR DESCRIPTION
The IPv6 test in parallel/test-dgram-error-message-address may fail
when the host system has disabled IPv6, as is the case on our FreeBSD
machines.  The test already accepted EAFNOSUPPORT as of commit 5ba307a,
now make it accept EPROTONOSUPPORT as well.

I'm not exactly thrilled by the profusion of error codes but they are
all legitimate.

R=@indutny?

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/150/