### PR TITLE
src: command line option to preload modules

### DIFF
--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -52,6 +52,8 @@ and servers.
   -i, --interactive      always enter the REPL even if stdin
                          does not appear to be a terminal
 
+  -r, --require          module to preload at startup
+
   --no-deprecation       silence deprecation warnings
 
   --trace-deprecation    show stack traces on deprecations

--- a/src/node.js
+++ b/src/node.js
@@ -68,84 +68,96 @@
       var d = NativeModule.require('_debug_agent');
       d.start();
 
-    } else if (process._eval != null) {
-      // User passed '-e' or '--eval' arguments to Node.
-      evalScript('[eval]');
-    } else if (process.argv[1]) {
-      // make process.argv[1] into a full path
-      var path = NativeModule.require('path');
-      process.argv[1] = path.resolve(process.argv[1]);
-
-      // If this is a worker in cluster mode, start up the communication
-      // channel.
-      if (process.env.NODE_UNIQUE_ID) {
-        var cluster = NativeModule.require('cluster');
-        cluster._setupWorker();
-
-        // Make sure it's not accidentally inherited by child processes.
-        delete process.env.NODE_UNIQUE_ID;
-      }
-
-      var Module = NativeModule.require('module');
-
-      if (global.v8debug &&
-          process.execArgv.some(function(arg) {
-            return arg.match(/^--debug-brk(=[0-9]*)?$/);
-          })) {
-
-        // XXX Fix this terrible hack!
-        //
-        // Give the client program a few ticks to connect.
-        // Otherwise, there's a race condition where `node debug foo.js`
-        // will not be able to connect in time to catch the first
-        // breakpoint message on line 1.
-        //
-        // A better fix would be to somehow get a message from the
-        // global.v8debug object about a connection, and runMain when
-        // that occurs.  --isaacs
-
-        var debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;
-        setTimeout(Module.runMain, debugTimeout);
-
-      } else {
-        // Main entry point into most programs:
-        Module.runMain();
-      }
-
     } else {
-      var Module = NativeModule.require('module');
+      // There is user code to be run
 
-      // If -i or --interactive were passed, or stdin is a TTY.
-      if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
-        // REPL
-        var opts = {
-          useGlobal: true,
-          ignoreUndefined: false
-        };
-        if (parseInt(process.env['NODE_NO_READLINE'], 10)) {
-          opts.terminal = false;
-        }
-        if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {
-          opts.useColors = false;
-        }
-        var repl = Module.requireRepl().start(opts);
-        repl.on('exit', function() {
-          process.exit();
+      // Load any preload modules
+      if (process._preload_modules) {
+        var Module = NativeModule.require('module');
+        process._preload_modules.forEach(function(module) {
+          Module._load(module);
         });
+      }
+
+      if (process._eval != null) {
+        // User passed '-e' or '--eval' arguments to Node.
+        evalScript('[eval]');
+      } else if (process.argv[1]) {
+        // make process.argv[1] into a full path
+        var path = NativeModule.require('path');
+        process.argv[1] = path.resolve(process.argv[1]);
+
+        // If this is a worker in cluster mode, start up the communication
+        // channel.
+        if (process.env.NODE_UNIQUE_ID) {
+          var cluster = NativeModule.require('cluster');
+          cluster._setupWorker();
+
+          // Make sure it's not accidentally inherited by child processes.
+          delete process.env.NODE_UNIQUE_ID;
+        }
+
+        var Module = NativeModule.require('module');
+
+        if (global.v8debug &&
+            process.execArgv.some(function(arg) {
+              return arg.match(/^--debug-brk(=[0-9]*)?$/);
+            })) {
+
+          // XXX Fix this terrible hack!
+          //
+          // Give the client program a few ticks to connect.
+          // Otherwise, there's a race condition where `node debug foo.js`
+          // will not be able to connect in time to catch the first
+          // breakpoint message on line 1.
+          //
+          // A better fix would be to somehow get a message from the
+          // global.v8debug object about a connection, and runMain when
+          // that occurs.  --isaacs
+
+          var debugTimeout = +process.env.NODE_DEBUG_TIMEOUT || 50;
+          setTimeout(Module.runMain, debugTimeout);
+
+        } else {
+          // Main entry point into most programs:
+          Module.runMain();
+        }
 
       } else {
-        // Read all of stdin - execute it.
-        process.stdin.setEncoding('utf8');
+        var Module = NativeModule.require('module');
 
-        var code = '';
-        process.stdin.on('data', function(d) {
-          code += d;
-        });
+        // If -i or --interactive were passed, or stdin is a TTY.
+        if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
+          // REPL
+          var opts = {
+            useGlobal: true,
+            ignoreUndefined: false
+          };
+          if (parseInt(process.env['NODE_NO_READLINE'], 10)) {
+            opts.terminal = false;
+          }
+          if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {
+            opts.useColors = false;
+          }
+          var repl = Module.requireRepl().start(opts);
+          repl.on('exit', function() {
+            process.exit();
+          });
 
-        process.stdin.on('end', function() {
-          process._eval = code;
-          evalScript('[stdin]');
-        });
+        } else {
+          // Read all of stdin - execute it.
+          process.stdin.setEncoding('utf8');
+
+          var code = '';
+          process.stdin.on('data', function(d) {
+            code += d;
+          });
+
+          process.stdin.on('end', function() {
+            process._eval = code;
+            evalScript('[stdin]');
+          });
+        }
       }
     }
   }

