### PR TITLE
test: verify fields in spawn{Sync} errors

### DIFF
--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -6,11 +6,16 @@ var assert = require('assert');
 var errors = 0;
 
 var enoentPath = 'foo123';
+var spawnargs = ['bar'];
 assert.equal(common.fileExists(enoentPath), false);
 
-var enoentChild = spawn(enoentPath);
+var enoentChild = spawn(enoentPath, spawnargs);
 enoentChild.on('error', function (err) {
+  assert.equal(err.code, 'ENOENT');
+  assert.equal(err.errno, 'ENOENT');
+  assert.equal(err.syscall, 'spawn ' + enoentPath);
   assert.equal(err.path, enoentPath);
+  assert.deepEqual(err.spawnargs, spawnargs);
   errors++;
 });
 

--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -23,8 +23,13 @@ console.log('sleep exited', stop);
 assert.strictEqual(stop[0], 1, 'sleep should not take longer or less than 1 second');
 
 // Error test when command does not exist
-var ret_err = spawnSync('command_does_not_exist');
-assert.strictEqual(ret_err.error.code, 'ENOENT');
+var ret_err = spawnSync('command_does_not_exist', ['bar']).error;
+
+assert.strictEqual(ret_err.code, 'ENOENT');
+assert.strictEqual(ret_err.errno, 'ENOENT');
+assert.strictEqual(ret_err.syscall, 'spawnSync command_does_not_exist');
+assert.strictEqual(ret_err.path, 'command_does_not_exist');
+assert.deepEqual(ret_err.spawnargs, ['bar']);
 
 // Verify that the cwd option works - GH #7824
 (function() {


### PR DESCRIPTION
This commit validates the properties of `ENOENT` error objects returned by `spawn()` and `spawnSync()`. This represents the tests requested in #721.

R=@rvagg 