### PR TITLE
fs: properly handle fd passed to truncate()

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -106,7 +106,8 @@ Synchronous ftruncate(2).
 ## fs.truncate(path, len, callback)
 
 Asynchronous truncate(2). No arguments other than a possible exception are
-given to the completion callback.
+given to the completion callback. A file descriptor can also be passed as the
+first argument. In this case, `fs.ftruncate()` is called.
 
 ## fs.truncateSync(path, len)
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -679,9 +679,7 @@ fs.renameSync = function(oldPath, newPath) {
 
 fs.truncate = function(path, len, callback) {
   if (typeof path === 'number') {
-    var req = new FSReqWrap();
-    req.oncomplete = callback;
-    return fs.ftruncate(path, len, req);
+    return fs.ftruncate(path, len, callback);
   }
   if (typeof len === 'function') {
     callback = len;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -65,8 +65,12 @@ function maybeCallback(cb) {
 // for callbacks that are passed to the binding layer, callbacks that are
 // invoked from JS already run in the proper scope.
 function makeCallback(cb) {
-  if (typeof cb !== 'function') {
+  if (cb === undefined) {
     return rethrow();
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('callback must be a function');
   }
 
   return function() {

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -1,0 +1,27 @@
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+
+function test(cb) {
+  return function() {
+    // fs.stat() calls makeCallback() on its second argument
+    fs.stat(__filename, cb);
+  };
+}
+
+// Verify the case where a callback function is provided
+assert.doesNotThrow(test(function() {}));
+
+// Passing undefined calls rethrow() internally, which is fine
+assert.doesNotThrow(test(undefined));
+
+// Anything else should throw
+assert.throws(test(null));
+assert.throws(test(true));
+assert.throws(test(false));
+assert.throws(test(1));
+assert.throws(test(0));
+assert.throws(test('foo'));
+assert.throws(test(/foo/));
+assert.throws(test([]));
+assert.throws(test({}));

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -1,0 +1,25 @@
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var fs = require('fs');
+var tmp = common.tmpDir;
+if (!fs.existsSync(tmp))
+  fs.mkdirSync(tmp);
+var filename = path.resolve(tmp, 'truncate-file.txt');
+
+var success = 0;
+
+fs.writeFileSync(filename, 'hello world', 'utf8');
+var fd = fs.openSync(filename, 'r+');
+fs.truncate(fd, 5, function(err) {
+  assert.ok(!err);
+  assert.equal(fs.readFileSync(filename, 'utf8'), 'hello');
+  success++;
+});
+
+process.on('exit', function() {
+  fs.closeSync(fd);
+  fs.unlinkSync(filename);
+  assert.equal(success, 1);
+  console.log('ok');
+});


### PR DESCRIPTION
Currently, `fs.truncate()` silently fails when a file descriptor is passed as the first argument. This commit changes this behavior to properly call `fs.ftruncate()`. This commit also adds proper type checking to the callback provided to `makeCallback()`.

Port of https://github.com/joyent/node/pull/9161
