### PR TITLE
deps: upgrade npm to 2.6.1

### DIFF
--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -158,8 +158,15 @@ Aria Stewart <aredridel@nbtsc.org>
 Adam Meadows <adam.meadows@gmail.com>
 Charlie Rudolph <charles.w.rudolph@gmail.com>
 Chulki Lee <chulki.lee@gmail.com>
+Vladimir Rutsky <rutsky@users.noreply.github.com>
 不四 <busi.hyy@taobao.com>
+Isaac Murchie <isaac@saucelabs.com>
+Marcin Wosinek <marcin.wosinek@gmail.com>
+David Marr <davemarr@gmail.com>
+Bryan English <bryan@bryanenglish.com>
+Anthony Zotti <amZotti@users.noreply.github.com>
 Thom Blake <tblake@brightroll.com>
+Karl Horky <karl.horky@gmail.com>
 Jess Martin <jessmartin@gmail.com>
 Spain Train <michael.spainhower@opower.com>
 Alex Rodionov <p0deje@gmail.com>
@@ -179,6 +186,7 @@ Jens Grunert <jens.grunert@gmail.com>
 Joost-Wim Boekesteijn <joost-wim@boekesteijn.nl>
 Dalmais Maxence <root@ip-10-195-202-5.ec2.internal>
 Marcus Ekwall <marcus.ekwall@gmail.com>
+Jordan Harband <ljharb@gmail.com>
 Steve Mason <stevem@brandwatch.com>
 Wil Moore III <wil.moore@wilmoore.com>
 Sergey Belov <peimei@ya.ru>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,22 @@
