### PR TITLE
benchmark: bump eventemitter number of iterations

### DIFF
--- a/benchmark/events/ee-emit-multi-args.js
+++ b/benchmark/events/ee-emit-multi-args.js
@@ -1,7 +1,7 @@
 var common = require('../common.js');
 var EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, {n: [25e4]});
+var bench = common.createBenchmark(main, {n: [2e6]});
 
 function main(conf) {
   var n = conf.n | 0;

--- a/benchmark/events/ee-emit.js
+++ b/benchmark/events/ee-emit.js
@@ -1,7 +1,7 @@
 var common = require('../common.js');
 var EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, {n: [25e4]});
+var bench = common.createBenchmark(main, {n: [2e6]});
 
 function main(conf) {
   var n = conf.n | 0;

--- a/benchmark/events/ee-listener-count.js
+++ b/benchmark/events/ee-listener-count.js
@@ -1,7 +1,7 @@
 var common = require('../common.js');
 var EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, {n: [25e4]});
+var bench = common.createBenchmark(main, {n: [5e7]});
 
 function main(conf) {
   var n = conf.n | 0;

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -1,7 +1,7 @@
 var common = require('../common.js');
 var EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, {n: [25e4]});
+var bench = common.createBenchmark(main, {n: [5e6]});
 
 function main(conf) {
   var n = conf.n | 0;

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -1,7 +1,7 @@
 var common = require('../common.js');
 var EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, {n: [25e4]});
+var bench = common.createBenchmark(main, {n: [5e6]});
 
 function main(conf) {
   var n = conf.n | 0;


### PR DESCRIPTION
Some of the benchmarks that were added in commit 847b9d2 complete too
quickly to draw meaningful conclusions from.  Increase the number of
iterations to make them run longer.

R=@mscdex?