### PR TITLE
Enable writev for Unix domain sockets

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -101,6 +101,7 @@ void PipeWrap::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "writeUtf8String", StreamWrap::WriteUtf8String);
   env->SetProtoMethod(t, "writeUcs2String", StreamWrap::WriteUcs2String);
   env->SetProtoMethod(t, "writeBinaryString", StreamWrap::WriteBinaryString);
+  env->SetProtoMethod(t, "writev", StreamWrap::Writev);
 
   env->SetProtoMethod(t, "bind", Bind);
   env->SetProtoMethod(t, "listen", Listen);


### PR DESCRIPTION
As far as I can tell, this is all that is necessary to make cork() / uncork() work on Unix domain sockets.