### PR TITLE
doc: disable font ligatures

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -1,6 +1,8 @@
 /*--------------------- Layout and Typography ----------------------------*/
 html {
   -webkit-font-smoothing: antialiased;
+  -webkit-font-variant-ligatures: none;
+          font-variant-ligatures: none;
 }
 
 body {


### PR DESCRIPTION
Very minor style issue here. The Lato font used in doc forms a 'fi' ligature by default, which I don't particulary like in a technical documentation. See the word 'filename' below:

Before:
![screenshot_32](https://cloud.githubusercontent.com/assets/115237/6164853/57a62b86-b2a3-11e4-98aa-5dd660e48805.png)

After:
![screenshot_33](https://cloud.githubusercontent.com/assets/115237/6164851/54ce2b8e-b2a3-11e4-8c64-ee1bdfb0639d.png)