### PR TITLE
node: improve performance of nextTick

### DIFF
--- a/test/parallel/test-timers-first-fire.js
+++ b/test/parallel/test-timers-first-fire.js
@@ -8,5 +8,5 @@ setTimeout(function() {
   var ms = (hr[0] * 1e3) + (hr[1] / 1e6);
   var delta = ms - TIMEOUT;
   console.log('timer fired in', delta);
-  assert.ok(delta > 0, 'Timer fired early');
+  assert.ok(delta > -0.5, 'Timer fired early');
 }, TIMEOUT);


### PR DESCRIPTION
Couple micro optimizations to improve performance of process.nextTick().
Removes ~80ns of execution time.

Also added small threshold to test that allows timer to fire early on
the order if microseconds.

R=@bnoordhuis 