### PR TITLE
test: fix infinite spawn cycle in stdio test

### DIFF
--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -13,6 +13,7 @@ if (process.argv[2] === 'child') {
       process.exit(42);
     });
   });
+  return;
 }
 
 // Run the script in a shell but close stdout and stderr.


### PR DESCRIPTION
Fix parallel/test-stdio-closed introduced in commit b5f25a9 ("src:
ensure that file descriptors 0-2 are valid") to not keep spawning
child processes ad infinitum.

The test spawns itself as a child process but a missing return statement
made the child process spawn itself again, and again, and again.

It went unnoticed for some time because the child process exits almost
immediately afterwards, i.e. it didn't fill up the process table.  The
observable effect was an iojs process that was quietly consuming CPU
cyles in the background with a PID that was constantly changing.

Refs: https://github.com/iojs/io.js/pull/938

R=@indutny

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/194/