### PR TITLE
tls: proxy `handle.reading` back to parent handle

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -281,7 +281,14 @@ TLSSocket.prototype._wrapHandle = function(handle) {
                 tls.createSecureContext();
   res = tls_wrap.wrap(handle, context.context, options.isServer);
   res._parent = handle;
-  res.reading = handle.reading;
+  Object.defineProperty(res, 'reading', {
+    get: function readingGetter() {
+      return handle.reading;
+    },
+    set: function readingSetter(value) {
+      handle.reading = value;
+    }
+  });
 
   // Proxy HandleWrap, PipeWrap and TCPWrap methods
   proxiedMethods.forEach(function(name) {


### PR DESCRIPTION
Fix: https://github.com/iojs/io.js/issues/995

cc @rvagg 