### PR TITLE
install: new performance counters provider guid

### DIFF
--- a/src/res/node_perfctr_provider.man
+++ b/src/res/node_perfctr_provider.man
@@ -8,7 +8,7 @@
         <provider symbol="NodeCounterProvider"
                   applicationIdentity="iojs.exe"
                   providerType="userMode"
-                  providerGuid="{1E2E15D7-3760-470E-8699-B9DB5248EDD5}">
+                  providerGuid="{793C9B44-3D6B-4F57-B5D7-4FF80ADCF9A2}">
           <counterSet symbol="NodeCounterSet"
                       guid="{3A22A8EC-297C-48AC-AB15-33EC93033FD8}"
                       uri="Microsoft.Windows.System.PerfCounters.NodeCounterSet"


### PR DESCRIPTION
io.js performance counters' manifest conflicts wth node.js' caused
install failures. A unique guid for the iojs performance counters
will resolve iojs/io.js#524.

refs: iojs/io.js#524