### PR TITLE
Update docs to reflect post node 0.10.* behaviour.

### DIFF
--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -22,7 +22,7 @@ attached to.
 
 To access the EventEmitter class, require `events`.
 ```javascript
-   var EventEmitter = require('events');
+var EventEmitter = require('events');
 ```
 
 When an `EventEmitter` instance experiences an error, the typical action is

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -20,7 +20,7 @@ attached to.
 
 ## Class: events.EventEmitter
 
-To access the EventEmitter class, require `events`.
+Use `require('events')` to access the EventEmitter class.
 ```javascript
 var EventEmitter = require('events');
 ```

--- a/doc/api/events.markdown
+++ b/doc/api/events.markdown
@@ -20,7 +20,10 @@ attached to.
 
 ## Class: events.EventEmitter
 
-To access the EventEmitter class, `require('events').EventEmitter`.
+To access the EventEmitter class, require `events`.
+```javascript
+   var EventEmitter = require('events');
+```
 
 When an `EventEmitter` instance experiences an error, the typical action is
 to emit an `'error'` event.  Error events are treated as a special case in


### PR DESCRIPTION
We don't need do `require('events').EventEmitter` any longer.