### PR TITLE
test: don't spawn child processes in domain test

### DIFF
--- a/src/node_counters.h
+++ b/src/node_counters.h
@@ -7,18 +7,18 @@
 #include "node_win32_perfctr_provider.h"
 #else
 #define NODE_COUNTER_ENABLED() (false)
-#define NODE_COUNT_HTTP_SERVER_REQUEST()
-#define NODE_COUNT_HTTP_SERVER_RESPONSE()
-#define NODE_COUNT_HTTP_CLIENT_REQUEST()
-#define NODE_COUNT_HTTP_CLIENT_RESPONSE()
-#define NODE_COUNT_SERVER_CONN_OPEN()
-#define NODE_COUNT_SERVER_CONN_CLOSE()
-#define NODE_COUNT_NET_BYTES_SENT(bytes)
-#define NODE_COUNT_NET_BYTES_RECV(bytes)
-#define NODE_COUNT_GET_GC_RAWTIME()
-#define NODE_COUNT_GC_PERCENTTIME(percent)
-#define NODE_COUNT_PIPE_BYTES_SENT(bytes)
-#define NODE_COUNT_PIPE_BYTES_RECV(bytes)
+#define NODE_COUNT_GC_PERCENTTIME(percent) do { } while (false)
+#define NODE_COUNT_GET_GC_RAWTIME() do { } while (false)
+#define NODE_COUNT_HTTP_CLIENT_REQUEST() do { } while (false)
+#define NODE_COUNT_HTTP_CLIENT_RESPONSE() do { } while (false)
+#define NODE_COUNT_HTTP_SERVER_REQUEST() do { } while (false)
+#define NODE_COUNT_HTTP_SERVER_RESPONSE() do { } while (false)
+#define NODE_COUNT_NET_BYTES_RECV(bytes) do { } while (false)
+#define NODE_COUNT_NET_BYTES_SENT(bytes) do { } while (false)
+#define NODE_COUNT_PIPE_BYTES_RECV(bytes) do { } while (false)
+#define NODE_COUNT_PIPE_BYTES_SENT(bytes) do { } while (false)
+#define NODE_COUNT_SERVER_CONN_CLOSE() do { } while (false)
+#define NODE_COUNT_SERVER_CONN_OPEN() do { } while (false)
 #endif
 
 #include "v8.h"


### PR DESCRIPTION
Make parallel/test-domain-abort-on-uncaught a little easier to debug,
make it execute the tests in the same process instead of each test in
a separate child process.

R=@chrisdickinson

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/202/