### PR TITLE
build: make test-ci target produce tap output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci: test-build
-	$(PYTHON) tools/test.py -J parallel sequential message addons
+	$(PYTHON) tools/test.py -J -p tap parallel sequential message addons
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release


### PR DESCRIPTION
Make `make test-ci` print output in TAP format.  The default output
doesn't show up in the Jenkins web view until the test suite finishes.
The web view is line buffered and the test runner doesn't emit newlines
until it's done.

A nice side effect is that the test runner now prints each test's
running time.

R=@rvagg?  I assume the Jenkins TAP plugin must be activated first.