### PR TITLE
doc: change the order of crypto.publicDecrypt

### DIFF
--- a/doc/api/crypto.markdown
+++ b/doc/api/crypto.markdown
@@ -692,6 +692,11 @@ key to this method.
 
 NOTE: All paddings are defined in `constants` module.
 
+## crypto.publicDecrypt(public_key, buffer)
+
+See above for details. Has the same API as `crypto.publicEncrypt`. Default
+padding is `RSA_PKCS1_PADDING`.
+
 ## crypto.privateDecrypt(private_key, buffer)
 
 Decrypts `buffer` with `private_key`.
@@ -714,11 +719,6 @@ NOTE: All paddings are defined in `constants` module.
 
 See above for details. Has the same API as `crypto.privateDecrypt`.
 Default padding is `RSA_PKCS1_PADDING`.
-
-## crypto.publicDecrypt(public_key, buffer)
-
-See above for details. Has the same API as `crypto.publicEncrypt`. Default
-padding is `RSA_PKCS1_PADDING`.
 
 ## crypto.DEFAULT_ENCODING
 


### PR DESCRIPTION
`crypto.publicDecrypt` should after `crypto.publicEncrypt`