### PR TITLE
net: unref timer in parent sockets

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -213,12 +213,12 @@ function TLSSocket(socket, options) {
     readable: false,
     writable: false
   });
-  if (socket)
+  if (socket) {
     this._parent = socket;
 
-  // To prevent assertion in afterConnect()
-  if (socket)
+    // To prevent assertion in afterConnect()
     this._connecting = socket._connecting;
+  }
 
   this._tlsOptions = options;
   this._secureEstablished = false;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -213,6 +213,8 @@ function TLSSocket(socket, options) {
     readable: false,
     writable: false
   });
+  if (socket)
+    this._parent = socket;
 
   // To prevent assertion in afterConnect()
   if (socket)

--- a/lib/net.js
+++ b/lib/net.js
@@ -120,6 +120,7 @@ function Socket(options) {
   this._connecting = false;
   this._hadError = false;
   this._handle = null;
+  this._parent = null;
   this._host = null;
 
   if (typeof options === 'number')
@@ -445,7 +446,8 @@ Socket.prototype._destroy = function(exception, cb) {
 
   this.readable = this.writable = false;
 
-  timers.unenroll(this);
+  for (var s = this; s !== null; s = s._parent)
+    timers.unenroll(s);
 
   debug('close');
   if (this._handle) {
@@ -490,7 +492,8 @@ function onread(nread, buffer) {
   var self = handle.owner;
   assert(handle === self._handle, 'handle != self._handle');
 
-  timers._unrefActive(self);
+  for (var s = self; s !== null; s = s._parent)
+    timers._unrefActive(s);
 
   debug('onread', nread);
 
@@ -621,7 +624,8 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   this._pendingData = null;
   this._pendingEncoding = '';
 
-  timers._unrefActive(this);
+  for (var s = this; s !== null; s = s._parent)
+    timers._unrefActive(s);
 
   if (!this._handle) {
     this._destroy(new Error('This socket is closed.'), cb);
@@ -749,7 +753,8 @@ function afterWrite(status, handle, req, err) {
     return;
   }
 
-  timers._unrefActive(self);
+  for (var s = self; s !== null; s = s._parent)
+    timers._unrefActive(s);
 
   if (self !== process.stderr && self !== process.stdout)
     debug('afterWrite call cb');
@@ -864,7 +869,8 @@ Socket.prototype.connect = function(options, cb) {
     self.once('connect', cb);
   }
 
-  timers._unrefActive(this);
+  for (var s = this; s !== null; s = s._parent)
+    timers._unrefActive(s);
 
   self._connecting = true;
   self.writable = true;
@@ -919,7 +925,8 @@ Socket.prototype.connect = function(options, cb) {
           self._destroy();
         });
       } else {
-        timers._unrefActive(self);
+        for (var s = self; s !== null; s = s._parent)
+          timers._unrefActive(s);
         connect(self,
                 ip,
                 port,
@@ -964,7 +971,8 @@ function afterConnect(status, handle, req, readable, writable) {
   if (status == 0) {
     self.readable = readable;
     self.writable = writable;
-    timers._unrefActive(self);
+    for (var s = self; s !== null; s = s._parent)
+      timers._unrefActive(s);
 
     self.emit('connect');
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -180,6 +180,11 @@ function Socket(options) {
 }
 util.inherits(Socket, stream.Duplex);
 
+Socket.prototype._unrefTimer = function unrefTimer() {
+  for (var s = this; s !== null; s = s._parent)
+    timers._unrefActive(s);
+};
+
 // the user has called .end(), and all the bytes have been
 // sent out to the other side.
 // If allowHalfOpen is false, or if the readable side has
@@ -492,8 +497,7 @@ function onread(nread, buffer) {
   var self = handle.owner;
   assert(handle === self._handle, 'handle != self._handle');
 
-  for (var s = self; s !== null; s = s._parent)
-    timers._unrefActive(s);
+  self._unrefTimer();
 
   debug('onread', nread);
 
@@ -624,8 +628,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   this._pendingData = null;
   this._pendingEncoding = '';
 
-  for (var s = this; s !== null; s = s._parent)
-    timers._unrefActive(s);
+  this._unrefTimer();
 
   if (!this._handle) {
     this._destroy(new Error('This socket is closed.'), cb);
@@ -753,8 +756,7 @@ function afterWrite(status, handle, req, err) {
     return;
   }
 
-  for (var s = self; s !== null; s = s._parent)
-    timers._unrefActive(s);
+  self._unrefTimer();
 
   if (self !== process.stderr && self !== process.stdout)
     debug('afterWrite call cb');
@@ -869,8 +871,7 @@ Socket.prototype.connect = function(options, cb) {
     self.once('connect', cb);
   }
 
-  for (var s = this; s !== null; s = s._parent)
-    timers._unrefActive(s);
+  this._unrefTimer();
 
   self._connecting = true;
   self.writable = true;
@@ -925,8 +926,7 @@ Socket.prototype.connect = function(options, cb) {
           self._destroy();
         });
       } else {
-        for (var s = self; s !== null; s = s._parent)
-          timers._unrefActive(s);
+        self._unrefTimer();
         connect(self,
                 ip,
                 port,
@@ -971,8 +971,7 @@ function afterConnect(status, handle, req, readable, writable) {
   if (status == 0) {
     self.readable = readable;
     self.writable = writable;
-    for (var s = self; s !== null; s = s._parent)
-      timers._unrefActive(s);
+    self._unrefTimer();
 
     self.emit('connect');
 

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -1,0 +1,34 @@
+if (!process.versions.openssl) process.exit();
+
+var common = require('../common');
+var assert = require('assert');
+var net = require('net');
+var tls = require('tls');
+var fs = require('fs');
+
+var options = {
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+var server = tls.createServer(options, function(c) {
+  setTimeout(function() {
+    c.write('hello');
+    setTimeout(function() {
+      c.destroy();
+      server.close();
+    }, 75);
+  }, 75);
+});
+
+server.listen(common.PORT, function() {
+  var socket = net.connect(common.PORT, function() {
+    socket.setTimeout(120, assert.fail);
+
+    var tsocket = tls.connect({
+      socket: socket,
+      rejectUnauthorized: false
+    });
+    tsocket.resume();
+  });
+});


### PR DESCRIPTION
`TLSSocket` wraps the original `net.Socket`, but writes/reads to/from
`TLSSocket` do not touch the timers of original `net.Socket`.

Introduce `socket._parent` property, and iterate through all parents
to unref timers and prevent timeout event on original `net.Socket`.

Fix: https://github.com/joyent/node/issues/9242