### PR TITLE
buffer: expose internals on binding

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const buffer = process.binding('buffer');
+const binding = process.binding('buffer');
 const smalloc = process.binding('smalloc');
 const util = require('util');
 const alloc = smalloc.alloc;
 const truncate = smalloc.truncate;
 const sliceOnto = smalloc.sliceOnto;
 const kMaxLength = smalloc.kMaxLength;
-var internal = {};
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -124,7 +123,7 @@ NativeBuffer.prototype = Buffer.prototype;
 
 
 // add methods to Buffer prototype
-buffer.setupBufferJS(NativeBuffer, internal);
+binding.setupBufferJS(NativeBuffer);
 
 
 // Static methods
@@ -142,7 +141,7 @@ Buffer.compare = function compare(a, b) {
   if (a === b)
     return 0;
 
-  return internal.compare(a, b);
+  return binding.compare(a, b);
 };
 
 
@@ -215,7 +214,7 @@ Buffer.byteLength = function(str, enc) {
       ret = str.length >>> 1;
       break;
     default:
-      ret = internal.byteLength(str, enc);
+      ret = binding.byteLength(str, enc);
   }
   return ret;
 };
@@ -274,7 +273,7 @@ Buffer.prototype.equals = function equals(b) {
   if (this === b)
     return true;
 
-  return internal.compare(this, b) === 0;
+  return binding.compare(this, b) === 0;
 };
 
 
@@ -298,7 +297,7 @@ Buffer.prototype.compare = function compare(b) {
   if (this === b)
     return 0;
 
-  return internal.compare(this, b);
+  return binding.compare(this, b);
 };
 
 
@@ -319,7 +318,7 @@ Buffer.prototype.fill = function fill(val, start, end) {
       val = code;
   }
 
-  internal.fill(this, val, start, end);
+  binding.fill(this, val, start, end);
 
   return this;
 };
@@ -663,7 +662,7 @@ Buffer.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return internal.readFloatLE(this, offset);
+  return binding.readFloatLE(this, offset);
 };
 
 
@@ -671,7 +670,7 @@ Buffer.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return internal.readFloatBE(this, offset);
+  return binding.readFloatBE(this, offset);
 };
 
 
@@ -679,7 +678,7 @@ Buffer.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 8, this.length);
-  return internal.readDoubleLE(this, offset);
+  return binding.readDoubleLE(this, offset);
 };
 
 
@@ -687,7 +686,7 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 8, this.length);
-  return internal.readDoubleBE(this, offset);
+  return binding.readDoubleBE(this, offset);
 };
 
 
@@ -910,7 +909,7 @@ Buffer.prototype.writeFloatLE = function writeFloatLE(val, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkFloat(this, val, offset, 4);
-  internal.writeFloatLE(this, val, offset);
+  binding.writeFloatLE(this, val, offset);
   return offset + 4;
 };
 
@@ -920,7 +919,7 @@ Buffer.prototype.writeFloatBE = function writeFloatBE(val, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkFloat(this, val, offset, 4);
-  internal.writeFloatBE(this, val, offset);
+  binding.writeFloatBE(this, val, offset);
   return offset + 4;
 };
 
@@ -930,7 +929,7 @@ Buffer.prototype.writeDoubleLE = function writeDoubleLE(val, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkFloat(this, val, offset, 8);
-  internal.writeDoubleLE(this, val, offset);
+  binding.writeDoubleLE(this, val, offset);
   return offset + 8;
 };
 
@@ -940,7 +939,7 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE(val, offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkFloat(this, val, offset, 8);
-  internal.writeDoubleBE(this, val, offset);
+  binding.writeDoubleBE(this, val, offset);
   return offset + 8;
 };
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -636,25 +636,6 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
   proto->ForceSet(env->offset_string(),
                   Uint32::New(env->isolate(), 0),
                   v8::ReadOnly);
-
-  CHECK(args[1]->IsObject());
-
-  Local<Object> internal = args[1].As<Object>();
-  ASSERT(internal->IsObject());
-
-  env->SetMethod(internal, "byteLength", ByteLength);
-  env->SetMethod(internal, "compare", Compare);
-  env->SetMethod(internal, "fill", Fill);
-
-  env->SetMethod(internal, "readDoubleBE", ReadDoubleBE);
-  env->SetMethod(internal, "readDoubleLE", ReadDoubleLE);
-  env->SetMethod(internal, "readFloatBE", ReadFloatBE);
-  env->SetMethod(internal, "readFloatLE", ReadFloatLE);
-
-  env->SetMethod(internal, "writeDoubleBE", WriteDoubleBE);
-  env->SetMethod(internal, "writeDoubleLE", WriteDoubleLE);
-  env->SetMethod(internal, "writeFloatBE", WriteFloatBE);
-  env->SetMethod(internal, "writeFloatLE", WriteFloatLE);
 }
 
 
@@ -662,8 +643,23 @@ void Initialize(Handle<Object> target,
                 Handle<Value> unused,
                 Handle<Context> context) {
   Environment* env = Environment::GetCurrent(context);
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "setupBufferJS"),
-              env->NewFunctionTemplate(SetupBufferJS)->GetFunction());
+
+  env->SetMethod(target, "setupBufferJS", SetupBufferJS);
+
+  env->SetMethod(target, "byteLength", ByteLength);
+  env->SetMethod(target, "byteLength", ByteLength);
+  env->SetMethod(target, "compare", Compare);
+  env->SetMethod(target, "fill", Fill);
+
+  env->SetMethod(target, "readDoubleBE", ReadDoubleBE);
+  env->SetMethod(target, "readDoubleLE", ReadDoubleLE);
+  env->SetMethod(target, "readFloatBE", ReadFloatBE);
+  env->SetMethod(target, "readFloatLE", ReadFloatLE);
+
+  env->SetMethod(target, "writeDoubleBE", WriteDoubleBE);
+  env->SetMethod(target, "writeDoubleLE", WriteDoubleLE);
+  env->SetMethod(target, "writeFloatBE", WriteFloatBE);
+  env->SetMethod(target, "writeFloatLE", WriteFloatLE);
 }
 
 


### PR DESCRIPTION
Remove `internal` object and expose functions directly on binding.
This makes possible to simply use internal functions in other builtin
modules.

R=@trevnorris 