### PR TITLE
doc: suggest alternatives to deprecated APIs

### DIFF
--- a/doc/api/fs.markdown
+++ b/doc/api/fs.markdown
@@ -642,6 +642,10 @@ callback, and have some fallback logic if it is null.
 
 ## fs.exists(path, callback)
 
+`fs.exists()` is **deprecated**. For supported alternatives please check out
+[`fs.stat`](fs.html#fs_fs_stat_path_callback) or 
+[`fs.access`](fs.html#fs_fs_access_path_mode_callback).
+
 Test whether or not the given path exists by checking with the file system.
 Then call the `callback` argument with either true or false.  Example:
 
@@ -657,13 +661,15 @@ that leaves you vulnerable to race conditions: another process may remove the
 file between the calls to `fs.exists()` and `fs.open()`.  Just open the file
 and handle the error when it's not there.
 
-`fs.exists()` is **deprecated**.
+
 
 ## fs.existsSync(path)
 
-Synchronous version of `fs.exists`.
+Synchronous version of [`fs.exists`](fs.html#fs_fs_exists_path_callback).
 
-`fs.existsSync()` is **deprecated**.
+`fs.existsSync()` is **deprecated**. For supported alternatives please check
+out [`fs.statSync`](fs.html#fs_fs_statsync_path) or 
+[`fs.accessSync`](fs.html#fs_fs_accesssync_path_mode).
 
 ## fs.access(path[, mode], callback)
 


### PR DESCRIPTION
At the moment users who want to use `fs.exists` get a warning that the method is deprecated but do not get offered an alternative in the page. This PR suggests `fs.stat` and `fs.access` as alternatives while keeping the warning about the use case in place.

This PR closes https://github.com/iojs/io.js/issues/1002