### PR TITLE
src: ensure that file descriptors 0-2 are valid

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1030,7 +1030,7 @@ Handle<Value> MakeCallback(Environment* env,
     try_catch.SetVerbose(false);
     env->async_hooks_pre_function()->Call(object, 0, nullptr);
     if (try_catch.HasCaught())
-      FatalError("node:;MakeCallback", "pre hook threw");
+      FatalError("node::MakeCallback", "pre hook threw");
     try_catch.SetVerbose(true);
   }
 

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -1,0 +1,24 @@
+var common = require('../common');
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+
+if (process.platform === 'win32') {
+  console.log('Skipping test, platform not supported.');
+  return;
+}
+
+if (process.argv[2] === 'child') {
+  process.stdout.write('stdout', function() {
+    process.stderr.write('stderr', function() {
+      process.exit(42);
+    });
+  });
+}
+
+// Run the script in a shell but close stdout and stderr.
+var cmd = '"' + process.execPath + '" "' + __filename + '" child 1>&- 2>&-';
+var proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
+
+proc.on('exit', common.mustCall(function(exitCode) {
+  assert.equal(exitCode, 42);
+}));


### PR DESCRIPTION
Check that stdin, stdout and stderr map to open file descriptors and
remap them to /dev/null if that isn't the case.  Protects against
information leaks or worse when io.js is started with closed stdio
file descriptors.

R=@vkurchatkin

The second commit is an unrelated typo fix.