### PR TITLE
cares: fix set_servers during active queries

### DIFF
--- a/deps/cares/src/ares_cancel.c
+++ b/deps/cares/src/ares_cancel.c
@@ -48,8 +48,9 @@ void ares_cancel(ares_channel channel)
     {
       query = list_node->data;
       list_node = list_node->next;  /* since we're deleting the query */
+      ares__free_query_pre(query);
       query->callback(query->arg, ARES_ECANCELLED, 0, NULL, 0);
-      ares__free_query(query);
+      ares__free_query_post(query);
     }
   }
   if (!(channel->flags & ARES_FLAG_STAYOPEN) && ares__is_list_empty(&(channel->all_queries)))

--- a/deps/cares/src/ares_destroy.c
+++ b/deps/cares/src/ares_destroy.c
@@ -41,10 +41,32 @@ void ares_destroy_options(struct ares_options *options)
 void ares_destroy(ares_channel channel)
 {
   int i;
+
+  ares__destroy_servers_state(channel);
+
+  if (channel->domains) {
+    for (i = 0; i < channel->ndomains; i++)
+      free(channel->domains[i]);
+    free(channel->domains);
+  }
+
+  if(channel->sortlist)
+    free(channel->sortlist);
+
+  if (channel->lookups)
+    free(channel->lookups);
+
+  free(channel);
+}
+
+void ares__destroy_servers_state(ares_channel channel)
+{
+  struct server_state *server;
+  int i;
   struct query *query;
   struct list_node* list_head;
   struct list_node* list_node;
-  
+
   if (!channel)
     return;
 
@@ -70,28 +92,6 @@ void ares_destroy(ares_channel channel)
       assert(ares__is_list_empty(&(channel->queries_by_timeout[i])));
     }
 #endif
-
-  ares__destroy_servers_state(channel);
-
-  if (channel->domains) {
-    for (i = 0; i < channel->ndomains; i++)
-      free(channel->domains[i]);
-    free(channel->domains);
-  }
-
-  if(channel->sortlist)
-    free(channel->sortlist);
-
-  if (channel->lookups)
-    free(channel->lookups);
-
-  free(channel);
-}
-
-void ares__destroy_servers_state(ares_channel channel)
-{
-  struct server_state *server;
-  int i;
 
   if (channel->servers)
     {

--- a/deps/cares/src/ares_private.h
+++ b/deps/cares/src/ares_private.h
@@ -324,6 +324,8 @@ void ares__close_sockets(ares_channel channel, struct server_state *server);
 int ares__get_hostent(FILE *fp, int family, struct hostent **host);
 int ares__read_line(FILE *fp, char **buf, size_t *bufsize);
 void ares__free_query(struct query *query);
+void ares__free_query_pre(struct query *query);
+void ares__free_query_post(struct query *query);
 unsigned short ares__generate_new_id(rc4_key* key);
 struct timeval ares__tvnow(void);
 int ares__expand_name_for_response(const unsigned char *encoded,


### PR DESCRIPTION
`ares_set_servers()` should terminate all active queries to previous
servers before destroying them.

When invoking query callback remove it from the queue, to ensure that it
won't be called two times.

Fix: iojs/io.js#894

NOTE: One of two proposed fixes, see #894 