+### v2.6.1 (2015-02-19):
+
+* [`8b98f0e`](https://github.com/npm/npm/commit/8b98f0e709d77a8616c944aebd48ab726f726f76)
+  [#4471](https://github.com/npm/npm/issues/4471) `npm outdated` (and only `npm
+  outdated`) now defaults to `--depth=0`. See the [docs for
+  `--depth`](https://github.com/npm/npm/blob/82f484672adb1a3caf526a8a48832789495bb43d/doc/misc/npm-config.md#depth)
+  for the mildly confusing details. ([@smikes](https://github.com/smikes))
+* [`aa79194`](https://github.com/npm/npm/commit/aa791942a9f3c8af6a650edec72a675deb7a7c6e)
+  [#6565](https://github.com/npm/npm/issues/6565) Tweak `peerDependency`
+  deprecation warning to include which peer dependency on which package is
+  going to need to change. ([@othiym23](https://github.com/othiym23))
+* [`5fa067f`](https://github.com/npm/npm/commit/5fa067fd47682ac3cdb12a2b009d8ca59b05f992)
+  [#7171](https://github.com/npm/npm/issues/7171) Tweak `engineStrict`
+  deprecation warning to include which `package.json` is using it.
+  ([@othiym23](https://github.com/othiym23))
+* [`0fe0caa`](https://github.com/npm/npm/commit/0fe0caa7eddb7acdacbe5ee81ceabaca27175c78)
+  `glob@4.4.0`: Glob patterns can now ignore matches.
+  ([@isaacs](https://github.com/isaacs))
+
 ### v2.6.0 (2015-02-12):
 
 #### A LONG-AWAITED GUEST
@@ -7,7 +26,7 @@
   make it do something useful on both bearer-based and basic-based authed
   clients. ([@othiym23](https://github.com/othiym23))
 * [`4bf0f5d`](https://github.com/npm/npm/commit/4bf0f5d56c33649124b486e016ba4a620c105c1c)
-  `npm-registry-clieng@6.1.1`: Support new `logout` endpoint to invalidate
+  `npm-registry-client@6.1.1`: Support new `logout` endpoint to invalidate
   token for sessions. ([@othiym23](https://github.com/othiym23))
 
 #### DEPRECATIONS
@@ -26,6 +45,7 @@
 * [`add5890`](https://github.com/npm/npm/commit/add5890ce447dabf120b907a85f715df1e065f44)
   [#4668](https://github.com/npm/npm/issues/4668) `read-package-json@1.3.1`:
   Warn when a `bin` symbolic link is a dangling reference.
+  ([@nicks](https://github.com/nicks))
 * [`4b42071`](https://github.com/npm/npm/commit/4b420714dfb84338d85def78c30bd665e32d72c1)
   `semver@4.3.0`: Add functions to extract parts of the version triple, fix a
   typo. ([@isaacs](https://github.com/isaacs))

--- a/deps/npm/doc/misc/npm-config.md
+++ b/deps/npm/doc/misc/npm-config.md
@@ -243,8 +243,13 @@ If true, then only prints color codes for tty file descriptors.
 * Default: Infinity
 * Type: Number
 
-The depth to go when recursing directories for `npm ls` and
-`npm cache ls`.
+The depth to go when recursing directories for `npm ls`, 
+`npm cache ls`, and `npm outdated`.
+
+For `npm outdated`, a setting of `Infinity` will be treated as `0`
+since that gives more useful information.  To show the outdated status
+of all packages and dependents, use a large integer value,
+e.g., `npm outdated --depth 9999`
 
 ### description
 

--- a/deps/npm/html/doc/README.html
+++ b/deps/npm/html/doc/README.html
@@ -126,7 +126,7 @@ specific purpose, or lack of malice in any given npm package.</p>
 <p>If you have a complaint about a package in the public npm registry,
 and cannot <a href="https://docs.npmjs.com/misc/disputes">resolve it with the package
 owner</a>, please email
-<a href="&#109;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;</a> and explain the situation.</p>
+<a href="&#109;&#97;&#105;&#x6c;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#109;</a> and explain the situation.</p>
 <p>Any data published to The npm Registry (including user account
 information) may be removed or modified at the sole discretion of the
 npm server administrators.</p>
@@ -169,5 +169,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.6.0</p>
+<p id="footer"><a href="../doc/README.html">README</a> &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-bin.html
+++ b/deps/npm/html/doc/api/npm-bin.html
@@ -28,5 +28,5 @@ to the <code>npm.bin</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.6.0</p>
+<p id="footer">npm-bin &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-bugs.html
+++ b/deps/npm/html/doc/api/npm-bugs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.6.0</p>
+<p id="footer">npm-bugs &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-cache.html
+++ b/deps/npm/html/doc/api/npm-cache.html
@@ -42,5 +42,5 @@ incrementation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.6.0</p>
+<p id="footer">npm-cache &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-commands.html
+++ b/deps/npm/html/doc/api/npm-commands.html
@@ -36,5 +36,5 @@ usage, or <code>man 3 npm-&lt;command&gt;</code> for programmatic usage.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-commands &mdash; npm@2.6.0</p>
+<p id="footer">npm-commands &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-config.html
+++ b/deps/npm/html/doc/api/npm-config.html
@@ -57,5 +57,5 @@ functions instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.6.0</p>
+<p id="footer">npm-config &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-deprecate.html
+++ b/deps/npm/html/doc/api/npm-deprecate.html
@@ -47,5 +47,5 @@ a deprecation warning to all who attempt to install it.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.6.0</p>
+<p id="footer">npm-deprecate &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-docs.html
+++ b/deps/npm/html/doc/api/npm-docs.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.6.0</p>
+<p id="footer">npm-docs &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-edit.html
+++ b/deps/npm/html/doc/api/npm-edit.html
@@ -36,5 +36,5 @@ and how this is used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.6.0</p>
+<p id="footer">npm-edit &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-explore.html
+++ b/deps/npm/html/doc/api/npm-explore.html
@@ -31,5 +31,5 @@ sure to use <code>npm rebuild &lt;pkg&gt;</code> if you make any changes.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.6.0</p>
+<p id="footer">npm-explore &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-help-search.html
+++ b/deps/npm/html/doc/api/npm-help-search.html
@@ -44,5 +44,5 @@ Name of the file that matched</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.6.0</p>
+<p id="footer">npm-help-search &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-init.html
+++ b/deps/npm/html/doc/api/npm-init.html
@@ -39,5 +39,5 @@ then go ahead and use this programmatically.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.6.0</p>
+<p id="footer">npm-init &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-install.html
+++ b/deps/npm/html/doc/api/npm-install.html
@@ -32,5 +32,5 @@ installed or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.6.0</p>
+<p id="footer">npm-install &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-link.html
+++ b/deps/npm/html/doc/api/npm-link.html
@@ -42,5 +42,5 @@ the package in the current working directory</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.6.0</p>
+<p id="footer">npm-link &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-load.html
+++ b/deps/npm/html/doc/api/npm-load.html
@@ -37,5 +37,5 @@ config object.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-load &mdash; npm@2.6.0</p>
+<p id="footer">npm-load &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-ls.html
+++ b/deps/npm/html/doc/api/npm-ls.html
@@ -63,5 +63,5 @@ dependency will only be output once.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.6.0</p>
+<p id="footer">npm-ls &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-outdated.html
+++ b/deps/npm/html/doc/api/npm-outdated.html
@@ -28,5 +28,5 @@ currently outdated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.6.0</p>
+<p id="footer">npm-outdated &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-owner.html
+++ b/deps/npm/html/doc/api/npm-owner.html
@@ -47,5 +47,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.6.0</p>
+<p id="footer">npm-owner &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-pack.html
+++ b/deps/npm/html/doc/api/npm-pack.html
@@ -33,5 +33,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.6.0</p>
+<p id="footer">npm-pack &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-prefix.html
+++ b/deps/npm/html/doc/api/npm-prefix.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.6.0</p>
+<p id="footer">npm-prefix &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-prune.html
+++ b/deps/npm/html/doc/api/npm-prune.html
@@ -30,5 +30,5 @@ package&#39;s dependencies list.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.6.0</p>
+<p id="footer">npm-prune &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-publish.html
+++ b/deps/npm/html/doc/api/npm-publish.html
@@ -46,5 +46,5 @@ the registry.  Overwrites when the &quot;force&quot; environment variable is set
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.6.0</p>
+<p id="footer">npm-publish &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-rebuild.html
+++ b/deps/npm/html/doc/api/npm-rebuild.html
@@ -30,5 +30,5 @@ the new binary. If no &#39;packages&#39; parameter is specify, every package wil
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.6.0</p>
+<p id="footer">npm-rebuild &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-repo.html
+++ b/deps/npm/html/doc/api/npm-repo.html
@@ -33,5 +33,5 @@ friendly for programmatic use.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.6.0</p>
+<p id="footer">npm-repo &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-restart.html
+++ b/deps/npm/html/doc/api/npm-restart.html
@@ -52,5 +52,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.6.0</p>
+<p id="footer">npm-restart &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-root.html
+++ b/deps/npm/html/doc/api/npm-root.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.6.0</p>
+<p id="footer">npm-root &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-run-script.html
+++ b/deps/npm/html/doc/api/npm-run-script.html
@@ -41,5 +41,5 @@ assumed to be the command to run. All other elements are ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.6.0</p>
+<p id="footer">npm-run-script &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-search.html
+++ b/deps/npm/html/doc/api/npm-search.html
@@ -53,5 +53,5 @@ like).</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.6.0</p>
+<p id="footer">npm-search &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/api/npm-shrinkwrap.html
@@ -33,5 +33,5 @@ been saved.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.6.0</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-start.html
+++ b/deps/npm/html/doc/api/npm-start.html
@@ -28,5 +28,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.6.0</p>
+<p id="footer">npm-start &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-stop.html
+++ b/deps/npm/html/doc/api/npm-stop.html
@@ -28,5 +28,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.6.0</p>
+<p id="footer">npm-stop &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-tag.html
+++ b/deps/npm/html/doc/api/npm-tag.html
@@ -36,5 +36,5 @@ used. For more information about how to set this config, check
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.6.0</p>
+<p id="footer">npm-tag &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-test.html
+++ b/deps/npm/html/doc/api/npm-test.html
@@ -30,5 +30,5 @@ in the <code>packages</code> parameter.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.6.0</p>
+<p id="footer">npm-test &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-uninstall.html
+++ b/deps/npm/html/doc/api/npm-uninstall.html
@@ -30,5 +30,5 @@ uninstalled or when an error has been encountered.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.6.0</p>
+<p id="footer">npm-uninstall &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-unpublish.html
+++ b/deps/npm/html/doc/api/npm-unpublish.html
@@ -33,5 +33,5 @@ the root package entry is removed from the registry entirely.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.6.0</p>
+<p id="footer">npm-unpublish &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-update.html
+++ b/deps/npm/html/doc/api/npm-update.html
@@ -27,5 +27,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.6.0</p>
+<p id="footer">npm-update &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-version.html
+++ b/deps/npm/html/doc/api/npm-version.html
@@ -32,5 +32,5 @@ not have exactly one element. The only element should be a version number.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.6.0</p>
+<p id="footer">npm-version &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-view.html
+++ b/deps/npm/html/doc/api/npm-view.html
@@ -81,5 +81,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.6.0</p>
+<p id="footer">npm-view &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm-whoami.html
+++ b/deps/npm/html/doc/api/npm-whoami.html
@@ -29,5 +29,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.6.0</p>
+<p id="footer">npm-whoami &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/api/npm.html
+++ b/deps/npm/html/doc/api/npm.html
@@ -23,7 +23,7 @@ npm.load([configObject, ]function (er, npm) {
   npm.commands.install([&quot;package&quot;], cb)
 })
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.6.0</p>
+<p>2.6.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>This is the API documentation for npm.
 To find documentation of the command line
@@ -109,5 +109,5 @@ method names.  Use the <code>npm.deref</code> method to find the real name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.6.0</p>
+<p id="footer">npm &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-access.html
+++ b/deps/npm/html/doc/cli/npm-access.html
@@ -75,5 +75,5 @@ with an HTTP 402 status code (logically enough), unless you use
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-access &mdash; npm@2.6.0</p>
+<p id="footer">npm-access &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-adduser.html
+++ b/deps/npm/html/doc/cli/npm-adduser.html
@@ -68,5 +68,5 @@ precedence over any global configuration.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-adduser &mdash; npm@2.6.0</p>
+<p id="footer">npm-adduser &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bin.html
+++ b/deps/npm/html/doc/cli/npm-bin.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bin &mdash; npm@2.6.0</p>
+<p id="footer">npm-bin &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bugs.html
+++ b/deps/npm/html/doc/cli/npm-bugs.html
@@ -54,5 +54,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bugs &mdash; npm@2.6.0</p>
+<p id="footer">npm-bugs &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-build.html
+++ b/deps/npm/html/doc/cli/npm-build.html
@@ -38,5 +38,5 @@ A folder containing a <code>package.json</code> file in its root.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-build &mdash; npm@2.6.0</p>
+<p id="footer">npm-build &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-bundle.html
+++ b/deps/npm/html/doc/cli/npm-bundle.html
@@ -31,5 +31,5 @@ install packages into the local space.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-bundle &mdash; npm@2.6.0</p>
+<p id="footer">npm-bundle &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-cache.html
+++ b/deps/npm/html/doc/cli/npm-cache.html
@@ -81,5 +81,5 @@ they do not make an HTTP request to the registry.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-cache &mdash; npm@2.6.0</p>
+<p id="footer">npm-cache &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-completion.html
+++ b/deps/npm/html/doc/cli/npm-completion.html
@@ -42,5 +42,5 @@ completions based on the arguments.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-completion &mdash; npm@2.6.0</p>
+<p id="footer">npm-completion &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-config.html
+++ b/deps/npm/html/doc/cli/npm-config.html
@@ -66,5 +66,5 @@ global config.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.6.0</p>
+<p id="footer">npm-config &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-dedupe.html
+++ b/deps/npm/html/doc/cli/npm-dedupe.html
@@ -63,5 +63,5 @@ versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dedupe &mdash; npm@2.6.0</p>
+<p id="footer">npm-dedupe &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-deprecate.html
+++ b/deps/npm/html/doc/cli/npm-deprecate.html
@@ -38,5 +38,5 @@ something like this:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-deprecate &mdash; npm@2.6.0</p>
+<p id="footer">npm-deprecate &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-dist-tag.html
+++ b/deps/npm/html/doc/cli/npm-dist-tag.html
@@ -76,5 +76,5 @@ begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-dist-tag &mdash; npm@2.6.0</p>
+<p id="footer">npm-dist-tag &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-docs.html
+++ b/deps/npm/html/doc/cli/npm-docs.html
@@ -56,5 +56,5 @@ the current folder and use the <code>name</code> property.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-docs &mdash; npm@2.6.0</p>
+<p id="footer">npm-docs &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-edit.html
+++ b/deps/npm/html/doc/cli/npm-edit.html
@@ -49,5 +49,5 @@ or <code>&quot;notepad&quot;</code> on Windows.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-edit &mdash; npm@2.6.0</p>
+<p id="footer">npm-edit &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-explore.html
+++ b/deps/npm/html/doc/cli/npm-explore.html
@@ -49,5 +49,5 @@ Windows</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-explore &mdash; npm@2.6.0</p>
+<p id="footer">npm-explore &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-help-search.html
+++ b/deps/npm/html/doc/cli/npm-help-search.html
@@ -46,5 +46,5 @@ where the terms were found in the documentation.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help-search &mdash; npm@2.6.0</p>
+<p id="footer">npm-help-search &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-help.html
+++ b/deps/npm/html/doc/cli/npm-help.html
@@ -52,5 +52,5 @@ matches are equivalent to specifying a topic name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-help &mdash; npm@2.6.0</p>
+<p id="footer">npm-help &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-init.html
+++ b/deps/npm/html/doc/cli/npm-init.html
@@ -40,5 +40,5 @@ defaults and not prompt you for any options.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-init &mdash; npm@2.6.0</p>
+<p id="footer">npm-init &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-install.html
+++ b/deps/npm/html/doc/cli/npm-install.html
@@ -239,5 +239,5 @@ affects a real use-case, it will be investigated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-install &mdash; npm@2.6.0</p>
+<p id="footer">npm-install &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-link.html
+++ b/deps/npm/html/doc/cli/npm-link.html
@@ -71,5 +71,5 @@ include that scope, e.g.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-link &mdash; npm@2.6.0</p>
+<p id="footer">npm-link &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-logout.html
+++ b/deps/npm/html/doc/cli/npm-logout.html
@@ -55,5 +55,5 @@ that registry at the same time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-logout &mdash; npm@2.6.0</p>
+<p id="footer">npm-logout &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-ls.html
+++ b/deps/npm/html/doc/cli/npm-ls.html
@@ -22,7 +22,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@2.6.0 /path/to/npm
+<pre><code>npm@2.6.1 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre><p>It will print out extraneous, missing, and invalid packages.</p>
@@ -85,5 +85,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-ls &mdash; npm@2.6.0</p>
+<p id="footer">npm-ls &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-outdated.html
+++ b/deps/npm/html/doc/cli/npm-outdated.html
@@ -67,5 +67,5 @@ project.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-outdated &mdash; npm@2.6.0</p>
+<p id="footer">npm-outdated &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-owner.html
+++ b/deps/npm/html/doc/cli/npm-owner.html
@@ -49,5 +49,5 @@ that is not implemented at this time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-owner &mdash; npm@2.6.0</p>
+<p id="footer">npm-owner &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-pack.html
+++ b/deps/npm/html/doc/cli/npm-pack.html
@@ -41,5 +41,5 @@ overwritten the second time.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-pack &mdash; npm@2.6.0</p>
+<p id="footer">npm-pack &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-prefix.html
+++ b/deps/npm/html/doc/cli/npm-prefix.html
@@ -38,5 +38,5 @@ to contain a package.json file unless <code>-g</code> is also specified.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prefix &mdash; npm@2.6.0</p>
+<p id="footer">npm-prefix &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-prune.html
+++ b/deps/npm/html/doc/cli/npm-prune.html
@@ -39,5 +39,5 @@ packages specified in your <code>devDependencies</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-prune &mdash; npm@2.6.0</p>
+<p id="footer">npm-prune &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-publish.html
+++ b/deps/npm/html/doc/cli/npm-publish.html
@@ -66,5 +66,5 @@ it is removed with <a href="../cli/npm-unpublish.html"><a href="../cli/npm-unpub
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-publish &mdash; npm@2.6.0</p>
+<p id="footer">npm-publish &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-rebuild.html
+++ b/deps/npm/html/doc/cli/npm-rebuild.html
@@ -38,5 +38,5 @@ the new binary.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rebuild &mdash; npm@2.6.0</p>
+<p id="footer">npm-rebuild &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-repo.html
+++ b/deps/npm/html/doc/cli/npm-repo.html
@@ -42,5 +42,5 @@ a <code>package.json</code> in the current folder and use the <code>name</code> 
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-repo &mdash; npm@2.6.0</p>
+<p id="footer">npm-repo &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-restart.html
+++ b/deps/npm/html/doc/cli/npm-restart.html
@@ -53,5 +53,5 @@ behavior will be accompanied by an increase in major version number</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-restart &mdash; npm@2.6.0</p>
+<p id="footer">npm-restart &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-rm.html
+++ b/deps/npm/html/doc/cli/npm-rm.html
@@ -39,5 +39,5 @@ on its behalf.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-rm &mdash; npm@2.6.0</p>
+<p id="footer">npm-rm &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-root.html
+++ b/deps/npm/html/doc/cli/npm-root.html
@@ -35,5 +35,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-root &mdash; npm@2.6.0</p>
+<p id="footer">npm-root &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-run-script.html
+++ b/deps/npm/html/doc/cli/npm-run-script.html
@@ -50,5 +50,5 @@ and not to any pre or post script.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-run-script &mdash; npm@2.6.0</p>
+<p id="footer">npm-run-script &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-search.html
+++ b/deps/npm/html/doc/cli/npm-search.html
@@ -49,5 +49,5 @@ fall on multiple lines.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-search &mdash; npm@2.6.0</p>
+<p id="footer">npm-search &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-shrinkwrap.html
+++ b/deps/npm/html/doc/cli/npm-shrinkwrap.html
@@ -164,5 +164,5 @@ contents rather than versions.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-shrinkwrap &mdash; npm@2.6.0</p>
+<p id="footer">npm-shrinkwrap &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-star.html
+++ b/deps/npm/html/doc/cli/npm-star.html
@@ -36,5 +36,5 @@ a vaguely positive way to show that you care.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-star &mdash; npm@2.6.0</p>
+<p id="footer">npm-star &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-stars.html
+++ b/deps/npm/html/doc/cli/npm-stars.html
@@ -37,5 +37,5 @@ you will most certainly enjoy this command.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stars &mdash; npm@2.6.0</p>
+<p id="footer">npm-stars &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-start.html
+++ b/deps/npm/html/doc/cli/npm-start.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-start &mdash; npm@2.6.0</p>
+<p id="footer">npm-start &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-stop.html
+++ b/deps/npm/html/doc/cli/npm-stop.html
@@ -34,5 +34,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-stop &mdash; npm@2.6.0</p>
+<p id="footer">npm-stop &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-tag.html
+++ b/deps/npm/html/doc/cli/npm-tag.html
@@ -62,5 +62,5 @@ that do not begin with a number or the letter <code>v</code>.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-tag &mdash; npm@2.6.0</p>
+<p id="footer">npm-tag &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-test.html
+++ b/deps/npm/html/doc/cli/npm-test.html
@@ -37,5 +37,5 @@ true.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-test &mdash; npm@2.6.0</p>
+<p id="footer">npm-test &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-uninstall.html
+++ b/deps/npm/html/doc/cli/npm-uninstall.html
@@ -57,5 +57,5 @@ npm uninstall dtrace-provider --save-optional
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-uninstall &mdash; npm@2.6.0</p>
+<p id="footer">npm-uninstall &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-unpublish.html
+++ b/deps/npm/html/doc/cli/npm-unpublish.html
@@ -47,5 +47,5 @@ package again, a new version number must be used.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-unpublish &mdash; npm@2.6.0</p>
+<p id="footer">npm-unpublish &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-update.html
+++ b/deps/npm/html/doc/cli/npm-update.html
@@ -42,5 +42,5 @@ or local) will be updated.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-update &mdash; npm@2.6.0</p>
+<p id="footer">npm-update &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-version.html
+++ b/deps/npm/html/doc/cli/npm-version.html
@@ -55,5 +55,5 @@ Enter passphrase:
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-version &mdash; npm@2.6.0</p>
+<p id="footer">npm-version &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-view.html
+++ b/deps/npm/html/doc/cli/npm-view.html
@@ -82,5 +82,5 @@ the field name.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-view &mdash; npm@2.6.0</p>
+<p id="footer">npm-view &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm-whoami.html
+++ b/deps/npm/html/doc/cli/npm-whoami.html
@@ -33,5 +33,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-whoami &mdash; npm@2.6.0</p>
+<p id="footer">npm-whoami &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/cli/npm.html
+++ b/deps/npm/html/doc/cli/npm.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.6.0</p>
+<p>2.6.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -110,7 +110,7 @@ easily by doing <code>npm view npm contributors</code>.</p>
 the issues list or ask on the mailing list.</p>
 <ul>
 <li><a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
-<li><a href="&#x6d;&#x61;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#114;&#111;&#117;&#x70;&#x73;&#46;&#99;&#x6f;&#x6d;">&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#114;&#111;&#117;&#x70;&#x73;&#46;&#99;&#x6f;&#x6d;</a></li>
+<li><a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#110;&#112;&#x6d;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#108;&#x65;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#x6f;&#x6d;">&#110;&#112;&#x6d;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#108;&#x65;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#x6f;&#x6d;</a></li>
 </ul>
 <h2 id="bugs">BUGS</h2>
 <p>When you find issues, please report them:</p>
@@ -118,7 +118,7 @@ the issues list or ask on the mailing list.</p>
 <li>web:
 <a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
 <li>email:
-<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x6e;&#x70;&#109;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#111;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#109;">&#x6e;&#x70;&#109;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#111;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#109;</a></li>
+<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#x6e;&#x70;&#x6d;&#x2d;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#115;&#46;&#99;&#x6f;&#109;">&#x6e;&#x70;&#x6d;&#x2d;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#115;&#46;&#99;&#x6f;&#109;</a></li>
 </ul>
 <p>Be sure to include <em>all</em> of the output from the npm command that didn&#39;t work
 as expected.  The <code>npm-debug.log</code> file is also helpful to provide.</p>
@@ -128,7 +128,7 @@ will no doubt tell you to put the output in a gist or email.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="http://twitter.com/izs">@izs</a> ::
-<a href="&#109;&#x61;&#x69;&#108;&#x74;&#111;&#x3a;&#x69;&#x40;&#105;&#122;&#115;&#46;&#x6d;&#101;">&#x69;&#x40;&#105;&#122;&#115;&#46;&#x6d;&#101;</a></p>
+<a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#58;&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#x6d;&#x65;">&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#x6d;&#x65;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html"><a href="../cli/npm-help.html">npm-help(1)</a></a></li>
@@ -154,5 +154,5 @@ will no doubt tell you to put the output in a gist or email.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm &mdash; npm@2.6.0</p>
+<p id="footer">npm &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/files/npm-folders.html
+++ b/deps/npm/html/doc/files/npm-folders.html
@@ -184,5 +184,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html"><a hr
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-folders &mdash; npm@2.6.0</p>
+<p id="footer">npm-folders &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/files/npm-global.html
+++ b/deps/npm/html/doc/files/npm-global.html
@@ -184,5 +184,5 @@ cannot be found elsewhere.  See <code><a href="../files/package.json.html"><a hr
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-global &mdash; npm@2.6.0</p>
+<p id="footer">npm-global &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/files/npm-json.html
+++ b/deps/npm/html/doc/files/npm-json.html
@@ -496,5 +496,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-json &mdash; npm@2.6.0</p>
+<p id="footer">npm-json &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/files/npmrc.html
+++ b/deps/npm/html/doc/files/npmrc.html
@@ -77,5 +77,5 @@ manner.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npmrc &mdash; npm@2.6.0</p>
+<p id="footer">npmrc &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/files/package.json.html
+++ b/deps/npm/html/doc/files/package.json.html
@@ -496,5 +496,5 @@ ignored.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">package.json &mdash; npm@2.6.0</p>
+<p id="footer">package.json &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/index.html
+++ b/deps/npm/html/doc/index.html
@@ -236,5 +236,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">index &mdash; npm@2.6.0</p>
+<p id="footer">index &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-coding-style.html
+++ b/deps/npm/html/doc/misc/npm-coding-style.html
@@ -147,5 +147,5 @@ set to anything.&quot;</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-coding-style &mdash; npm@2.6.0</p>
+<p id="footer">npm-coding-style &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-config.html
+++ b/deps/npm/html/doc/misc/npm-config.html
@@ -206,8 +206,12 @@ If true, then only prints color codes for tty file descriptors.</p>
 <li>Default: Infinity</li>
 <li>Type: Number</li>
 </ul>
-<p>The depth to go when recursing directories for <code>npm ls</code> and
-<code>npm cache ls</code>.</p>
+<p>The depth to go when recursing directories for <code>npm ls</code>, 
+<code>npm cache ls</code>, and <code>npm outdated</code>.</p>
+<p>For <code>npm outdated</code>, a setting of <code>Infinity</code> will be treated as <code>0</code>
+since that gives more useful information.  To show the outdated status
+of all packages and dependents, use a large integer value,
+e.g., <code>npm outdated --depth 9999</code></p>
 <h3 id="description">description</h3>
 <ul>
 <li>Default: true</li>
@@ -774,5 +778,5 @@ exit successfully.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-config &mdash; npm@2.6.0</p>
+<p id="footer">npm-config &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-developers.html
+++ b/deps/npm/html/doc/misc/npm-developers.html
@@ -189,5 +189,5 @@ from a fresh checkout.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-developers &mdash; npm@2.6.0</p>
+<p id="footer">npm-developers &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-disputes.html
+++ b/deps/npm/html/doc/misc/npm-disputes.html
@@ -13,7 +13,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="&#109;&#97;&#105;&#x6c;&#116;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#46;&#x63;&#111;&#x6d;">&#115;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#46;&#x63;&#111;&#x6d;</a></li>
+<li>Email the author, CC <a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#x6f;&#x3a;&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;">&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -51,12 +51,12 @@ Joe&#39;s appropriate course of action in each case is the same.</p>
 owner (Bob).</li>
 <li>Joe emails Bob, explaining the situation <strong>as respectfully as
 possible</strong>, and what he would like to do with the module name.  He
-adds the npm support staff <a href="&#x6d;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#115;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;</a> to the CC list of
+adds the npm support staff <a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#x6d;">&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#x6d;</a> to the CC list of
 the email.  Mention in the email that Bob can run <code>npm owner add
 joe foo</code> to add Joe as an owner of the <code>foo</code> package.</li>
 <li>After a reasonable amount of time, if Bob has not responded, or if
 Bob and Joe can&#39;t come to any sort of resolution, email support
-<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#x73;&#117;&#x70;&#x70;&#111;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#x70;&#111;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
+<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#111;&#x3a;&#x73;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;">&#x73;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
 usually at least 4 weeks, but extra time is allowed around common
 holidays.)</li>
 </ol>
@@ -112,5 +112,5 @@ things into it.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-disputes &mdash; npm@2.6.0</p>
+<p id="footer">npm-disputes &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-faq.html
+++ b/deps/npm/html/doc/misc/npm-faq.html
@@ -236,7 +236,7 @@ that has a package.json in its root, or a git url.
 <p>To check if the registry is down, open up
 <a href="https://registry.npmjs.org/">https://registry.npmjs.org/</a> in a web browser.  This will also tell
 you if you are just unable to access the internet for some reason.</p>
-<p>If the registry IS down, let us know by emailing <a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#111;&#58;&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#109;&#x6a;&#115;&#46;&#x63;&#x6f;&#109;">&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#109;&#x6a;&#115;&#46;&#x63;&#x6f;&#109;</a>
+<p>If the registry IS down, let us know by emailing <a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#58;&#x73;&#x75;&#x70;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#x6f;&#x6d;">&#x73;&#x75;&#x70;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#x6f;&#x6d;</a>
 or posting an issue at <a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a>.  If it&#39;s
 down for the world (and not just on your local network) then we&#39;re
 probably already being pinged about it.</p>
@@ -307,5 +307,5 @@ good folks at <a href="http://www.npmjs.com">npm, Inc.</a></p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-faq &mdash; npm@2.6.0</p>
+<p id="footer">npm-faq &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-index.html
+++ b/deps/npm/html/doc/misc/npm-index.html
@@ -236,5 +236,5 @@
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-index &mdash; npm@2.6.0</p>
+<p id="footer">npm-index &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-registry.html
+++ b/deps/npm/html/doc/misc/npm-registry.html
@@ -70,5 +70,5 @@ effectively implement the entire CouchDB API anyway.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-registry &mdash; npm@2.6.0</p>
+<p id="footer">npm-registry &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-scope.html
+++ b/deps/npm/html/doc/misc/npm-scope.html
@@ -78,5 +78,5 @@ that registry instead.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scope &mdash; npm@2.6.0</p>
+<p id="footer">npm-scope &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/npm-scripts.html
+++ b/deps/npm/html/doc/misc/npm-scripts.html
@@ -216,5 +216,5 @@ the user will sudo the npm command in question.</li>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">npm-scripts &mdash; npm@2.6.0</p>
+<p id="footer">npm-scripts &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/removing-npm.html
+++ b/deps/npm/html/doc/misc/removing-npm.html
@@ -57,5 +57,5 @@ modules.  To track those down, you can do the following:</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">removing-npm &mdash; npm@2.6.0</p>
+<p id="footer">removing-npm &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/doc/misc/semver.html
+++ b/deps/npm/html/doc/misc/semver.html
@@ -282,5 +282,5 @@ range, use the <code>satisfies(version, range)</code> function.</p>
 <tr><td style="width:60px;height:10px;background:rgb(237,127,127)" colspan=6>&nbsp;</td><td colspan=10 style="width:10px;height:10px;background:rgb(237,127,127)">&nbsp;</td></tr>
 <tr><td colspan=5 style="width:50px;height:10px;background:#fff">&nbsp;</td><td style="width:40px;height:10px;background:rgb(237,127,127)" colspan=4>&nbsp;</td><td style="width:90px;height:10px;background:#fff" colspan=9>&nbsp;</td></tr>
 </table>
-<p id="footer">semver &mdash; npm@2.6.0</p>
+<p id="footer">semver &mdash; npm@2.6.1</p>
 

--- a/deps/npm/html/partial/doc/README.html
+++ b/deps/npm/html/partial/doc/README.html
@@ -115,7 +115,7 @@ specific purpose, or lack of malice in any given npm package.</p>
 <p>If you have a complaint about a package in the public npm registry,
 and cannot <a href="https://docs.npmjs.com/misc/disputes">resolve it with the package
 owner</a>, please email
-<a href="&#109;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;</a> and explain the situation.</p>
+<a href="&#109;&#97;&#105;&#x6c;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#x75;&#x70;&#x70;&#111;&#114;&#116;&#x40;&#x6e;&#x70;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#109;</a> and explain the situation.</p>
 <p>Any data published to The npm Registry (including user account
 information) may be removed or modified at the sole discretion of the
 npm server administrators.</p>

--- a/deps/npm/html/partial/doc/api/npm.html
+++ b/deps/npm/html/partial/doc/api/npm.html
@@ -12,7 +12,7 @@ npm.load([configObject, ]function (er, npm) {
   npm.commands.install([&quot;package&quot;], cb)
 })
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.6.0</p>
+<p>2.6.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>This is the API documentation for npm.
 To find documentation of the command line

--- a/deps/npm/html/partial/doc/cli/npm-ls.html
+++ b/deps/npm/html/partial/doc/cli/npm-ls.html
@@ -11,7 +11,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm&#39;s source tree will show:</p>
-<pre><code>npm@2.6.0 /path/to/npm
+<pre><code>npm@2.6.1 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre><p>It will print out extraneous, missing, and invalid packages.</p>

--- a/deps/npm/html/partial/doc/cli/npm.html
+++ b/deps/npm/html/partial/doc/cli/npm.html
@@ -2,7 +2,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <pre><code>npm &lt;command&gt; [args]
 </code></pre><h2 id="version">VERSION</h2>
-<p>2.6.0</p>
+<p>2.6.1</p>
 <h2 id="description">DESCRIPTION</h2>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -99,7 +99,7 @@ easily by doing <code>npm view npm contributors</code>.</p>
 the issues list or ask on the mailing list.</p>
 <ul>
 <li><a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
-<li><a href="&#x6d;&#x61;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#114;&#111;&#117;&#x70;&#x73;&#46;&#99;&#x6f;&#x6d;">&#x6e;&#112;&#109;&#45;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#114;&#111;&#117;&#x70;&#x73;&#46;&#99;&#x6f;&#x6d;</a></li>
+<li><a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#110;&#112;&#x6d;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#108;&#x65;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#x6f;&#x6d;">&#110;&#112;&#x6d;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#108;&#x65;&#103;&#114;&#x6f;&#117;&#x70;&#x73;&#x2e;&#x63;&#x6f;&#x6d;</a></li>
 </ul>
 <h2 id="bugs">BUGS</h2>
 <p>When you find issues, please report them:</p>
@@ -107,7 +107,7 @@ the issues list or ask on the mailing list.</p>
 <li>web:
 <a href="http://github.com/npm/npm/issues">http://github.com/npm/npm/issues</a></li>
 <li>email:
-<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x6e;&#x70;&#109;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#111;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#109;">&#x6e;&#x70;&#109;&#x2d;&#x40;&#103;&#x6f;&#111;&#103;&#x6c;&#101;&#103;&#114;&#111;&#117;&#112;&#x73;&#46;&#x63;&#x6f;&#109;</a></li>
+<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#x6e;&#x70;&#x6d;&#x2d;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#115;&#46;&#99;&#x6f;&#109;">&#x6e;&#x70;&#x6d;&#x2d;&#64;&#103;&#111;&#x6f;&#103;&#x6c;&#x65;&#103;&#x72;&#111;&#x75;&#112;&#115;&#46;&#99;&#x6f;&#109;</a></li>
 </ul>
 <p>Be sure to include <em>all</em> of the output from the npm command that didn&#39;t work
 as expected.  The <code>npm-debug.log</code> file is also helpful to provide.</p>
@@ -117,7 +117,7 @@ will no doubt tell you to put the output in a gist or email.</p>
 <p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
 <a href="https://github.com/isaacs/">isaacs</a> ::
 <a href="http://twitter.com/izs">@izs</a> ::
-<a href="&#109;&#x61;&#x69;&#108;&#x74;&#111;&#x3a;&#x69;&#x40;&#105;&#122;&#115;&#46;&#x6d;&#101;">&#x69;&#x40;&#105;&#122;&#115;&#46;&#x6d;&#101;</a></p>
+<a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#58;&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#x6d;&#x65;">&#x69;&#64;&#105;&#x7a;&#115;&#x2e;&#x6d;&#x65;</a></p>
 <h2 id="see-also">SEE ALSO</h2>
 <ul>
 <li><a href="../cli/npm-help.html">npm-help(1)</a></li>

--- a/deps/npm/html/partial/doc/misc/npm-config.html
+++ b/deps/npm/html/partial/doc/misc/npm-config.html
@@ -195,8 +195,12 @@ If true, then only prints color codes for tty file descriptors.</p>
 <li>Default: Infinity</li>
 <li>Type: Number</li>
 </ul>
-<p>The depth to go when recursing directories for <code>npm ls</code> and
-<code>npm cache ls</code>.</p>
+<p>The depth to go when recursing directories for <code>npm ls</code>, 
+<code>npm cache ls</code>, and <code>npm outdated</code>.</p>
+<p>For <code>npm outdated</code>, a setting of <code>Infinity</code> will be treated as <code>0</code>
+since that gives more useful information.  To show the outdated status
+of all packages and dependents, use a large integer value,
+e.g., <code>npm outdated --depth 9999</code></p>
 <h3 id="description">description</h3>
 <ul>
 <li>Default: true</li>

--- a/deps/npm/html/partial/doc/misc/npm-disputes.html
+++ b/deps/npm/html/partial/doc/misc/npm-disputes.html
@@ -2,7 +2,7 @@
 <h2 id="synopsis">SYNOPSIS</h2>
 <ol>
 <li>Get the author email with <code>npm owner ls &lt;pkgname&gt;</code></li>
-<li>Email the author, CC <a href="&#109;&#97;&#105;&#x6c;&#116;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#46;&#x63;&#111;&#x6d;">&#115;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#x70;&#x6d;&#106;&#x73;&#46;&#x63;&#111;&#x6d;</a></li>
+<li>Email the author, CC <a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#x6f;&#x3a;&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;">&#x73;&#117;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#x6e;&#112;&#x6d;&#106;&#115;&#x2e;&#x63;&#111;&#x6d;</a></li>
 <li>After a few weeks, if there&#39;s no resolution, we&#39;ll sort it out.</li>
 </ol>
 <p>Don&#39;t squat on package names.  Publish code or move out of the way.</p>
@@ -40,12 +40,12 @@ Joe&#39;s appropriate course of action in each case is the same.</p>
 owner (Bob).</li>
 <li>Joe emails Bob, explaining the situation <strong>as respectfully as
 possible</strong>, and what he would like to do with the module name.  He
-adds the npm support staff <a href="&#x6d;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#115;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;">&#115;&#117;&#x70;&#112;&#111;&#x72;&#116;&#64;&#x6e;&#112;&#109;&#x6a;&#115;&#x2e;&#x63;&#x6f;&#109;</a> to the CC list of
+adds the npm support staff <a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#58;&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#x6d;">&#115;&#x75;&#x70;&#x70;&#111;&#x72;&#116;&#x40;&#x6e;&#x70;&#x6d;&#x6a;&#x73;&#x2e;&#x63;&#x6f;&#x6d;</a> to the CC list of
 the email.  Mention in the email that Bob can run <code>npm owner add
 joe foo</code> to add Joe as an owner of the <code>foo</code> package.</li>
 <li>After a reasonable amount of time, if Bob has not responded, or if
 Bob and Joe can&#39;t come to any sort of resolution, email support
-<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#x73;&#117;&#x70;&#x70;&#111;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;">&#x73;&#117;&#x70;&#x70;&#111;&#114;&#x74;&#x40;&#x6e;&#112;&#109;&#106;&#115;&#x2e;&#x63;&#x6f;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
+<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#111;&#x3a;&#x73;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;">&#x73;&#x75;&#x70;&#x70;&#x6f;&#x72;&#x74;&#64;&#110;&#112;&#x6d;&#106;&#x73;&#x2e;&#99;&#111;&#x6d;</a> and we&#39;ll sort it out.  (&quot;Reasonable&quot; is
 usually at least 4 weeks, but extra time is allowed around common
 holidays.)</li>
 </ol>

--- a/deps/npm/html/partial/doc/misc/npm-faq.html
+++ b/deps/npm/html/partial/doc/misc/npm-faq.html
@@ -225,7 +225,7 @@ that has a package.json in its root, or a git url.
 <p>To check if the registry is down, open up
 <a href="https://registry.npmjs.org/">https://registry.npmjs.org/</a> in a web browser.  This will also tell
 you if you are just unable to access the internet for some reason.</p>
-<p>If the registry IS down, let us know by emailing <a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#111;&#58;&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#109;&#x6a;&#115;&#46;&#x63;&#x6f;&#109;">&#x73;&#x75;&#112;&#112;&#x6f;&#114;&#116;&#x40;&#110;&#x70;&#109;&#x6a;&#115;&#46;&#x63;&#x6f;&#109;</a>
+<p>If the registry IS down, let us know by emailing <a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#58;&#x73;&#x75;&#x70;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#x6f;&#x6d;">&#x73;&#x75;&#x70;&#x70;&#111;&#x72;&#x74;&#64;&#x6e;&#x70;&#109;&#106;&#x73;&#46;&#x63;&#x6f;&#x6d;</a>
 or posting an issue at <a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a>.  If it&#39;s
 down for the world (and not just on your local network) then we&#39;re
 probably already being pinged about it.</p>

--- a/deps/npm/lib/cache/add-named.js
+++ b/deps/npm/lib/cache/add-named.js
@@ -12,6 +12,7 @@ var path = require("path")
   , addRemoteTarball = require("./add-remote-tarball.js")
   , cachedPackageRoot = require("./cached-package-root.js")
   , mapToRegistry = require("../utils/map-to-registry.js")
+  , warnStrict = require("../utils/warn-deprecated.js")("engineStrict")
 
 
 module.exports = addNamed
@@ -92,9 +93,10 @@ function engineFilter (data) {
     var eng = data.versions[v].engines
     if (!eng) return
     if (data.versions[v].engineStrict) {
-      log.warn("deprecation", "Per-package engineStrict will no longer be used")
-      log.warn("deprecation", "in upcoming versions of npm. Use the config")
-      log.warn("deprecation", "setting `engine-strict` instead.")
+      warnStrict([
+        "Per-package engineStrict (found in package.json for "+data.name+")",
+        "won't be used in npm 3+. Use the config setting `engine-strict` instead."
+      ], data.name)
     }
     if (!strict && !data.versions[v].engineStrict) return
     if (eng.node && !semver.satisfies(nodev, eng.node, true)

--- a/deps/npm/lib/install.js
+++ b/deps/npm/lib/install.js
@@ -89,6 +89,7 @@ var npm = require("./npm.js")
   , locker = require("./utils/locker.js")
   , lock = locker.lock
   , unlock = locker.unlock
+  , warnPeers = require("./utils/warn-deprecated.js")("peerDependencies")
 
 function install (args, cb_) {
   var hasArguments = !!args.length
@@ -159,15 +160,14 @@ function install (args, cb_) {
               "install",
               "peerDependency", dep, "wasn't going to be installed; adding"
             )
+            warnPeers([
+              "The peer dependency "+dep+" included from "+data.name+" will no",
+              "longer be automatically installed to fulfill the peerDependency ",
+              "in npm 3+. Your application will need to depend on it explicitly."
+            ], dep+","+data.name)
             peers.push(dep)
           }
         })
-        if (peers.length) {
-          log.warn("deprecation", "peerDependencies will no longer be")
-          log.warn("deprecation", "installed implicitly in the next major")
-          log.warn("deprecation", "version of npm (npm@3). You will need to")
-          log.warn("deprecation", "switch to depending on them explicitly.")
-        }
         log.verbose("install", "where, peers", [where, peers])
 
         var context = { family: {}
@@ -1042,6 +1042,13 @@ function write (target, targetFolder, context, cb_) {
         //  favor of killing implicit peerDependency installs with fire.
         var peerDeps = prepareForInstallMany(data, "peerDependencies", bundled,
             wrap, family)
+        peerDeps.forEach(function (pd) {
+            warnPeers([
+              "The peer dependency "+pd+" included from "+data.name+" will no",
+              "longer be automatically installed to fulfill the peerDependency ",
+              "in npm 3+. Your application will need to depend on it explicitly."
+            ], pd+","+data.name)
+        })
         var pdTargetFolder = path.resolve(targetFolder, "..", "..")
         var pdContext = context
         if (peerDeps.length > 0) {

--- a/deps/npm/lib/outdated.js
+++ b/deps/npm/lib/outdated.js
@@ -40,6 +40,10 @@ var path = require("path")
 function outdated (args, silent, cb) {
   if (typeof cb !== "function") cb = silent, silent = false
   var dir = path.resolve(npm.dir, "..")
+
+  // default depth for `outdated` is 0 (cf. `ls`)
+  if (npm.config.get("depth") === Infinity) npm.config.set("depth", 0)
+
   outdated_(args, dir, {}, 0, function (er, list) {
     if (!list) list = []
     if (er || silent || list.length === 0) return cb(er, list)

--- a/deps/npm/lib/utils/warn-deprecated.js
+++ b/deps/npm/lib/utils/warn-deprecated.js
@@ -1,0 +1,24 @@
+module.exports = warnDeprecated
+
+var log = require("npmlog")
+
+var deprecations = {}
+
+function warnDeprecated (type) {
+  return function warn (messages, instance) {
+    if (!instance) {
+      if (!deprecations[type]) {
+        deprecations[type] = {}
+        messages.forEach(function (m) { log.warn(type, m) })
+      }
+    }
+    else {
+      if (!deprecations[type]) deprecations[type] = {}
+
+      if (!deprecations[type][instance]) {
+        deprecations[type][instance] = true
+        messages.forEach(function (m) { log.warn(type, m) })
+      }
+    }
+  }
+}

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -23,7 +23,7 @@ For example, running \fBnpm ls promzard\fR in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@2.6.0 /path/to/npm
+npm@2.6.1 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SH VERSION
 .P
-2.6.0
+2.6.1
 .SH DESCRIPTION
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man3/npm.3
+++ b/deps/npm/man/man3/npm.3
@@ -20,7 +20,7 @@ npm\.load([configObject, ]function (er, npm) {
 .RE
 .SH VERSION
 .P
-2.6.0
+2.6.1
 .SH DESCRIPTION
 .P
 This is the API documentation for npm\.

--- a/deps/npm/man/man7/npm-config.7
+++ b/deps/npm/man/man7/npm-config.7
@@ -340,8 +340,13 @@ Type: Number
 
 .RE
 .P
-The depth to go when recursing directories for \fBnpm ls\fR and
-\fBnpm cache ls\fR\|\.
+The depth to go when recursing directories for \fBnpm ls\fR, 
+\fBnpm cache ls\fR, and \fBnpm outdated\fR\|\.
+.P
+For \fBnpm outdated\fR, a setting of \fBInfinity\fR will be treated as \fB0\fR
+since that gives more useful information\.  To show the outdated status
+of all packages and dependents, use a large integer value,
+e\.g\., \fBnpm outdated \-\-depth 9999\fR
 .SS description
 .RS 0
 .IP \(bu 2

--- a/deps/npm/node_modules/glob/README.md
+++ b/deps/npm/node_modules/glob/README.md
@@ -264,6 +264,7 @@ filesystem.
 * `nocomment` Suppress `comment` behavior.  (See below.)
 * `nonull` Return the pattern when no matches are found.
 * `nodir` Do not match directories, only files.
+* `ignore` Add a pattern or an array of patterns to exclude matches.
 
 ## Comparisons to other fnmatch/glob implementations
 

--- a/deps/npm/node_modules/glob/common.js
+++ b/deps/npm/node_modules/glob/common.js
@@ -6,6 +6,8 @@ exports.ownProp = ownProp
 exports.makeAbs = makeAbs
 exports.finish = finish
 exports.mark = mark
+exports.isIgnored = isIgnored
+exports.childrenIgnored = childrenIgnored
 
 function ownProp (obj, field) {
   return Object.prototype.hasOwnProperty.call(obj, field)
@@ -41,6 +43,29 @@ function alphasort (a, b) {
   return a.localeCompare(b)
 }
 
+function setupIgnores (self, options) {
+  self.ignore = options.ignore || []
+
+  if (!Array.isArray(self.ignore))
+    self.ignore = [self.ignore]
+
+  if (self.ignore.length) {
+    self.ignore = self.ignore.map(ignoreMap)
+  }
+}
+
+function ignoreMap (pattern) {
+  var gmatcher = null
+  if (pattern.slice(-3) === '/**') {
+    var gpattern = pattern.replace(/(\/\*\*)+$/, '')
+    gmatcher = new Minimatch(gpattern, { nonegate: true })
+  }
+
+  return {
+    matcher: new Minimatch(pattern, { nonegate: true }),
+    gmatcher: gmatcher
+  }
+}
 
 function setopts (self, pattern, options) {
   if (!options)
@@ -73,6 +98,8 @@ function setopts (self, pattern, options) {
   self.cache = options.cache || Object.create(null)
   self.statCache = options.statCache || Object.create(null)
   self.symlinks = options.symlinks || Object.create(null)
+
+  setupIgnores(self, options)
 
   self.changedCwd = false
   var cwd = process.cwd()
@@ -139,6 +166,11 @@ function finish (self) {
     }
   }
 
+  if (self.ignore.length)
+    all = all.filter(function(m) {
+      return !isIgnored(self, m)
+    })
+
   self.found = all
 }
 
@@ -166,7 +198,7 @@ function mark (self, p) {
 // lotta situps...
 function makeAbs (self, f) {
   var abs = f
-  if (f.charAt(0) === "/") {
+  if (f.charAt(0) === '/') {
     abs = path.join(self.root, f)
   } else if (exports.isAbsolute(f)) {
     abs = f
@@ -174,4 +206,25 @@ function makeAbs (self, f) {
     abs = path.resolve(self.cwd, f)
   }
   return abs
+}
+
+
+// Return true, if pattern ends with globstar '**', for the accompanying parent directory.
+// Ex:- If node_modules/** is the pattern, add 'node_modules' to ignore list along with it's contents
+function isIgnored (self, path) {
+  if (!self.ignore.length)
+    return false
+
+  return self.ignore.some(function(item) {
+    return item.matcher.match(path) || !!(item.gmatcher && item.gmatcher.match(path))
+  })
+}
+
+function childrenIgnored (self, path) {
+  if (!self.ignore.length)
+    return false
+
+  return self.ignore.some(function(item) {
+    return !!(item.gmatcher && item.gmatcher.match(path))
+  })
 }

--- a/deps/npm/node_modules/glob/glob.js
+++ b/deps/npm/node_modules/glob/glob.js
@@ -56,6 +56,7 @@ var setopts = common.setopts
 var ownProp = common.ownProp
 var inflight = require('inflight')
 var util = require('util')
+var childrenIgnored = common.childrenIgnored
 
 var once = require('once')
 
@@ -270,13 +271,16 @@ Glob.prototype._process = function (pattern, index, inGlobStar, cb) {
 
   var abs = this._makeAbs(read)
 
+  //if ignored, skip _processing
+  if (childrenIgnored(this, read))
+    return cb()
+
   var isGlobStar = remain[0] === minimatch.GLOBSTAR
   if (isGlobStar)
     this._processGlobStar(prefix, read, abs, remain, index, inGlobStar, cb)
   else
     this._processReaddir(prefix, read, abs, remain, index, inGlobStar, cb)
 }
-
 
 Glob.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar, cb) {
   var self = this

--- a/deps/npm/node_modules/glob/package.json
+++ b/deps/npm/node_modules/glob/package.json
@@ -6,7 +6,7 @@
   },
   "name": "glob",
   "description": "a little globber",
-  "version": "4.3.5",
+  "version": "4.4.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/node-glob.git"
@@ -42,16 +42,16 @@
     "benchclean": "bash benchclean.sh"
   },
   "license": "ISC",
-  "gitHead": "9de4cb6bfeb9c8458cf188fe91447b99bf8f3cfd",
+  "gitHead": "57e6b293108b48d9771a05e2b9a6a1b12cb81c12",
   "bugs": {
     "url": "https://github.com/isaacs/node-glob/issues"
   },
   "homepage": "https://github.com/isaacs/node-glob",
-  "_id": "glob@4.3.5",
-  "_shasum": "80fbb08ca540f238acce5d11d1e9bc41e75173d3",
-  "_from": "glob@>=4.3.5 <4.4.0",
-  "_npmVersion": "2.2.0",
-  "_nodeVersion": "0.10.35",
+  "_id": "glob@4.4.0",
+  "_shasum": "91d63dc1ed1d82b52ba2cb76044852ccafc2130f",
+  "_from": "glob@>=4.4.0 <4.5.0",
+  "_npmVersion": "2.6.0",
+  "_nodeVersion": "1.1.0",
   "_npmUser": {
     "name": "isaacs",
     "email": "i@izs.me"
@@ -63,9 +63,10 @@
     }
   ],
   "dist": {
-    "shasum": "80fbb08ca540f238acce5d11d1e9bc41e75173d3",
-    "tarball": "http://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
+    "shasum": "91d63dc1ed1d82b52ba2cb76044852ccafc2130f",
+    "tarball": "http://registry.npmjs.org/glob/-/glob-4.4.0.tgz"
   },
   "directories": {},
-  "_resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
+  "_resolved": "https://registry.npmjs.org/glob/-/glob-4.4.0.tgz",
+  "readme": "ERROR: No README data found!"
 }

--- a/deps/npm/node_modules/glob/sync.js
+++ b/deps/npm/node_modules/glob/sync.js
@@ -14,6 +14,7 @@ var alphasorti = common.alphasorti
 var isAbsolute = common.isAbsolute
 var setopts = common.setopts
 var ownProp = common.ownProp
+var childrenIgnored = common.childrenIgnored
 
 function globSync (pattern, options) {
   if (typeof options === 'function' || arguments.length === 3)
@@ -98,12 +99,17 @@ GlobSync.prototype._process = function (pattern, index, inGlobStar) {
 
   var abs = this._makeAbs(read)
 
+  //if ignored, skip processing
+  if (childrenIgnored(this, read))
+    return
+
   var isGlobStar = remain[0] === minimatch.GLOBSTAR
   if (isGlobStar)
     this._processGlobStar(prefix, read, abs, remain, index, inGlobStar)
   else
     this._processReaddir(prefix, read, abs, remain, index, inGlobStar)
 }
+
 
 GlobSync.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar) {
   var entries = this._readdir(abs, inGlobStar)

--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -42,7 +42,7 @@
           '-luuid.lib',
           '-lodbc32.lib',
           '-lDelayImp.lib',
-          '-l"<(node_root_dir)/$(ConfigurationName)/iojs.lib"'
+          '-l"<(node_root_dir)/$(ConfigurationName)/node.lib"'
         ],
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'

--- a/deps/npm/node_modules/node-gyp/lib/build.js
+++ b/deps/npm/node_modules/node-gyp/lib/build.js
@@ -173,7 +173,7 @@ function build (gyp, argv, callback) {
   }
 
   /**
-   * Copies the iojs.lib file for the current target architecture into the
+   * Copies the node.lib file for the current target architecture into the
    * current proper dev dir location.
    */
 
@@ -181,15 +181,15 @@ function build (gyp, argv, callback) {
     if (!win || !copyDevLib) return doBuild()
 
     var buildDir = path.resolve(nodeDir, buildType)
-      , archNodeLibPath = path.resolve(nodeDir, arch, 'iojs.lib')
-      , buildNodeLibPath = path.resolve(buildDir, 'iojs.lib')
+      , archNodeLibPath = path.resolve(nodeDir, arch, 'node.lib')
+      , buildNodeLibPath = path.resolve(buildDir, 'node.lib')
 
     mkdirp(buildDir, function (err, isNew) {
       if (err) return callback(err)
       log.verbose('"' + buildType + '" dir needed to be created?', isNew)
       var rs = fs.createReadStream(archNodeLibPath)
         , ws = fs.createWriteStream(buildNodeLibPath)
-      log.verbose('copying "iojs.lib" for ' + arch, buildNodeLibPath)
+      log.verbose('copying "node.lib" for ' + arch, buildNodeLibPath)
       rs.pipe(ws)
       rs.on('error', callback)
       ws.on('error', callback)

--- a/deps/npm/node_modules/node-gyp/lib/install.js
+++ b/deps/npm/node_modules/node-gyp/lib/install.js
@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
 
 
   // Determine which node dev files version we are installing
@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
 
       // now download the node tarball
       var tarPath = gyp.opts['tarball']
-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
+      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
         , badDownload = false
         , extractCount = 0
         , gunzip = zlib.createGunzip()
@@ -267,7 +267,7 @@ function install (gyp, argv, callback) {
         var async = 0
 
         if (win) {
-          // need to download iojs.lib
+          // need to download node.lib
           async++
           downloadNodeLib(deref)
         }
@@ -343,36 +343,36 @@ function install (gyp, argv, callback) {
       }
 
       function downloadNodeLib (done) {
-        log.verbose('on Windows; need to download `iojs.lib`...')
+        log.verbose('on Windows; need to download `node.lib`...')
         var dir32 = path.resolve(devDir, 'ia32')
           , dir64 = path.resolve(devDir, 'x64')
-          , nodeLibPath32 = path.resolve(dir32, 'iojs.lib')
-          , nodeLibPath64 = path.resolve(dir64, 'iojs.lib')
-          , nodeLibUrl32 = distUrl + '/v' + version + '/win-x86/iojs.lib'
-          , nodeLibUrl64 = distUrl + '/v' + version + '/win-x64/iojs.lib'
+          , nodeLibPath32 = path.resolve(dir32, 'node.lib')
+          , nodeLibPath64 = path.resolve(dir64, 'node.lib')
+          , nodeLibUrl32 = distUrl + '/v' + version + '/node.lib'
+          , nodeLibUrl64 = distUrl + '/v' + version + '/x64/node.lib'
 
-        log.verbose('32-bit iojs.lib dir', dir32)
-        log.verbose('64-bit iojs.lib dir', dir64)
-        log.verbose('`iojs.lib` 32-bit url', nodeLibUrl32)
-        log.verbose('`iojs.lib` 64-bit url', nodeLibUrl64)
+        log.verbose('32-bit node.lib dir', dir32)
+        log.verbose('64-bit node.lib dir', dir64)
+        log.verbose('`node.lib` 32-bit url', nodeLibUrl32)
+        log.verbose('`node.lib` 64-bit url', nodeLibUrl64)
 
         var async = 2
         mkdir(dir32, function (err) {
           if (err) return done(err)
-          log.verbose('streaming 32-bit iojs.lib to:', nodeLibPath32)
+          log.verbose('streaming 32-bit node.lib to:', nodeLibPath32)
 
           var req = download(nodeLibUrl32)
           if (!req) return
           req.on('error', done)
           req.on('response', function (res) {
             if (res.statusCode !== 200) {
-              done(new Error(res.statusCode + ' status code downloading 32-bit iojs.lib'))
+              done(new Error(res.statusCode + ' status code downloading 32-bit node.lib'))
               return
             }
 
             getContentSha(res, function (_, checksum) {
-              contentShasums['win-x86/iojs.lib'] = checksum
-              log.verbose('content checksum', 'win-x86/iojs.lib', checksum)
+              contentShasums['node.lib'] = checksum
+              log.verbose('content checksum', 'node.lib', checksum)
             })
 
             var ws = fs.createWriteStream(nodeLibPath32)
@@ -385,20 +385,20 @@ function install (gyp, argv, callback) {
         })
         mkdir(dir64, function (err) {
           if (err) return done(err)
-          log.verbose('streaming 64-bit iojs.lib to:', nodeLibPath64)
+          log.verbose('streaming 64-bit node.lib to:', nodeLibPath64)
 
           var req = download(nodeLibUrl64)
           if (!req) return
           req.on('error', done)
           req.on('response', function (res) {
             if (res.statusCode !== 200) {
-              done(new Error(res.statusCode + ' status code downloading 64-bit iojs.lib'))
+              done(new Error(res.statusCode + ' status code downloading 64-bit node.lib'))
               return
             }
 
             getContentSha(res, function (_, checksum) {
-              contentShasums['win-x64/iojs.lib'] = checksum
-              log.verbose('content checksum', 'win-x64/iojs.lib', checksum)
+              contentShasums['x64/node.lib'] = checksum
+              log.verbose('content checksum', 'x64/node.lib', checksum)
             })
 
             var ws = fs.createWriteStream(nodeLibPath64)

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.6.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -53,7 +53,7 @@
     "fstream-npm": "~1.0.1",
     "github-url-from-git": "~1.4.0",
     "github-url-from-username-repo": "~1.0.2",
-    "glob": "~4.3.5",
+    "glob": "~4.4.0",
     "graceful-fs": "~3.0.5",
     "inflight": "~1.0.4",
     "inherits": "~2.0.1",

--- a/deps/npm/test/tap/outdated-depth-deep.js
+++ b/deps/npm/test/tap/outdated-depth-deep.js
@@ -1,0 +1,78 @@
+var common = require("../common-tap")
+  , path = require("path")
+  , test = require("tap").test
+  , rimraf = require("rimraf")
+  , npm = require("../../")
+  , mr = require("npm-registry-mock")
+  , pkg = path.resolve(__dirname, "outdated-depth-deep")
+  , cache = path.resolve(pkg, "cache")
+
+var osenv = require("osenv")
+var mkdirp = require("mkdirp")
+var fs = require("fs")
+
+var pj = JSON.stringify({
+  "name": "whatever",
+  "description": "yeah idk",
+  "version": "1.2.3",
+  "main": "index.js",
+  "dependencies": {
+    "underscore": "1.3.1",
+    "npm-test-peer-deps": "0.0.0"
+  },
+  "repository": "git://github.com/luk-/whatever"
+}, null, 2)
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}
+
+function setup () {
+  mkdirp.sync(pkg)
+  process.chdir(pkg)
+  fs.writeFileSync(path.resolve(pkg, "package.json"), pj)
+}
+
+test("setup", function (t) {
+  cleanup()
+  setup()
+  t.end()
+})
+
+test("outdated depth deep (9999)", function (t) {
+  var underscoreOutdated = ["underscore", "1.3.1", "1.3.1", "1.5.1", "1.3.1"]
+  var childPkg = path.resolve(pkg, "node_modules", "npm-test-peer-deps")
+
+  var expected = [ [pkg].concat(underscoreOutdated),
+                   [childPkg].concat(underscoreOutdated) ]
+
+  process.chdir(pkg)
+
+  mr({port : common.port}, function (er, s) {
+    npm.load({
+      cache: cache
+    , loglevel: "silent"
+    , registry: common.registry
+    , depth: 9999
+    }
+    , function () {
+        npm.install(".", function (er) {
+          if (er) throw new Error(er)
+          npm.outdated(function (err, d) {
+            if (err) throw new Error(err)
+            t.deepEqual(d, expected)
+            s.close()
+            t.end()
+          })
+        })
+      }
+    )
+  })
+})
+
+
+test("cleanup", function (t) {
+  cleanup()
+  t.end()
+})

--- a/deps/npm/test/tap/outdated-depth.js
+++ b/deps/npm/test/tap/outdated-depth.js
@@ -30,7 +30,6 @@ test("outdated depth zero", function (t) {
       cache: cache
     , loglevel: "silent"
     , registry: common.registry
-    , depth: 0
     }
     , function () {
         npm.install(".", function (er) {

--- a/deps/npm/test/tap/outdated-depth/package.json
+++ b/deps/npm/test/tap/outdated-depth/package.json
@@ -4,7 +4,8 @@
   "version": "1.2.3",
   "main": "index.js",
   "dependencies": {
-    "underscore": "1.3.1"
+    "underscore": "1.3.1",
+    "npm-test-peer-deps": "0.0.0"
   },
   "repository": "git://github.com/luk-/whatever"
 }


### PR DESCRIPTION
This is a comparatively modest update, at least compared to `npm@2.7.0`, which includes at least one feature that is very relevant to io.js's interests (foreshadowing!). Here are the pertinent changes in `npm@2.6.1`:

* [`8b98f0e`](https://github.com/npm/npm/commit/8b98f0e709d77a8616c944aebd48ab726f726f76)
  [#4471](https://github.com/npm/npm/issues/4471) `npm outdated` (and only `npm
  outdated`) now defaults to `--depth=0`. This also has the excellent but unexpected effect of making `npm update -g` work the way almost everyone wants it to. See the [docs for
  `--depth`](https://github.com/npm/npm/blob/82f484672adb1a3caf526a8a48832789495bb43d/doc/misc/npm-config.md#depth)
  for the mildly confusing details. ([@smikes](https://github.com/smikes))
* [`aa79194`](https://github.com/npm/npm/commit/aa791942a9f3c8af6a650edec72a675deb7a7c6e)
  [#6565](https://github.com/npm/npm/issues/6565) Tweak `peerDependency`
  deprecation warning to include which peer dependency on which package is
  going to need to change. ([@othiym23](https://github.com/othiym23))
* [`5fa067f`](https://github.com/npm/npm/commit/5fa067fd47682ac3cdb12a2b009d8ca59b05f992)
  [#7171](https://github.com/npm/npm/issues/7171) Tweak `engineStrict`
  deprecation warning to include which `package.json` is using it.
  ([@othiym23](https://github.com/othiym23))

@bnoordhuis, do the floating patches for `node-gyp` still need to be applied, or did da730c76e98fb9fd18dac445dafbbec74d79f802 take care of one or both of them? I was unclear on this, so held off on applying them.