### PR TITLE
stream_base: `.writev()` has limited support

### DIFF
--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -210,7 +210,7 @@ void JSStream::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "readBuffer", ReadBuffer);
   env->SetProtoMethod(t, "emitEOF", EmitEOF);
 
-  StreamBase::AddMethods<JSStream>(env, t);
+  StreamBase::AddMethods<JSStream>(env, t, StreamBase::kFlagHasWritev);
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "JSStream"),
               t->GetFunction());
   env->set_jsstream_constructor_template(t);

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -21,7 +21,9 @@ using v8::String;
 using v8::Value;
 
 template <class Base>
-void StreamBase::AddMethods(Environment* env, Handle<FunctionTemplate> t) {
+void StreamBase::AddMethods(Environment* env,
+                            Handle<FunctionTemplate> t,
+                            int flags) {
   HandleScope scope(env->isolate());
 
   enum PropertyAttribute attributes =
@@ -36,7 +38,8 @@ void StreamBase::AddMethods(Environment* env, Handle<FunctionTemplate> t) {
   env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
   env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
   env->SetProtoMethod(t, "shutdown", JSMethod<Base, &StreamBase::Shutdown>);
-  env->SetProtoMethod(t, "writev", JSMethod<Base, &StreamBase::Writev>);
+  if ((flags & kFlagHasWritev) != 0)
+    env->SetProtoMethod(t, "writev", JSMethod<Base, &StreamBase::Writev>);
   env->SetProtoMethod(t,
                       "writeBuffer",
                       JSMethod<Base, &StreamBase::WriteBuffer>);

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -158,9 +158,15 @@ class StreamResource {
 
 class StreamBase : public StreamResource {
  public:
+  enum Flags {
+    kFlagNone = 0x0,
+    kFlagHasWritev = 0x1
+  };
+
   template <class Base>
   static inline void AddMethods(Environment* env,
-                                v8::Handle<v8::FunctionTemplate> target);
+                                v8::Handle<v8::FunctionTemplate> target,
+                                int flags = kFlagNone);
 
   virtual void* Cast() = 0;
   virtual bool IsAlive() = 0;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -81,9 +81,10 @@ StreamWrap::StreamWrap(Environment* env,
 
 
 void StreamWrap::AddMethods(Environment* env,
-                            v8::Handle<v8::FunctionTemplate> target) {
+                            v8::Handle<v8::FunctionTemplate> target,
+                            int flags) {
   env->SetProtoMethod(target, "setBlocking", SetBlocking);
-  StreamBase::AddMethods<StreamWrap>(env, target);
+  StreamBase::AddMethods<StreamWrap>(env, target, flags);
 }
 
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -68,7 +68,8 @@ class StreamWrap : public HandleWrap, public StreamBase {
   void UpdateWriteQueueSize();
 
   static void AddMethods(Environment* env,
-                         v8::Handle<v8::FunctionTemplate> target);
+                         v8::Handle<v8::FunctionTemplate> target,
+                         int flags = StreamBase::kFlagNone);
 
  private:
   static void SetBlocking(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -89,7 +89,7 @@ void TCPWrap::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
 
-  StreamWrap::AddMethods(env, t);
+  StreamWrap::AddMethods(env, t, StreamBase::kFlagHasWritev);
 
   env->SetProtoMethod(t, "open", Open);
   env->SetProtoMethod(t, "bind", Bind);


### PR DESCRIPTION
Only TCP and JSStream do support `.writev()` on all platforms at the
moment. Ensure that it won't be enabled everywhere.

Fix: https://github.com/iojs/io.js/issues/995

cc @rvagg @piscisaureus should fix that writev ENOTSUP thing on windows.