### PR TITLE
util: accept a variable arity of constructors by inherits()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -624,7 +624,7 @@ exports.log = function() {
 
 
 /**
- * Inherit the prototype methods from one constructor into another.
+ * Inherit the prototype methods from one constructor into others.
  *
  * The Function.prototype.inherits from lang.js rewritten as a standalone
  * function (not on Function.prototype). NOTE: If this file is to be loaded
@@ -632,11 +632,17 @@ exports.log = function() {
  * functions as prototype setup using normal JavaScript does not work as
  * expected during bootstrapping (see mirror.js in r114903).
  *
- * @param {function} ctor Constructor function which needs to inherit the
- *     prototype.
+ * @param (variable arity) {function} ctor Constructor functions which need to
+ *     inherit the prototype.
  * @param {function} superCtor Constructor function to inherit prototype from.
  */
-exports.inherits = function(ctor, superCtor) {
+exports.inherits = function(ctor, ctor, ctor, superCtor) {
+  var superCtor = arguments[arguments.length-1];
+  var ctors = arguments.length-1;
+  while(--ctors > -1) inherit(arguments[ctors], superCtor);
+}
+
+function inherit(ctor, superCtor) {
   ctor.super_ = superCtor;
   ctor.prototype = Object.create(superCtor.prototype, {
     constructor: {


### PR DESCRIPTION
although the API has long been frozen, and despite *stability level 3 and up being off-limits,* this should be considered because merit of its usefulness outweighs the need to enforce frozen stability.

instead of doing this:
```js
var util = require('util');
var EventEmitter = require('events').EventEmitter;

util.inherits(Ctor, EventEmitter);
util.inherits(AnotherCtor, EventEmitter);

function Ctor(){}
function AnotherCtor(){}
```

we ought to do:
```js
require('util').inherits(Ctor, AnotherCtor, require('events').EventEmitter);

function Ctor(){}
function AnotherCtor(){}
```