### PR TITLE
process: chdir with callback implementation

### DIFF
--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -308,9 +308,11 @@ and process.argv:
 This causes io.js to emit an abort. This will cause io.js to exit and
 generate a core file.
 
-## process.chdir(directory)
+## process.chdir(path, callback)
 
 Changes the current working directory of the process or throws an exception if that fails.
+
+Example:
 
     console.log('Starting directory: ' + process.cwd());
     try {
@@ -321,6 +323,20 @@ Changes the current working directory of the process or throws an exception if t
       console.log('chdir: ' + err);
     }
 
+Or you may process asynchronously:
+
+    console.log('Starting directory: ' + process.cwd());
+    process.chdir('/tmp', function(err) {
+      if (err) throw err;
+      console.log('Working directory: ' + process.cwd());
+    });
+    console.log('Resulting directory: ' + process.cwd());
+
+which might result in output like:
+
+    Starting directory: /home/howard
+    Working directory: /tmp
+    Resulting directory: /home/howard
 
 
 ## process.cwd()

--- a/src/node.cc
+++ b/src/node.cc
@@ -1529,14 +1529,47 @@ static void Abort(const FunctionCallbackInfo<Value>& args) {
 static void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() != 1 || !args[0]->IsString()) {
-    return env->ThrowTypeError("Bad argument.");
-  }
+  if (args.Length() < 1)
+    return env->ThrowTypeError("path required");
+  if (!args[0]->IsString())
+    return env->ThrowTypeError("path must be a string");
+  if (!args[1]->IsUndefined() && !args[1]->IsFunction())
+    return env->ThrowTypeError("callback must be a function");
 
   node::Utf8Value path(args.GetIsolate(), args[0]);
-  int err = uv_chdir(*path);
-  if (err) {
-    return env->ThrowUVException(err, "uv_chdir");
+
+  if (args[1]->IsFunction()) {
+#ifdef _WIN32
+    // MAX_PATH is in characters, not bytes. Make sure we have enough
+    // headroom.
+    char init[MAX_PATH * 4];
+#else
+    char init[PATH_MAX];
+#endif
+
+    // Throw exception on setup and teardown, but not invocation of
+    // callback
+    size_t cwd_len = sizeof(init);
+    int err = uv_cwd(init, &cwd_len);
+    if (err) {
+      return env->ThrowUVException(err, "uv_cwd");
+    }
+
+    err = uv_chdir(*path);
+    /* we should pass the error into the callback invocation parameters */
+    Local<Function> callback_function = Local<Function>::Cast(args[1]);
+    callback_function->Call(env->context()->Global(), 0, NULL);
+
+    err = uv_chdir(init);
+    if (err) {
+      return env->ThrowUVException(err, "uv_chdir");
+    }
+
+  } else {
+    int err = uv_chdir(*path);
+    if (err) {
+      return env->ThrowUVException(err, "uv_chdir");
+    }
   }
 }
 

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+
+var initial_dir  = process.cwd();
+var expected_dir = initial_dir + '/test'
+
+/**
+ * Test Asynchronus
+ */
+process.chdir("test", function(err) {
+    if (err) throw err;
+
+    assert.equal(expected_dir, process.cwd(), "expected to be in a different directory");
+});
+assert.equal(initial_dir, process.cwd(), "expected to be in the initial directory");
+
+
+/**
+ * Test Synchronous
+ */
+process.chdir("test");
+assert.equal(expected_dir, process.cwd(), "expected to be in a different directory");
+
+/* Tear Down */
+process.chdir("..");
+assert.equal(initial_dir, process.cwd(), "expected to be in the initial directory");

--- a/test/sequential/test-chdir.js
+++ b/test/sequential/test-chdir.js
@@ -18,6 +18,6 @@ process.chdir('..');
 assert(process.cwd() == path.resolve(common.fixturesDir));
 fs.rmdirSync(dir);
 
-assert.throws(function() { process.chdir({}); }, TypeError, 'Bad argument.');
-assert.throws(function() { process.chdir(); }, TypeError, 'Bad argument.');
-assert.throws(function() { process.chdir("x", "y"); }, TypeError, 'Bad argument.');
+assert.throws(function() { process.chdir({}); }, TypeError, 'path must be a string');
+assert.throws(function() { process.chdir(); }, TypeError, 'path required');
+assert.throws(function() { process.chdir("x", "y"); }, TypeError, 'callback must be a function');


### PR DESCRIPTION
Add an optional callback argument to the process.chdir function which
enables execution of a closure in a directory different than the outer
scope. Also improve error messages that can be thrown and make sure
existing tests continue to pass.