### PR TITLE
build: reduce tarball size by 8-10%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,12 +277,14 @@ $(PKG): release-only
 	SIGN="$(INT_SIGN)" PKG="$(PKG)" bash tools/osx-productsign.sh
 
 $(TARBALL): release-only $(NODE_EXE) doc
-	git archive --format=tar --prefix=$(TARNAME)/ HEAD | tar xf -
+	git checkout-index -a -f --prefix=$(TARNAME)/
 	mkdir -p $(TARNAME)/doc/api
 	cp doc/iojs.1 $(TARNAME)/doc/iojs.1
 	cp -r out/doc/api/* $(TARNAME)/doc/api/
-	rm -rf $(TARNAME)/deps/v8/test # too big
+	rm -rf $(TARNAME)/deps/v8/{test,samples,tools/profviz} # too big
 	rm -rf $(TARNAME)/doc/images # too big
+	rm -rf $(TARNAME)/deps/uv/{docs,samples,test}
+	rm -rf $(TARNAME)/deps/openssl/{doc,demos,test}
 	rm -rf $(TARNAME)/deps/zlib/contrib # too big, unused
 	find $(TARNAME)/ -type l | xargs rm # annoying on windows
 	tar -cf $(TARNAME).tar $(TARNAME)


### PR DESCRIPTION
Slim the tarballs further by removing examples, documentation and test for third party libraries. Also switch to checkout-index versus archive so we avoid using tar.

"Verified" by using a generated tarball to configure, compile and test io.js.

Beyond this, it'll get tricker to further reduce the size. A few things to consider:
 - npm node_submodule tests: saves ~400k off the tarballs but I think this falls out of scope for what we should meddle with. (If at all) I'd prefer upstream doing this.
 - `make bench-http` requires `tools/wrk` which is bundled (3.9mb) but a lot of benchmarks also assumes `ab` is available. Perhaps drop `wrk` from our bundle and make the same assumption?