### PR TITLE
Re-export HTTP parsers

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -9,6 +9,7 @@ exports.IncomingMessage = require('_http_incoming').IncomingMessage;
 
 const common = require('_http_common');
 exports.METHODS = common.methods.slice().sort();
+exports.parsers = common.parsers;
 
 
 exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;


### PR DESCRIPTION
This change reverses 299cf84490a2f28ffdc4c82e4fb7078ac591b6d3. Having HTTP parsers exported is useful when needing to debug HTTP connections (accessing raw buffers in particular). An example usage can be found here: http://miensol.pl/2014/03/23/nonintrusive-http-proxy-in-nodejs.html

NB: Commit message for 299cf84490a2f28ffdc4c82e4fb7078ac591b6d3 mentions that a different name might be needed, as changes to the parsers' lifecycle may break existing usage.