--- a/test/fixtures/printA.js
+++ b/test/fixtures/printA.js
@@ -1,0 +1,1 @@
+console.log('A')

--- a/test/fixtures/printB.js
+++ b/test/fixtures/printB.js
@@ -1,0 +1,1 @@
+console.log('B')

--- a/test/fixtures/printC.js
+++ b/test/fixtures/printC.js
@@ -1,0 +1,1 @@
+console.log('C')

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -1,0 +1,75 @@
+var common = require('../common'),
+    assert = require('assert'),
+    path = require('path'),
+    child_process = require('child_process');
+
+var nodeBinary = process.argv[0];
+
+var preloadOption = function(preloads) {
+  var option = '';
+  preloads.forEach(function(preload, index) {
+    // TODO: randomly pick -r or --require
+    option += '-r ' + preload + ' ';
+  });
+  return option;
+}
+
+var fixture = function(name) {
+  return path.join(__dirname, '../fixtures/' + name);
+}
+
+var fixtureA = fixture('printA.js');
+var fixtureB = fixture('printB.js');
+var fixtureC = fixture('printC.js')
+var fixtureThrows = fixture('throws_error4.js');
+
+// test preloading a single module works
+child_process.exec(nodeBinary + ' '
+  + preloadOption([fixtureA]) + ' '
+  + fixtureB,
+  function(err, stdout, stderr) {
+    if (err) throw err;
+    assert.equal(stdout, 'A\nB\n');
+  });
+
+// test preloading multiple modules works
+child_process.exec(nodeBinary + ' '
+  + preloadOption([fixtureA, fixtureB]) + ' '
+  + fixtureC,
+  function(err, stdout, stderr) {
+    if (err) throw err;
+    assert.equal(stdout, 'A\nB\nC\n');
+  });
+
+// test that preloading a throwing module aborts
+child_process.exec(nodeBinary + ' '
+  + preloadOption([fixtureA, fixtureThrows]) + ' '
+  + fixtureB,
+  function(err, stdout, stderr) {
+    if (err) {
+      assert.equal(stdout, 'A\n');
+    } else {
+      throw new Error('Preload should have failed');
+    }
+  });
+
+// test that preload can be used with --eval
+child_process.exec(nodeBinary + ' '
+  + preloadOption([fixtureA])
+  + '-e "console.log(\'hello\');"',
+  function(err, stdout, stderr) {
+    if (err) throw err;
+    assert.equal(stdout, 'A\nhello\n');
+  });
+
+// test that preload placement at other points in the cmdline
+// also test that duplicated preload only gets loaded once
+child_process.exec(nodeBinary + ' '
+  + preloadOption([fixtureA])
+  + '-e "console.log(\'hello\');" '
+  + preloadOption([fixtureA, fixtureB]),
+  function(err, stdout, stderr) {
+    if (err) throw err;
+    assert.equal(stdout, 'A\nB\nhello\n');
+  });
+


### PR DESCRIPTION
Here's a proposal, along with a PR, I would like to get feedback from the community on.

It would be nice if there was a standard mechanism to allow vendors, such as a cloud host, to customize startup of node applications.

Basically, I want to be able to inject functionality into a node application without requiring an explicit require. This could be useful to automatically enable, e.g., vendor specific tracing and application performance monitoring APIs when applications are deployed.

There are a few ways this could be done:
0. (Status quo) Ask the developers to modify their applications and add an explicit require of a vendor provided npm module. This adds friction to the deployment experience and possibly prevents people from being able to easily try different cloud vendors.
1. The vendor can maintain their own fork of node.js/io.js but with extra functionality added. This package would be offered instead of the standard node.js/io.js packages. This is potentially high overhead for the vendor. Effort may be duplicated by different vendors.
2. Build a standard mechanism into node.js/io.js that allows vendors to inject some functionality into the node startup process.

Here's a proposal on how to do option 2 (EDIT: updated as per suggestions by @piscisaureus):
* ~~On startup, node checks if `process.env.NODE_VENDOR_STARTUP` is set. If so, the file `node_prefix + '/lib/vendor/index.js'` is loaded (if it exists).~~
* ~~Vendors could package up their distributions of node/io by adding lib/vendor.~~
~~Another alternative would be for `NODE_VENDOR_STARTUP` to be a path. It gives more flexibility, but is probably not as secure.~~

EDIT: 20150313: change to command line option.
```
iojs -r foo -r /bar/baz.js -r quux
```
translates to:
```javascript
require('foo');
require('/bar/baz.js');
require('quux');
```

Thoughts?