### PR TITLE
lib: make debug client connect to 127.0.0.1

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1620,7 +1620,7 @@ Interface.prototype.trySpawn = function(cb) {
   var self = this,
       breakpoints = this.breakpoints || [],
       port = exports.port,
-      host = 'localhost',
+      host = '127.0.0.1',
       childArgs = this.args;
 
   this.killChild();


### PR DESCRIPTION
On machines without network connectivity, a DNS lookup for 'localhost'
may fail.  Connect to 127.0.0.1 to skip the host resolve step.

Fixes: https://github.com/iojs/io.js/issues/726

R=@cjihrig?