### PR TITLE
http: don't confuse automatic headers for others

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -10,12 +10,12 @@ const CRLF = common.CRLF;
 const chunkExpression = common.chunkExpression;
 const debug = common.debug;
 
-const connectionExpression = /Connection/i;
-const transferEncodingExpression = /Transfer-Encoding/i;
+const connectionExpression = /^Connection$/i;
+const transferEncodingExpression = /^Transfer-Encoding$/i;
 const closeExpression = /close/i;
-const contentLengthExpression = /Content-Length/i;
-const dateExpression = /Date/i;
-const expectExpression = /Expect/i;
+const contentLengthExpression = /^Content-Length$/i;
+const dateExpression = /^Date$/i;
+const expectExpression = /^Expect$/i;
 
 const automaticHeaders = {
   connection: true,

--- a/test/parallel/test-http-automatic-headers.js
+++ b/test/parallel/test-http-automatic-headers.js
@@ -1,0 +1,30 @@
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  res.setHeader('X-Date', 'foo');
+  res.setHeader('X-Connection', 'bar');
+  res.setHeader('X-Transfer-Encoding', 'baz');
+  res.end();
+});
+server.listen(common.PORT);
+
+server.on('listening', function() {
+  var agent = new http.Agent({ port: common.PORT, maxSockets: 1 });
+  http.get({
+    port: common.PORT,
+    path: '/hello',
+    agent: agent
+  }, function(res) {
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers['x-date'], 'foo');
+    assert.equal(res.headers['x-connection'], 'bar');
+    assert.equal(res.headers['x-transfer-encoding'], 'baz');
+    assert(res.headers['date']);
+    assert.equal(res.headers['connection'], 'keep-alive');
+    assert.equal(res.headers['transfer-encoding'], 'chunked');
+    server.close();
+    agent.destroy();
+  });
+});

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -41,7 +41,8 @@ var proxy = net.createServer(function(clientSocket) {
       // Verify the CONNECT request
       assert.equal('CONNECT localhost:' + common.PORT + ' HTTP/1.1\r\n' +
                    'Proxy-Connections: keep-alive\r\n' +
-                   'Host: localhost:' + proxyPort + '\r\n\r\n',
+                   'Host: localhost:' + proxyPort + '\r\n' +
+                   'Connection: close\r\n\r\n',
                    chunk);
 
       console.log('PROXY: got CONNECT request');


### PR DESCRIPTION
If you set a custom http header which includes eg. the string `Date`, then http will not automatic send the `Date` header. This is also true for other automatic http headers.

Btw, there is no header named `Proxy-Connections` which is used in the test I'm changing.