### PR TITLE
doc: mark class should have a reasonable contrast ratio

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -217,7 +217,6 @@ h1 span, h2 span, h3 span, h4 span {
   display: block;
   top: 0;
   right: 0;
-  opacity: 0.3;
 }
 
 h1 span:hover, h2 span:hover, h3 span:hover, h4 span:hover {
@@ -401,7 +400,7 @@ span.type {
 span > .mark,
 span > .mark:visited {
   font-size: 18px;
-  color: #ccc;
+  color: #707070;
   position: absolute;
   top: 0px;
   right: 0px;


### PR DESCRIPTION
The mark class coupled with the opacity applied from the header span makes it hard to see the hashtag next to each header.

I only knew the hashtag's existed after running an [accessibility audit tool](https://github.com/GoogleChrome/accessibility-developer-tools) on the page. I used a [contrast checker](http://webaim.org/resources/contrastchecker/) to figure out which color to use.

![before](https://cloud.githubusercontent.com/assets/690856/6175211/f6c9f298-b2b1-11e4-84ba-13faf5224680.png)
![after](https://cloud.githubusercontent.com/assets/690856/6175212/f6cf7128-b2b1-11e4-9e08-86baacf9558c.png)
