### PR TITLE
benchmark: pass execArgv to the benchmarking process

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -145,6 +145,7 @@ Benchmark.prototype._run = function() {
     var argv = queue[i++];
     if (!argv)
       return;
+    argv = process.execArgv.concat(argv);
     var child = spawn(node, argv, { stdio: 'inherit' });
     child.on('close', function(code, signal) {
       if (code)


### PR DESCRIPTION
Benchmarker should pass exec flags (e.g. --no-crankshaft,
--turbofan-filter, --trace-opt etc) to the benchmarking process