### PR TITLE
node: Added check for already defined macro NOMINMAX

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -25,7 +25,9 @@
 # define _WIN32_WINNT   0x0501
 #endif
 
-#define NOMINMAX
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
 
 #endif
 


### PR DESCRIPTION
In order to avoid Visual C++ warning C4005 about macro redefinition when node.h is included in other project.