### PR TITLE
tls: proxy `handle.reading` back to parent handle

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -282,6 +282,14 @@ TLSSocket.prototype._wrapHandle = function(handle) {
   res = tls_wrap.wrap(handle, context.context, options.isServer);
   res._parent = handle;
   res.reading = handle.reading;
+  Object.defineProperty(handle, 'reading', {
+    get: function readingGetter() {
+      return res.reading;
+    },
+    set: function readingSetter(value) {
+      res.reading = value;
+    }
+  });
 
   // Proxy HandleWrap, PipeWrap and TCPWrap methods
   proxiedMethods.forEach(function(name) {


### PR DESCRIPTION
Fix: https://github.com/iojs/io.js/issues/995

cc @rvagg this should be a faster version of #1003 

Please verify it and if it works - land it instead of #1003 