### PR TITLE
doc: use HTTPS URL for the API documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ string which includes their date (in UTC time) and the commit SHA at
 the HEAD of the release.
 
 **API documentation** is available in each release and nightly
-directory under _docs_. <http://iojs.org/api/> points to the the
+directory under _docs_. <https://iojs.org/api/> points to the the
 latest version.
 
 ### Verifying Binaries


### PR DESCRIPTION
`http://iojs.org/api/` -> `https://iojs.org/api/`
