### PR TITLE
contextify: share security token with debug ctx

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -236,7 +236,13 @@ class ContextifyContext {
     Local<String> script_source(args[0]->ToString(args.GetIsolate()));
     if (script_source.IsEmpty())
       return;  // Exception pending.
-    Context::Scope context_scope(Debug::GetDebugContext());
+
+    Environment* env = Environment::GetCurrent(args.GetIsolate());
+    Local<Context> ctx = Debug::GetDebugContext();
+    if (!ctx.IsEmpty())
+      ctx->SetSecurityToken(env->context()->GetSecurityToken());
+
+    Context::Scope context_scope(ctx);
     Local<Script> script = Script::Compile(script_source);
     if (script.IsEmpty())
       return;  // Exception pending.

--- a/test/parallel/test-vm-debug-context-token.js
+++ b/test/parallel/test-vm-debug-context-token.js
@@ -1,0 +1,12 @@
+var common = require('../common');
+var vm = require('vm');
+var assert = require('assert');
+
+var proto = vm.runInDebugContext('DebugCommandProcessor.prototype');
+proto.prop = true;
+assert.equal(proto.prop, true);
+proto = vm.runInDebugContext('DebugCommandProcessor.prototype');
+assert.equal(proto.prop, true);
+proto = vm.runInDebugContext('DebugCommandProcessor.prototype.prop = true;' +
+                             'DebugCommandProcessor.prototype');
+assert.equal(proto.prop, true);


### PR DESCRIPTION
If security token does not match - no changes are allowed to the objects
from different context. We already copy the security token to the newly
created contexts in contextify.cc . Copy the security token to the debug
context too.

Fix: https://github.com/joyent/node/issues/9156