### PR TITLE
test: fix test failure with shared openssl

### DIFF
--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -9,6 +9,11 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 var tls = require('tls');
 
+if (common.opensslCli === false) {
+  console.error('Skipping because openssl command cannot be executed');
+  process.exit(0);
+}
+
 var cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');
 var key = fs.readFileSync(common.fixturesDir + '/test_key.pem');
 var server = tls.createServer({ cert: cert, key: key }, assert.fail);


### PR DESCRIPTION
When configured with share openssl, use external openssl command and check if it can be executed.

Fixes: https://github.com/iojs/io.js/issues/618

Cc:  @jbergstroem 

Please someone in @iojs/collaborators review this.