### PR TITLE
benchmark: add csv and plotting script

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -3,8 +3,14 @@ var fs = require('fs');
 var path = require('path');
 var spawn = require('child_process').spawn;
 
-var silent = +process.env.NODE_BENCH_SILENT;
-var outputFormat = process.env.OUTPUT_FORMAT || 'default';
+var outputFormat = process.env.OUTPUT_FORMAT ||
+                   (+process.env.NODE_BENCH_SILENT ? 'silent' : false) ||
+                   'default';
+
+// verify outputFormat
+if (['default', 'csv', 'silent'].indexOf(outputFormat) == -1) {
+  throw new Error('OUTPUT_FORMAT set to invalid value');
+}
 
 exports.PORT = process.env.PORT || 12346;
 
@@ -211,12 +217,10 @@ Benchmark.prototype.end = function(operations) {
 Benchmark.prototype.report = function(value) {
   var heading = this.getHeading();
 
-  if (!silent) {
-    if (outputFormat == 'default')
-      console.log('%s: %s', heading, value.toFixed(5));
-    else if (outputFormat == 'csv')
-      console.log('%s,%s', heading, value.toFixed(5));
-  }
+  if (outputFormat == 'default')
+    console.log('%s: %s', heading, value.toFixed(5));
+  else if (outputFormat == 'csv')
+    console.log('%s,%s', heading, value.toFixed(5));
 
   process.exit(0);
 };
@@ -232,7 +236,5 @@ Benchmark.prototype.getHeading = function() {
     return this._name + ',' + Object.keys(conf).map(function(key) {
       return conf[key];
     }).join(',');
-  } else {
-    throw new Error('OUTPUT_FORMAT set to invalid value');
   }
 };

--- a/benchmark/plot_csv.R
+++ b/benchmark/plot_csv.R
@@ -1,0 +1,38 @@
+#!/usr/bin/env Rscript
+
+# To use this to graph some benchmarks, install R (http://www.r-project.org/)
+# and ggplot (http://ggplot2.org/).
+#
+# Once installed, you can generate some CSV output with a command like this:
+#
+#     $ OUTPUT_FORMAT=csv iojs benchmark/http/client-request-body.js > data.csv
+#     $ ./benchmark/plot_csv.R data.csv data.png bytes type
+#
+# Where the 3rd argument to this script is the graph's X coordinate, the 4th is
+# how the output is grouped, and the Y coordinate defaults to result.
+
+library(methods)
+library(ggplot2)
+
+# get info from arguments
+args <- commandArgs(TRUE)
+
+csvFilename <- args[1]
+graphFilename <- args[2]
+
+xCoordinate <- args[3]
+groupBy <- args[4]
+
+# read data
+data <- read.csv(file = csvFilename, head = TRUE)
+
+# plot and save
+plot <- ggplot(data = data, aes_string(x = xCoordinate, y = 'result', col = groupBy)) +
+        geom_point(size = 5) +
+        ggtitle(data$filename)
+
+png(filename = graphFilename, width = 560, height = 480, units = 'px')
+print(plot)
+graphics.off()
+
+cat(paste('Saved to', graphFilename, '\n'))


### PR DESCRIPTION
This pull request consists of two commits:

> [`dda466b`](https://github.com/brendanashworth/io.js/commit/dda466b753850fd0f54e690021390130482e4f82): Adds an environment variable `OUTPUT_FORMAT` to be parsed when a benchmark is ran, that now allows for CSV output when it is set to `csv`. It will default back to standard behavior when it is not set, or when it is set to `default`. Best for shell redirection into a `.csv` file.

For each commit, longer and better explanations are in each commit description.

> [`394735d`](https://github.com/brendanashworth/io.js/commit/394735d2dbe85f7bcb8f1b265f132bdc6233a1a4): Adds a script for graphing CSV output of the benchmarks that allows for easy X coordinates and grouping. [Here is the given example](http://pasteboard.co/10p9OxUT.png).

The reasoning behind the new graphing script is that it makes it easier to visualize where the improvements can be made when optimizing, allows for more visual speed comparisons between commits, and that the already-present `plot.R` script hasn't been touched for a long time and doesn't do the same functionality.