### PR TITLE
util: handle symbols properly in format()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -30,7 +30,7 @@ exports.format = function(f) {
     }
   });
   for (var x = args[i]; i < len; x = args[++i]) {
-    if (x === null || typeof x !== 'object') {
+    if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
       str += ' ' + x;
     } else {
       str += ' ' + inspect(x);

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -1,6 +1,7 @@
 var common = require('../common');
 var assert = require('assert');
 var util = require('util');
+var symbol = Symbol('foo');
 
 assert.equal(util.format(), '');
 assert.equal(util.format(''), '');
@@ -13,6 +14,15 @@ assert.equal(util.format('test'), 'test');
 
 // CHECKME this is for console.log() compatibility - but is it *right*?
 assert.equal(util.format('foo', 'bar', 'baz'), 'foo bar baz');
+
+// ES6 Symbol handling
+assert.equal(util.format(symbol), 'Symbol(foo)');
+assert.equal(util.format('foo', symbol), 'foo Symbol(foo)');
+assert.equal(util.format('%s', symbol), 'Symbol(foo)');
+assert.equal(util.format('%j', symbol), 'undefined');
+assert.throws(function() {
+  util.format('%d', symbol);
+}, TypeError);
 
 assert.equal(util.format('%d', 42.0), '42');
 assert.equal(util.format('%d', 42), '42');


### PR DESCRIPTION
Currently, if `util.format()` is called with a string as its first argument, and a Symbol as one of the subsequent arguments, an exception is thrown due to an attempted implicit string conversion. This commit causes Symbols to be explicitly converted.

This bug is due to a discrepancy between how the docs say `util.format()` work, and what really happens. The docs state:

> If there are more arguments than placeholders, the extra arguments are converted to strings with util.inspect() and these strings are concatenated, delimited by a space.

However, [only objects actually use `util.inspect()`](https://github.com/iojs/io.js/blob/v1.x/lib/util.js#L33-L37). I think we should bring behavior into line with what the docs say, but this is a slightly breaking change.

Closes #927. R=@domenic