### PR TITLE
tls: more secure defaults

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -703,10 +703,10 @@ Server.prototype.setOptions = function(options) {
   if (options.sessionTimeout) this.sessionTimeout = options.sessionTimeout;
   if (options.ticketKeys) this.ticketKeys = options.ticketKeys;
   var secureOptions = options.secureOptions || 0;
-  if (options.honorCipherOrder)
-    this.honorCipherOrder = true;
+  if (options.honorCipherOrder !== undefined)
+    this.honorCipherOrder = !!options.honorCipherOrder;
   else
-    this.honorCipherOrder = false;
+    this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.sessionIdContext) {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -13,11 +13,24 @@ exports.CLIENT_RENEG_WINDOW = 600;
 
 exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 
-exports.DEFAULT_CIPHERS =
-    // TLS 1.2
-    'ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:AES128-GCM-SHA256:' +
-    // TLS 1.0
-    'RC4:HIGH:!MD5:!aNULL';
+exports.DEFAULT_CIPHERS = [
+    'ECDHE-RSA-AES256-SHA384',
+    'DHE-RSA-AES256-SHA384',
+    'ECDHE-RSA-AES256-SHA256',
+    'DHE-RSA-AES256-SHA256',
+    'ECDHE-RSA-AES128-SHA256',
+    'DHE-RSA-AES128-SHA256',
+    'HIGH',
+    '!aNULL',
+    '!eNULL',
+    '!EXPORT',
+    '!DES',
+    '!RC4',
+    '!MD5',
+    '!PSK',
+    '!SRP',
+    '!CAMELLIA'
+].join(':');
 
 exports.DEFAULT_ECDH_CURVE = 'prime256v1';
 


### PR DESCRIPTION
This changes the TLS defaults to be more secure. It includes these changes:

1. Remove the `AES128-GCM-SHA256` cipherset. It seems Chrome likes to choose it over an more secure ECDHE variant with `honorCipherOrder` enabled.
2. Disable the insecure RC4 algorithm completely. This doesn't seem to cause any new incompatibilties with clients, as IE6 can't handshake with the current defaults right now.
3. Enable `honorCipherOrder` by default. This probably should've been the default for a while now.

Combined with DH parameters > 1024 bit and HSTS, this gives an A+ rating on the OpenSSL test (was an B rating before). All clients except IE on Windows XP achieve Forward Secrecy.

Motivating issue: #818
CC: @indutny

Ciphers before this change:
````
Android 2.3.7                TLS 1.0    TLS_RSA_WITH_RC4_128_SHA (0x5)
Android 4.0.4                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)   
Android 4.1.1                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)   
Android 4.2.2                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)   
Android 4.3                  TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)   
Android 4.4.2                TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (0xc030)
BingBot Dec 2013             TLS 1.0    TLS_RSA_WITH_AES_128_CBC_SHA (0x2f) 
BingPreview Jun 2014         TLS 1.0    TLS_DHE_RSA_WITH_AES_256_CBC_SHA (0x39)
Chrome 39 / OS X             TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (0xc02f)
Firefox 31.3.0 ESR / Win 7   TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (0xc02f)
Firefox 34 / OS X            TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (0xc02f)
Googlebot Jun 2014           TLS 1.0    TLS_ECDHE_RSA_WITH_RC4_128_SHA (0xc011)
IE 6 / XP                    Protocol or cipher suite mismatch
IE 7 / Vista                 TLS 1.0    TLS_RSA_WITH_AES_128_CBC_SHA (0x2f)
IE 8 / XP                    TLS 1.0    TLS_RSA_WITH_RC4_128_SHA (0x5)
IE 8-10 / Win 7              TLS 1.0    TLS_RSA_WITH_AES_128_CBC_SHA (0x2f)
IE 11 / Win 7                TLS 1.2    TLS_RSA_WITH_AES_128_CBC_SHA256 (0x3c)
IE 11 / Win 10 Preview       TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (0xc030)
IE 11 / Win 8.1              TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (0xc028)
IE Mobile 10 / Win Phone 8.0 TLS 1.0    TLS_RSA_WITH_AES_128_CBC_SHA (0x2f) 
IE Mobile 11 / Win Phone 8.1 TLS 1.2    TLS_RSA_WITH_AES_128_CBC_SHA256 (0x3c)
Java 6u45                    TLS 1.0    TLS_RSA_WITH_RC4_128_SHA (0x5)
Java 7u25                    TLS 1.0    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (0xc013)   
Java 8b132                   TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)
OpenSSL 0.9.8y               TLS 1.0    TLS_DHE_RSA_WITH_AES_256_CBC_SHA (0x39)
OpenSSL 1.0.1h               TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (0xc030)
Safari 5.1.9 / OS X 10.6.8   TLS 1.0    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (0xc013)   
Safari 6 / iOS 6.0.1         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (0xc028)
Safari 7 / iOS 7.1           TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (0xc028)
Safari 8 / iOS 8.0 Beta      TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (0xc028)
Safari 6.0.4 / OS X 10.8.4   TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)   
Safari 7 / OS X 10.9         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 (0xc028)
Yahoo Slurp Jun 2014         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (0xc030)
YandexBot Sep 2014           TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (0xc030)
````

Ciphers after this change:
````
Android 2.3.7                TLS 1.0    TLS_DHE_RSA_WITH_AES_128_CBC_SHA (0x33)  
Android 4.0.4                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Android 4.1.1                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Android 4.2.2                TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Android 4.3                  TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Android 4.4.2                TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
BingBot Dec 2013             TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
BingPreview Jun 2014         TLS 1.0    TLS_DHE_RSA_WITH_AES_256_CBC_SHA (0x39)  
Chrome 39 / OS X             TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Firefox 31.3.0 ESR / Win 7   TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Firefox 34 / OS X            TLS 1.2    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Googlebot Jun 2014           TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
IE 6 / XP                    Protocol or cipher suite mismatch
IE 7 / Vista                 TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
IE 8 / XP                    TLS 1.0    TLS_RSA_WITH_3DES_EDE_CBC_SHA (0xa)
IE 8-10 / Win 7              TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
IE 11 / Win 7                TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
IE 11 / Win 10 Preview       TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
IE 11 / Win 8.1              TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
IE Mobile 10 / Win Phone 8.0 TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
IE Mobile 11 / Win Phone 8.1 TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Java 6u45                    TLS 1.0    TLS_DHE_RSA_WITH_AES_128_CBC_SHA (0x33)  
Java 7u25                    TLS 1.0    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (0xc013)  
Java 8b132                   TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
OpenSSL 0.9.8y               TLS 1.0    TLS_DHE_RSA_WITH_AES_256_CBC_SHA (0x39)  
OpenSSL 1.0.1h               TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Safari 5.1.9 / OS X 10.6.8   TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Safari 6 / iOS 6.0.1         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Safari 7 / iOS 7.1           TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Safari 8 / iOS 8.0 Beta      TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Safari 6.0.4 / OS X 10.8.4   TLS 1.0    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)  
Safari 7 / OS X 10.9         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
Yahoo Slurp Jun 2014         TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
YandexBot Sep 2014           TLS 1.2    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)  
````

Haven't touched the docs yet (and I probably need some assistance on these), as I'd like to get some feedback on this first.