### PR TITLE
src: fix add-on builds, partially revert 8aed9d66

### DIFF
--- a/src/node_object_wrap.h
+++ b/src/node_object_wrap.h
@@ -36,7 +36,7 @@ class ObjectWrap {
 
 
   inline v8::Local<v8::Object> handle() {
-    return v8::Local<v8::Object>::New(handle_->GetIsolate(), persistent());
+    return handle(v8::Isolate::GetCurrent());
   }
 
 


### PR DESCRIPTION
Commit 8aed9d66 ("src: cleanup `Isolate::GetCurrent()`") breaks building
add-ons because of the following:

    In file included from ../node_modules/nan/nan.h:27:0,
                     from ../src/binding.cc:18:
    /home/bnoordhuis/src/v1.x/src/node_object_wrap.h: In member function
    'v8::Local<v8::Object> node::ObjectWrap::handle()':
    /home/bnoordhuis/src/v1.x/src/node_object_wrap.h:39:46: error: base
    operand of '->' has non-pointer type 'v8::Persistent<v8::Object>'
         return v8::Local<v8::Object>::New(handle_->GetIsolate(),
                                           persistent());

Mea culpa, I was one of the reviewers.

R=@vkurchatkin