### PR TITLE
http: introduce `getAllHeaders()`

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -381,6 +381,15 @@ Example:
 
     var contentType = response.getHeader('content-type');
 
+### response.getAllHeaders()
+
+Reads out all headers that are already been queued but not yet sent to the
+client. This can only be called before headers get implicitly flushed.
+
+Example:
+
+    var headers = response.getAllHeaders();
+
 ### response.removeHeader(name)
 
 Removes a header that's queued for implicit sending.

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -337,6 +337,14 @@ OutgoingMessage.prototype.getHeader = function(name) {
 };
 
 
+OutgoingMessage.prototype.getAllHeaders = function() {
+  if (!this._headers)
+    return;
+  else
+    return util._extend({}, this._headers);
+};
+
+
 OutgoingMessage.prototype.removeHeader = function(name) {
   if (arguments.length < 1) {
     throw new Error('`name` is required for removeHeader(name).');

--- a/test/parallel/test-http-header-get-all.js
+++ b/test/parallel/test-http-header-get-all.js
@@ -1,0 +1,23 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+// Verify that ServerResponse.getHeader() works correctly even after
+// the response header has been sent. Issue 752 on github.
+
+var rando = Math.random();
+var expected = util._extend({}, {
+  'X-Random-Thing': rando,
+});
+var server = http.createServer(function(req, res) {
+  res.setHeader('X-Random-Thing', rando);
+  headers = res.getAllHeaders();
+  res.end('hello');
+  assert.strictEqual(res.getAllHeaders(), null);
+});
+server.listen(common.PORT, function() {
+  http.get({port: common.PORT}, function(resp) {
+    assert.deepEqual(response.headers, expected);
+    server.close();
+  });
+});


### PR DESCRIPTION
Succeeds the patch proposed in #170

R=@chrisdickinson, cc @iankronquist