### PR TITLE
test: fix racey-ness in tls-inception

### DIFF
--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -28,6 +28,10 @@ a = tls.createServer(options, function (socket) {
   var dest = net.connect(options);
   dest.pipe(socket);
   socket.pipe(dest);
+
+  dest.on('close', function() {
+    socket.destroy();
+  });
 });
 
 // the "target" server


### PR DESCRIPTION
Fix test failure on FreeBSD and SmartOS, which happens due to a bad
timing:

    events.js:141
          throw er; // Unhandled 'error' event
                ^
    Error: read ECONNRESET
        at exports._errnoException (util.js:734:11)
        at TLSWrap.onread (net.js:538:26)

The outer `net.conncet()` socket stays alive after the inner socket is
gone. This happens because `.pipe()`'s implementation does not `destroy`
the source side when the destination has emitted `close`.

Fix: https://github.com/iojs/io.js/issues/1012