### PR TITLE
url: throw for invalid values to url.format

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -353,7 +353,13 @@ function urlFormat(obj) {
   // this way, you can call url_format() on strings
   // to clean up potentially wonky urls.
   if (typeof obj === 'string') obj = urlParse(obj);
-  if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
+
+  else if (typeof obj !== 'object' || obj === null)
+    throw new TypeError("Parameter 'urlObj' must be an object, not " +
+                        obj === null ? 'null' : typeof obj);
+
+  else if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
+
   return obj.format();
 }
 

--- a/test/parallel/test-url.js
+++ b/test/parallel/test-url.js
@@ -1557,3 +1557,20 @@ relativeTests2.forEach(function(relativeTest) {
                'format(' + relativeTest[1] + ') == ' + expected +
                '\nactual:' + actual);
 });
+
+
+
+// https://github.com/iojs/io.js/pull/1036
+var throws = [
+  undefined,
+  null,
+  true,
+  false,
+  0,
+  function () {}
+];
+for (var i = 0; i < throws.length; i++) {
+  assert.throws(function () { url.format(throws[i]); }, TypeError);
+};
+assert(url.format('') === '');
+assert(url.format({}) === '');


### PR DESCRIPTION
(Original title:  "url: fix passing undefined to url.format")

`'use strict'` changes the behavior for `Function.prototype.call` when
the context is `undefined`. In earlier versions of node the value
`undefined` would make `url.format` look for fields in the global scope.

Fixes: https://github.com/iojs/io.js/issues/1033