### PR TITLE
doc: Close code span correctly

### DIFF
--- a/doc/api/child_process.markdown
+++ b/doc/api/child_process.markdown
@@ -177,7 +177,7 @@ Example:
 
 ### child.connected
 
-* {Boolean} Set to false after `.disconnect' is called
+* {Boolean} Set to false after `.disconnect` is called
 
 If `.connected` is false, it is no longer possible to send messages.
 


### PR DESCRIPTION
The code span is closed with a straight quote instead of the correct
back tick being used.