### PR TITLE
util: fixed behavior of isObject()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -543,7 +543,8 @@ function isRegExp(re) {
 exports.isRegExp = isRegExp;
 
 function isObject(arg) {
-  return arg !== null && typeof arg === 'object';
+  var type = typeof arg;
+  return type === 'function' || type === 'object' && !!arg;
 }
 exports.isObject = isObject;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -544,7 +544,7 @@ exports.isRegExp = isRegExp;
 
 function isObject(arg) {
   var type = typeof arg;
-  return type === 'function' || type === 'object' && !!arg;
+  return type === 'function' || type === 'object' && arg !== null;
 }
 exports.isObject = isObject;
 

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -50,6 +50,14 @@ assert.equal(true, util.isError(Object.create(Error.prototype)));
 
 // isObject
 assert.ok(util.isObject({}) === true);
+assert.ok(util.isObject(function() {}) === true);
+assert.ok(util.isObject([1, 2, 3]) === true);
+assert.ok(util.isObject(new String('string')) === true);
+assert.ok(util.isObject(null) === false);
+assert.ok(util.isObject(undefined) === false);
+assert.ok(util.isObject('string') === false);
+assert.ok(util.isObject(42) === false);
+assert.ok(util.isObject(true) === false);
 
 // isPrimitive
 assert.equal(false, util.isPrimitive({}));


### PR DESCRIPTION
This fixes issue #743.

Brought the behavior of util.isObject() in line with expected
behavior, inspired by utility libraries like underscore & lodash.
In particular, it now returns true for functions.

Added eight tests for isObject() to ensure it behaves as
expected for a wide variety of input, including cases where it
is expected to return false.