### PR TITLE
test: common.js -> common

### DIFF
--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -1,6 +1,6 @@
 var http = require('http');
 var cluster = require('cluster');
-var common = require('../../common.js');
+var common = require('../../common');
 
 function handleRequest(request, response) {
   response.end('hello world\n');

--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -11,7 +11,7 @@ var http  = require('http'),
     count   = 0,
     countGC = 0,
     todo    = 500,
-    common = require('../common.js'),
+    common = require('../common'),
     assert = require('assert'),
     PORT = common.PORT;
 

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -13,7 +13,7 @@ var http  = require('http'),
     count   = 0,
     countGC = 0,
     todo    = 500,
-    common = require('../common.js'),
+    common = require('../common'),
     assert = require('assert'),
     PORT = common.PORT;
 

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -15,7 +15,7 @@ var http  = require('http'),
     count   = 0,
     countGC = 0,
     todo    = 550,
-    common = require('../common.js'),
+    common = require('../common'),
     assert = require('assert'),
     PORT = common.PORT;
 

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -11,7 +11,7 @@ var http  = require('http'),
     count   = 0,
     countGC = 0,
     todo    = 500,
-    common = require('../common.js'),
+    common = require('../common'),
     assert = require('assert'),
     PORT = common.PORT;
 

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -22,7 +22,7 @@ var net  = require('net'),
     count   = 0,
     countGC = 0,
     todo    = 500,
-    common = require('../common.js'),
+    common = require('../common'),
     assert = require('assert'),
     PORT = common.PORT;
 

--- a/test/message/error_exit.js
+++ b/test/message/error_exit.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 
 process.on('exit', function(code) {

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -4,7 +4,7 @@ if (module.parent) {
   process.exit(42);
 }
 
-var common = require('../common.js'),
+var common = require('../common'),
     assert = require('assert'),
     child = require('child_process'),
     nodejs = '"' + process.execPath + '"';

--- a/test/parallel/test-domain-exit-dispose-again.js
+++ b/test/parallel/test-domain-exit-dispose-again.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 var disposalFailed = false;

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -1,7 +1,7 @@
 var domain = require('domain');
 var http = require('http');
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 
 var objects = { foo: 'bar', baz: {}, num: 42, arr: [1,2,3] };
 objects.baz.asdf = objects;

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -1,6 +1,6 @@
 var domain = require('domain');
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 
 var timeout_err, timeout, immediate_err;
 

--- a/test/parallel/test-http-exit-delay.js
+++ b/test/parallel/test-http-exit-delay.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var http = require('http');
 
 var start;

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var net = require('net');

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var https = require('https');
 var tls = require('tls');

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 
 var util   = require('util');
 var repl   = require('repl');

--- a/test/parallel/test-repl-timeout-throw.js
+++ b/test/parallel/test-repl-timeout-throw.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 
 var spawn = require('child_process').spawn;
 

--- a/test/parallel/test-signal-safety.js
+++ b/test/parallel/test-signal-safety.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var Signal = process.binding('signal_wrap').Signal;
 

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('stream').Readable;
 var assert = require('assert');
 

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('_stream_readable');
 var W = require('_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var stream = require('stream');
 var Buffer = require('buffer').Buffer;
 

--- a/test/parallel/test-stream2-large-read-stall.js
+++ b/test/parallel/test-stream2-large-read-stall.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 
 // If everything aligns so that you do a read(n) of exactly the

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('_stream_readable');
 var Writable = require('_stream_writable');
 var assert = require('assert');

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 
 var util = require('util');

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var stream = require('stream');
 var Readable = stream.Readable;
 var Writable = stream.Writable;

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var fromList = require('_stream_readable')._fromList;
 
 // tiny node-tap lookalike.

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var Readable = require('_stream_readable');
 
 var len = 0;

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var R = require('_stream_readable');
 var util = require('util');

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var common = require('../common.js');
+var common = require('../common');
 var PassThrough = require('_stream_passthrough');
 var Transform = require('_stream_transform');
 

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
 var crypto = require('crypto');

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var W = require('_stream_writable');
 var D = require('_stream_duplex');
 var assert = require('assert');

--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -1,6 +1,6 @@
 // test convenience methods with and without options supplied
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-dictionary.js
+++ b/test/parallel/test-zlib-dictionary.js
@@ -1,6 +1,6 @@
 // test compression/decompression with dictionary
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');

--- a/test/parallel/test-zlib-flush.js
+++ b/test/parallel/test-zlib-flush.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -1,7 +1,7 @@
 // test unzipping a file that was created with a non-node gzip lib,
 // piped in as fast as possible.
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -1,6 +1,6 @@
 // test compressing and uncompressing a string with zlib
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -1,6 +1,6 @@
 // test uncompressing invalid input
 
-var common = require('../common.js'),
+var common = require('../common'),
     assert = require('assert'),
     zlib = require('zlib');
 

--- a/test/parallel/test-zlib-params.js
+++ b/test/parallel/test-zlib-params.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var zlib = require('zlib');
 var path = require('path');

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 

--- a/test/sequential/test-regress-GH-3542.js
+++ b/test/sequential/test-regress-GH-3542.js
@@ -3,7 +3,7 @@ if (process.platform !== 'win32') {
   return process.exit(0);
 }
 
-var common = require('../common.js'),
+var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
     path = require('path'),

--- a/test/sequential/test-regress-GH-3739.js
+++ b/test/sequential/test-regress-GH-3739.js
@@ -1,4 +1,4 @@
-var common = require('../common.js'),
+var common = require('../common'),
     assert = require('assert'),
     fs = require('fs'),
     path = require('path');

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var R = require('_stream_readable');
 var assert = require('assert');
 

--- a/test/sequential/test-stream2-httpclient-response-end.js
+++ b/test/sequential/test-stream2-httpclient-response-end.js
@@ -1,4 +1,4 @@
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var http = require('http');
 var msg = 'Hello';

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -1,6 +1,6 @@
 // Make sure that sync writes to stderr get processed before exiting.
 
-var common = require('../common.js');
+var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 


### PR DESCRIPTION
This commit changes many test styles to change all references
from `require('./common.js');` to `require('./common');`.

The latter is much more common, with the former only being used in 50
tests. It is just a stylistic change, and it seems that `common.js` was
introduced by a rogue test and copied and pasted into the rest.