### PR TITLE
iojs: introduce internal modules

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const FreeList = require('freelist').FreeList;
+const FreeList = require('internal/freelist').FreeList;
 const HTTPParser = process.binding('http_parser').HTTPParser;
 
 const incoming = require('_http_incoming');

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// This is a free list to avoid creating so many of the same object.
+exports.FreeList = function(name, max, constructor) {
+  this.name = name;
+  this.constructor = constructor;
+  this.max = max;
+  this.list = [];
+};
+
+
+exports.FreeList.prototype.alloc = function() {
+  //debug("alloc " + this.name + " " + this.list.length);
+  return this.list.length ? this.list.shift() :
+                            this.constructor.apply(this, arguments);
+};
+
+
+exports.FreeList.prototype.free = function(obj) {
+  //debug("free " + this.name + " " + this.list.length);
+  if (this.list.length < this.max) {
+    this.list.push(obj);
+    return true;
+  }
+  return false;
+};

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -10,14 +10,12 @@ exports.FreeList = function(name, max, constructor) {
 
 
 exports.FreeList.prototype.alloc = function() {
-  //debug("alloc " + this.name + " " + this.list.length);
   return this.list.length ? this.list.shift() :
                             this.constructor.apply(this, arguments);
 };
 
 
 exports.FreeList.prototype.free = function(obj) {
-  //debug("free " + this.name + " " + this.list.length);
   if (this.list.length < this.max) {
     this.list.push(obj);
     return true;

--- a/lib/module.js
+++ b/lib/module.js
@@ -200,7 +200,7 @@ Module._nodeModulePaths = function(from) {
 
 
 Module._resolveLookupPaths = function(request, parent) {
-  if (NativeModule.exists(request)) {
+  if (NativeModule.nonInternalExists(request)) {
     return [request, []];
   }
 
@@ -262,7 +262,7 @@ Module._load = function(request, parent, isMain) {
     return cachedModule.exports;
   }
 
-  if (NativeModule.exists(filename)) {
+  if (NativeModule.nonInternalExists(filename)) {
     // REPL is a special case, because it needs the real require.
     if (filename == 'repl') {
       var replModule = new Module('repl');
@@ -299,7 +299,7 @@ Module._load = function(request, parent, isMain) {
 };
 
 Module._resolveFilename = function(request, parent) {
-  if (NativeModule.exists(request)) {
+  if (NativeModule.nonInternalExists(request)) {
     return request;
   }
 

--- a/node.gyp
+++ b/node.gyp
@@ -70,7 +70,7 @@
       'lib/vm.js',
       'lib/zlib.js',
 
-      'lib/internal/freelist.js'
+      'lib/internal/freelist.js',
     ],
   },
 

--- a/node.gyp
+++ b/node.gyp
@@ -69,6 +69,8 @@
       'lib/v8.js',
       'lib/vm.js',
       'lib/zlib.js',
+
+      'lib/internal/freelist.js'
     ],
   },
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3133,6 +3133,9 @@ static void ParseArgs(int* argc,
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
       icu_data_dir = arg + 15;
 #endif
+    } else if (strcmp(arg, "--expose-internals") == 0 ||
+               strcmp(arg, "--expose_internals") == 0) {
+      // consumed in js
     } else {
       // V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;

--- a/src/node.js
+++ b/src/node.js
@@ -838,6 +838,14 @@
     return NativeModule._source.hasOwnProperty(id);
   };
 
+  NativeModule.nonInternalExists = function(id) {
+    return NativeModule.exists(id) && !NativeModule.isInternal(id);
+  };
+
+  NativeModule.isInternal = function(id) {
+    return id.startsWith('internal/');
+  };
+
   NativeModule.getSource = function(id) {
     return NativeModule._source[id];
   };

--- a/src/node.js
+++ b/src/node.js
@@ -838,13 +838,22 @@
     return NativeModule._source.hasOwnProperty(id);
   };
 
-  NativeModule.nonInternalExists = function(id) {
-    return NativeModule.exists(id) && !NativeModule.isInternal(id);
-  };
+  if (process.env['NODE_EXPOSE_INTERNALS']) {
+    NativeModule.nonInternalExists = NativeModule.exists;
 
-  NativeModule.isInternal = function(id) {
-    return id.startsWith('internal/');
-  };
+    NativeModule.isInternal = function(id) {
+      return false;
+    };
+  } else {
+    NativeModule.nonInternalExists = function(id) {
+      return NativeModule.exists(id) && !NativeModule.isInternal(id);
+    };
+
+    NativeModule.isInternal = function(id) {
+      return id.startsWith('internal/');
+    };
+  }
+
 
   NativeModule.getSource = function(id) {
     return NativeModule._source[id];

--- a/src/node.js
+++ b/src/node.js
@@ -838,7 +838,11 @@
     return NativeModule._source.hasOwnProperty(id);
   };
 
-  if (process.env['NODE_EXPOSE_INTERNALS']) {
+  const EXPOSE_INTERNALS = process.execArgv.some(function(arg) {
+    return arg.match(/^--expose[-_]internals$/);
+  });
+
+  if (EXPOSE_INTERNALS) {
     NativeModule.nonInternalExists = NativeModule.exists;
 
     NativeModule.isInternal = function(id) {

--- a/test/fixtures/internal-modules/index.js
+++ b/test/fixtures/internal-modules/index.js
@@ -1,3 +1,1 @@
-'use strict';
-
 module.exports = require('internal/freelist');

--- a/test/fixtures/internal-modules/node_modules/internal/freelist.js
+++ b/test/fixtures/internal-modules/node_modules/internal/freelist.js
@@ -1,0 +1,1 @@
+module.exports = true;

--- a/test/fixtures/internal-modules/node_modules/internal/freelist.js
+++ b/test/fixtures/internal-modules/node_modules/internal/freelist.js
@@ -1,1 +1,1 @@
-module.exports = true;
+module.exports = 42;

--- a/test/parallel/test-internal-modules-expose.js
+++ b/test/parallel/test-internal-modules-expose.js
@@ -1,0 +1,6 @@
+// Flags: --expose_internals
+
+var common = require('../common');
+var assert = require('assert');
+
+assert.equal(typeof require('internal/freelist').FreeList, 'function');

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -5,4 +5,4 @@ assert.throws(function() {
   require('internal/freelist');
 });
 
-assert(require('../fixtures/internal-modules') === true);
+assert(require('../fixtures/internal-modules') === 42);

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -1,0 +1,8 @@
+var common = require('../common');
+var assert = require('assert');
+
+assert.throws(function() {
+  require('internal/freelist');
+});
+
+assert(require('../fixtures/internal-modules') === true);

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -238,11 +238,11 @@ static const struct _native natives[] = {
 
 
 NATIVE_DECLARATION = """\
-  { "%(id)s", %(id)s_native, sizeof(%(id)s_native)-1 },
+  { "%(id)s", %(escaped_id)s_native, sizeof(%(escaped_id)s_native)-1 },
 """
 
 SOURCE_DECLARATION = """\
-  const char %(id)s_native[] = { %(data)s };
+  const char %(escaped_id)s_native[] = { %(data)s };
 """
 
 
@@ -293,16 +293,18 @@ def JS2C(source, target):
     lines = ExpandMacros(lines, macros)
     lines = CompressScript(lines, do_jsmin)
     data = ToCArray(s, lines)
-    id = os.path.basename(str(s)).split('.')[0]
+    id = '/'.join((str(s).split(os.sep)[1:])).split('.')[0]
     if delay: id = id[:-6]
     if delay:
       delay_ids.append((id, len(lines)))
     else:
       ids.append((id, len(lines)))
-    source_lines.append(SOURCE_DECLARATION % { 'id': id, 'data': data })
-    source_lines_empty.append(SOURCE_DECLARATION % { 'id': id, 'data': 0 })
-    native_lines.append(NATIVE_DECLARATION % { 'id': id })
-  
+
+    escaped_id = id.replace('/', '$')
+    source_lines.append(SOURCE_DECLARATION % { 'id': id, 'escaped_id': escaped_id, 'data': data })
+    source_lines_empty.append(SOURCE_DECLARATION % { 'id': id, 'escaped_id': escaped_id, 'data': 0 })
+    native_lines.append(NATIVE_DECLARATION % { 'id': id, 'escaped_id': escaped_id })
+
   # Build delay support functions
   get_index_cases = [ ]
   get_script_source_cases = [ ]

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -293,7 +293,7 @@ def JS2C(source, target):
     lines = ExpandMacros(lines, macros)
     lines = CompressScript(lines, do_jsmin)
     data = ToCArray(s, lines)
-    id = '/'.join((str(s).split(os.sep)[1:])).split('.')[0]
+    id = '/'.join(re.split('/|\\\\', s)[1:]).split('.')[0]
     if delay: id = id[:-6]
     if delay:
       delay_ids.append((id, len(lines)))
@@ -301,9 +301,20 @@ def JS2C(source, target):
       ids.append((id, len(lines)))
 
     escaped_id = id.replace('/', '$')
-    source_lines.append(SOURCE_DECLARATION % { 'id': id, 'escaped_id': escaped_id, 'data': data })
-    source_lines_empty.append(SOURCE_DECLARATION % { 'id': id, 'escaped_id': escaped_id, 'data': 0 })
-    native_lines.append(NATIVE_DECLARATION % { 'id': id, 'escaped_id': escaped_id })
+    source_lines.append(SOURCE_DECLARATION % {
+      'id': id,
+      'escaped_id': escaped_id,
+      'data': data
+    })
+    source_lines_empty.append(SOURCE_DECLARATION % {
+      'id': id,
+      'escaped_id': escaped_id,
+      'data': 0
+    })
+    native_lines.append(NATIVE_DECLARATION % {
+      'id': id,
+      'escaped_id': escaped_id
+    })
 
   # Build delay support functions
   get_index_cases = [ ]


### PR DESCRIPTION
Internal modules can be used to share private code between public modules without risk to expose private APIs to the user.

Later some flag (build time or runtime) could be added for making unit-testing possible.

#569

R=@iojs/owners @iojs/collaborators 