### PR TITLE
deps: enable node-gyp iojs.lib download checksum

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -295,8 +295,7 @@ function install (gyp, argv, callback) {
             // check content shasums
             for (var k in contentShasums) {
               log.verbose('validating download checksum for ' + k, '(%s == %s)', contentShasums[k], expectShasums[k])
-              // TODO(piscisaureus) re-enable checksum verification when the correct files are in place.
-              if (false || contentShasums[k] !== expectShasums[k]) {
+              if (contentShasums[k] !== expectShasums[k]) {
                 cb(new Error(k + ' local checksum ' + contentShasums[k] + ' not match remote ' + expectShasums[k]))
                 return
               }


### PR DESCRIPTION
Originally disabled in commit 5de334c ("deps: make node-gyp work again
on windows") due to the then-website lacking the requisite SHASUMS.txt
or SHASUMS256.txt files.  The website has a SHASUMS256.txt now so start
checksumming the download again.

R=@piscisaureus, /cc @othiym23