### PR TITLE
doc: fix dns.lookup options example

### DIFF
--- a/doc/api/dns.markdown
+++ b/doc/api/dns.markdown
@@ -79,8 +79,8 @@ All properties are optional. An example usage of options is shown below.
 ```
 {
   family: 4,
-  hints: dns.ADDRCONFIG | dns.V4MAPPED
-  all: true
+  hints: dns.ADDRCONFIG | dns.V4MAPPED,
+  all: false
 }
 ```
 


### PR DESCRIPTION
Small amendment to #744, fixing a missing trailing comma and setting `all` to `false` in the example, because that's what most people will use most likely.