### PR TITLE
crypto: fix to check ext method for shared lib

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1099,15 +1099,9 @@ void SSLWrap<Base>::OnClientHello(void* arg,
 
 
 static bool SafeX509ExtPrint(BIO* out, X509_EXTENSION* ext) {
-  // Only alt_name is escaped at the moment
-  if (OBJ_obj2nid(ext->object) != NID_subject_alt_name)
-    return false;
-
   const X509V3_EXT_METHOD* method = X509V3_EXT_get(ext);
-  if (method == NULL || method->it == NULL)
-    return false;
 
-  if (method->i2v != reinterpret_cast<X509V3_EXT_I2V>(i2v_GENERAL_NAMES))
+  if (method != X509V3_EXT_get_nid(NID_subject_alt_name))
     return false;
 
   const unsigned char* p = ext->value->data;


### PR DESCRIPTION
In the case of using openssl with shared library, reinterpret_cast<X509V3_EXT_I2V>(i2v_GENERAL_NAMES)) refers plt pointer so that SafeX509ExtPrint returns false.

Fix it to check it with nid of ext method.

This patch originally was created by Fedor Indutny.

Fixes: https://github.com/iojs/io.js/issues/617

Reviewer: @indutny @bnoordhuis 