### PR TITLE
os: remove trailing slash from os.tmpdir()

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -23,16 +23,20 @@ exports.platform = function() {
 };
 
 exports.tmpdir = function() {
+  var path;
   if (isWindows) {
-    return process.env.TEMP ||
+    path = process.env.TEMP ||
            process.env.TMP ||
            (process.env.SystemRoot || process.env.windir) + '\\temp';
   } else {
-    return process.env.TMPDIR ||
+    path = process.env.TMPDIR ||
            process.env.TMP ||
            process.env.TEMP ||
            '/tmp';
   }
+  if (/[\\\/]$/.test(path))
+    path = path.slice(0, -1);
+  return path;
 };
 
 exports.tmpDir = exports.tmpdir;

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -1,9 +1,9 @@
 #ifndef SRC_NODE_VERSION_H_
 #define SRC_NODE_VERSION_H_
 
-#define NODE_MAJOR_VERSION 1
-#define NODE_MINOR_VERSION 6
-#define NODE_PATCH_VERSION 2
+#define NODE_MAJOR_VERSION 2
+#define NODE_MINOR_VERSION 0
+#define NODE_PATCH_VERSION 0
 
 #define NODE_VERSION_IS_RELEASE 0
 
@@ -45,6 +45,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 43  /* io.js v1.1.0 */
+#define NODE_MODULE_VERSION 44  /* io.js v2.x */
 
 #endif  /* SRC_NODE_VERSION_H_ */

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -13,6 +13,8 @@ if (process.platform === 'win32') {
   process.env.TMP = '';
   var expected = (process.env.SystemRoot || process.env.windir) + '\\temp';
   assert.equal(os.tmpdir(), expected);
+  process.env.TEMP = '\\temp\\';
+  assert.equal(os.tmpdir(), '\\temp');
 } else {
   assert.equal(os.tmpdir(), '/tmpdir');
   process.env.TMPDIR = '';
@@ -21,6 +23,8 @@ if (process.platform === 'win32') {
   assert.equal(os.tmpdir(), '/temp');
   process.env.TEMP = '';
   assert.equal(os.tmpdir(), '/tmp');
+  process.env.TMPDIR = '/tmpdir/';
+  assert.equal(os.tmpdir(), '/tmpdir');
 }
 
 var endianness = os.endianness();


### PR DESCRIPTION
This commit makes `os.tmpdir()` behave consistently on all platforms. It
changes `os.tmpdir()` to always return a path without trailing slash.

Semver: Major
Fixes: https://github.com/iojs/io.js/issues/715