### PR TITLE
stream_base: remove static JSMethod declarations

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -156,6 +156,7 @@
         'src/req-wrap-inl.h',
         'src/string_bytes.h',
         'src/stream_base.h',
+        'src/stream_base-inl.h',
         'src/stream_wrap.h',
         'src/tree.h',
         'src/util.h',

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -5,6 +5,7 @@
 #include "env-inl.h"
 #include "node_buffer.h"
 #include "stream_base.h"
+#include "stream_base-inl.h"
 #include "v8.h"
 
 namespace node {

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -1,0 +1,83 @@
+#ifndef SRC_STREAM_BASE_INL_H_
+#define SRC_STREAM_BASE_INL_H_
+
+#include "stream_base.h"
+
+#include "node.h"
+#include "env.h"
+#include "env-inl.h"
+#include "v8.h"
+
+namespace node {
+
+using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::HandleScope;
+using v8::Local;
+using v8::PropertyAttribute;
+using v8::PropertyCallbackInfo;
+using v8::String;
+using v8::Value;
+
+template <class Base>
+void StreamBase::AddMethods(Environment* env, Handle<FunctionTemplate> t) {
+  HandleScope scope(env->isolate());
+
+  enum PropertyAttribute attributes =
+      static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
+  t->InstanceTemplate()->SetAccessor(env->fd_string(),
+                                     GetFD<Base>,
+                                     nullptr,
+                                     Handle<Value>(),
+                                     v8::DEFAULT,
+                                     attributes);
+
+  env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
+  env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
+  env->SetProtoMethod(t, "shutdown", JSMethod<Base, &StreamBase::Shutdown>);
+  env->SetProtoMethod(t, "writev", JSMethod<Base, &StreamBase::Writev>);
+  env->SetProtoMethod(t,
+                      "writeBuffer",
+                      JSMethod<Base, &StreamBase::WriteBuffer>);
+  env->SetProtoMethod(t,
+                      "writeAsciiString",
+                      JSMethod<Base, &StreamBase::WriteString<ASCII> >);
+  env->SetProtoMethod(t,
+                      "writeUtf8String",
+                      JSMethod<Base, &StreamBase::WriteString<UTF8> >);
+  env->SetProtoMethod(t,
+                      "writeUcs2String",
+                      JSMethod<Base, &StreamBase::WriteString<UCS2> >);
+  env->SetProtoMethod(t,
+                      "writeBinaryString",
+                      JSMethod<Base, &StreamBase::WriteString<BINARY> >);
+}
+
+
+template <class Base>
+void StreamBase::GetFD(Local<String> key,
+                       const PropertyCallbackInfo<Value>& args) {
+  StreamBase* wrap = Unwrap<Base>(args.Holder());
+
+  if (!wrap->IsAlive())
+    return args.GetReturnValue().Set(UV_EINVAL);
+
+  args.GetReturnValue().Set(wrap->GetFD());
+}
+
+
+template <class Base,
+          int (StreamBase::*Method)(const FunctionCallbackInfo<Value>& args)>
+void StreamBase::JSMethod(const FunctionCallbackInfo<Value>& args) {
+  StreamBase* wrap = Unwrap<Base>(args.Holder());
+
+  if (!wrap->IsAlive())
+    return args.GetReturnValue().Set(UV_EINVAL);
+
+  args.GetReturnValue().Set((wrap->*Method)(args));
+}
+
+}  // namespace node
+
+#endif  // SRC_STREAM_BASE_INL_H_

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -19,83 +19,23 @@ namespace node {
 using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::Handle;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Number;
 using v8::Object;
-using v8::PropertyAttribute;
-using v8::PropertyCallbackInfo;
 using v8::String;
 using v8::Value;
 
-template void StreamBase::AddMethods<StreamWrap>(Environment* env,
-                                                 Handle<FunctionTemplate> t);
-template void StreamBase::AddMethods<TLSWrap>(Environment* env,
-                                              Handle<FunctionTemplate> t);
-template void StreamBase::AddMethods<JSStream>(Environment* env,
-                                               Handle<FunctionTemplate> t);
-
-
-template <class Base>
-void StreamBase::AddMethods(Environment* env, Handle<FunctionTemplate> t) {
-  HandleScope scope(env->isolate());
-
-  enum PropertyAttribute attributes =
-      static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(env->fd_string(),
-                                     GetFD<Base>,
-                                     nullptr,
-                                     Handle<Value>(),
-                                     v8::DEFAULT,
-                                     attributes);
-
-  env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
-  env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
-  env->SetProtoMethod(t, "shutdown", JSMethod<Base, &StreamBase::Shutdown>);
-  env->SetProtoMethod(t, "writev", JSMethod<Base, &StreamBase::Writev>);
-  env->SetProtoMethod(t,
-                      "writeBuffer",
-                      JSMethod<Base, &StreamBase::WriteBuffer>);
-  env->SetProtoMethod(t,
-                      "writeAsciiString",
-                      JSMethod<Base, &StreamBase::WriteString<ASCII> >);
-  env->SetProtoMethod(t,
-                      "writeUtf8String",
-                      JSMethod<Base, &StreamBase::WriteString<UTF8> >);
-  env->SetProtoMethod(t,
-                      "writeUcs2String",
-                      JSMethod<Base, &StreamBase::WriteString<UCS2> >);
-  env->SetProtoMethod(t,
-                      "writeBinaryString",
-                      JSMethod<Base, &StreamBase::WriteString<BINARY> >);
-}
-
-
-template <class Base>
-void StreamBase::GetFD(Local<String> key,
-                       const PropertyCallbackInfo<Value>& args) {
-  StreamBase* wrap = Unwrap<Base>(args.Holder());
-
-  if (!wrap->IsAlive())
-    return args.GetReturnValue().Set(UV_EINVAL);
-
-  args.GetReturnValue().Set(wrap->GetFD());
-}
-
-
-template <class Base,
-          int (StreamBase::*Method)(const FunctionCallbackInfo<Value>& args)>
-void StreamBase::JSMethod(const FunctionCallbackInfo<Value>& args) {
-  StreamBase* wrap = Unwrap<Base>(args.Holder());
-
-  if (!wrap->IsAlive())
-    return args.GetReturnValue().Set(UV_EINVAL);
-
-  args.GetReturnValue().Set((wrap->*Method)(args));
-}
+template int StreamBase::WriteString<ASCII>(
+    const FunctionCallbackInfo<Value>& args);
+template int StreamBase::WriteString<UTF8>(
+    const FunctionCallbackInfo<Value>& args);
+template int StreamBase::WriteString<UCS2>(
+    const FunctionCallbackInfo<Value>& args);
+template int StreamBase::WriteString<BINARY>(
+    const FunctionCallbackInfo<Value>& args);
 
 
 int StreamBase::ReadStart(const FunctionCallbackInfo<Value>& args) {

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -159,8 +159,8 @@ class StreamResource {
 class StreamBase : public StreamResource {
  public:
   template <class Base>
-  static void AddMethods(Environment* env,
-                         v8::Handle<v8::FunctionTemplate> target);
+  static inline void AddMethods(Environment* env,
+                                v8::Handle<v8::FunctionTemplate> target);
 
   virtual void* Cast() = 0;
   virtual bool IsAlive() = 0;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -1,4 +1,7 @@
 #include "stream_wrap.h"
+#include "stream_base.h"
+#include "stream_base-inl.h"
+
 #include "env-inl.h"
 #include "env.h"
 #include "handle_wrap.h"

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -9,6 +9,8 @@
 #include "node_wrap.h"  // WithGenericStream
 #include "node_counters.h"
 #include "node_internals.h"
+#include "stream_base.h"
+#include "stream_base-inl.h"
 #include "util.h"
 #include "util-inl.h"
 


### PR DESCRIPTION
Move JS methods to the stream_base-inl.h and thus define them on each
use of `StreamBase::AddMethods`. Inline `AddMethods` itself, so that
there won't be any need in a static declaration in stream_base.cc.

NOTE: This basically allows using this API in user-land, though, some
polishing is required before releasing it.

cc @piscisaureus @iojs/streams @chrisdickinson 