### PR TITLE
tls: fix typo `handle._reading` => `handle.reading`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -281,7 +281,7 @@ TLSSocket.prototype._wrapHandle = function(handle) {
                 tls.createSecureContext();
   res = tls_wrap.wrap(handle, context.context, options.isServer);
   res._parent = handle;
-  res._reading = handle._reading;
+  res.reading = handle.reading;
 
   // Proxy HandleWrap, PipeWrap and TCPWrap methods
   proxiedMethods.forEach(function(name) {


### PR DESCRIPTION
The problem does not manifest itself on unixes, because
`uv_read_start()` always return 0 there. However on Windows on a second
call `uv_read_start()` returns `UV__EALREADY` destroying all sockets on
a read attempt.

Set `.reading` property that is already handled by `net.js` code.

Fix: https://github.com/iojs/io.js/issues/988