### PR TITLE
src: fix StringBytes::Write()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -139,9 +139,6 @@ static uv_async_t dispatch_debug_messages_async;
 
 static Isolate* node_isolate = nullptr;
 
-int WRITE_UTF8_FLAGS = v8::String::HINT_MANY_WRITES_EXPECTED |
-                       v8::String::NO_NULL_TERMINATION;
-
 class ArrayBufferAllocator : public ArrayBuffer::Allocator {
  public:
   // Impose an upper limit to avoid out of memory errors that bring down
@@ -3818,11 +3815,6 @@ static void StartNodeInstance(void* arg) {
 
 int Start(int argc, char** argv) {
   PlatformInit();
-
-  const char* replace_invalid = secure_getenv("NODE_INVALID_UTF8");
-
-  if (replace_invalid == nullptr)
-    WRITE_UTF8_FLAGS |= String::REPLACE_INVALID_UTF8;
 
   CHECK_GT(argc, 0);
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -415,9 +415,6 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   if (max_length == 0)
     return args.GetReturnValue().Set(0);
 
-  if (encoding == UCS2)
-    max_length = max_length / 2;
-
   if (offset >= obj_length)
     return env->ThrowRangeError("Offset is out of bounds");
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -754,20 +754,16 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
 Local<Value> StringBytes::Encode(Isolate* isolate,
                                  const uint16_t* buf,
                                  size_t buflen) {
-  const uint16_t* src = buf;
-
   Local<String> val;
+
   if (buflen < EXTERN_APEX) {
     val = String::NewFromTwoByte(isolate,
-                                 src,
+                                 buf,
                                  String::kNormalString,
                                  buflen);
   } else {
-    val = ExternTwoByteString::NewFromCopy(isolate, src, buflen);
+    val = ExternTwoByteString::NewFromCopy(isolate, buf, buflen);
   }
-
-  if (src != buf)
-    delete[] src;
 
   return val;
 }

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -279,13 +279,15 @@ size_t StringBytes::Write(Isolate* isolate,
                           int* chars_written) {
   HandleScope scope(isolate);
   const char* data = nullptr;
-  size_t len = 0;
-  bool is_extern = GetExternalParts(isolate, val, &data, &len);
-  size_t extlen = len;
+  size_t nbytes = 0;
+  const bool is_extern = GetExternalParts(isolate, val, &data, &nbytes);
+  const size_t external_nbytes = nbytes;
 
   CHECK(val->IsString() == true);
   Local<String> str = val.As<String>();
-  len = len < buflen ? len : buflen;
+
+  if (nbytes > buflen)
+    nbytes = buflen;
 
   int flags = String::HINT_MANY_WRITES_EXPECTED |
               String::NO_NULL_TERMINATION |
@@ -295,67 +297,65 @@ size_t StringBytes::Write(Isolate* isolate,
     case ASCII:
     case BINARY:
     case BUFFER:
-      if (is_extern)
-        memcpy(buf, data, len);
-      else
-        len = str->WriteOneByte(reinterpret_cast<uint8_t*>(buf),
-                                0,
-                                buflen,
-                                flags);
+      if (is_extern && str->IsOneByte()) {
+        memcpy(buf, data, nbytes);
+      } else {
+        uint8_t* const dst = reinterpret_cast<uint8_t*>(buf);
+        nbytes = str->WriteOneByte(dst, 0, buflen, flags);
+      }
       if (chars_written != nullptr)
-        *chars_written = len;
+        *chars_written = nbytes;
       break;
 
     case UTF8:
-      if (is_extern)
-        // TODO(tjfontaine) should this validate invalid surrogate pairs as
-        // well?
-        memcpy(buf, data, len);
-      else
-        len = str->WriteUtf8(buf, buflen, chars_written, flags);
+      nbytes = str->WriteUtf8(buf, buflen, chars_written, flags);
       break;
 
-    case UCS2:
-      if (is_extern)
-        memcpy(buf, data, len);
-      else
-        len = str->Write(reinterpret_cast<uint16_t*>(buf), 0, buflen, flags);
+    case UCS2: {
+      uint16_t* const dst = reinterpret_cast<uint16_t*>(buf);
+      size_t nchars;
+      if (is_extern && !str->IsOneByte()) {
+        memcpy(buf, data, nbytes);
+        nchars = nbytes / sizeof(*dst);
+      } else {
+        nchars = buflen / sizeof(*dst);
+        nchars = str->Write(dst, 0, nchars, flags);
+        nbytes = nchars * sizeof(*dst);
+      }
       if (IsBigEndian()) {
         // Node's "ucs2" encoding wants LE character data stored in
         // the Buffer, so we need to reorder on BE platforms.  See
         // http://nodejs.org/api/buffer.html regarding Node's "ucs2"
         // encoding specification
-        uint16_t* buf16 = reinterpret_cast<uint16_t*>(buf);
-        for (size_t i = 0; i < len; i++) {
-          buf16[i] = (buf16[i] << 8) | (buf16[i] >> 8);
-        }
+        for (size_t i = 0; i < nchars; i++)
+          dst[i] = dst[i] << 8 | dst[i] >> 8;
       }
       if (chars_written != nullptr)
-        *chars_written = len;
-      len = len * sizeof(uint16_t);
+        *chars_written = nchars;
       break;
+    }
 
     case BASE64:
       if (is_extern) {
-        len = base64_decode(buf, buflen, data, extlen);
+        nbytes = base64_decode(buf, buflen, data, external_nbytes);
       } else {
         String::Value value(str);
-        len = base64_decode(buf, buflen, *value, value.length());
+        nbytes = base64_decode(buf, buflen, *value, value.length());
       }
       if (chars_written != nullptr) {
-        *chars_written = len;
+        *chars_written = nbytes;
       }
       break;
 
     case HEX:
       if (is_extern) {
-        len = hex_decode(buf, buflen, data, extlen);
+        nbytes = hex_decode(buf, buflen, data, external_nbytes);
       } else {
         String::Value value(str);
-        len = hex_decode(buf, buflen, *value, value.length());
+        nbytes = hex_decode(buf, buflen, *value, value.length());
       }
       if (chars_written != nullptr) {
-        *chars_written = len * 2;
+        *chars_written = nbytes;
       }
       break;
 
@@ -364,7 +364,7 @@ size_t StringBytes::Write(Isolate* isolate,
       break;
   }
 
-  return len;
+  return nbytes;
 }
 
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -263,7 +263,7 @@ bool StringBytes::GetExternalParts(Isolate* isolate,
     const String::ExternalStringResource* ext;
     ext = str->GetExternalStringResource();
     *data = reinterpret_cast<const char*>(ext->data());
-    *len = ext->length();
+    *len = ext->length() * sizeof(*ext->data());
     return true;
   }
 
@@ -317,7 +317,7 @@ size_t StringBytes::Write(Isolate* isolate,
 
     case UCS2:
       if (is_extern)
-        memcpy(buf, data, len * 2);
+        memcpy(buf, data, len);
       else
         len = str->Write(reinterpret_cast<uint16_t*>(buf), 0, buflen, flags);
       if (IsBigEndian()) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -28,8 +28,7 @@ class ExternString: public ResourceType {
   public:
     ~ExternString() override {
       delete[] data_;
-      int64_t change_in_bytes = -static_cast<int64_t>(length_);
-      isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+      isolate()->AdjustAmountOfExternalAllocatedMemory(-byte_length());
     }
 
     const TypeName* data() const override {
@@ -38,6 +37,10 @@ class ExternString: public ResourceType {
 
     size_t length() const override {
       return length_;
+    }
+
+    int64_t byte_length() const {
+      return length() * sizeof(*data());
     }
 
     static Local<String> NewFromCopy(Isolate* isolate,
@@ -69,7 +72,7 @@ class ExternString: public ResourceType {
                                                                      data,
                                                                      length);
       Local<String> str = String::NewExternal(isolate, h_str);
-      isolate->AdjustAmountOfExternalAllocatedMemory(length);
+      isolate->AdjustAmountOfExternalAllocatedMemory(h_str->byte_length());
 
       return scope.Escape(str);
     }

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -287,8 +287,9 @@ size_t StringBytes::Write(Isolate* isolate,
   Local<String> str = val.As<String>();
   len = len < buflen ? len : buflen;
 
-  int flags = String::NO_NULL_TERMINATION |
-              String::HINT_MANY_WRITES_EXPECTED;
+  int flags = String::HINT_MANY_WRITES_EXPECTED |
+              String::NO_NULL_TERMINATION |
+              String::REPLACE_INVALID_UTF8;
 
   switch (encoding) {
     case ASCII:
@@ -311,7 +312,7 @@ size_t StringBytes::Write(Isolate* isolate,
         // well?
         memcpy(buf, data, len);
       else
-        len = str->WriteUtf8(buf, buflen, chars_written, WRITE_UTF8_FLAGS);
+        len = str->WriteUtf8(buf, buflen, chars_written, flags);
       break;
 
     case UCS2:

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -10,8 +10,6 @@
 
 namespace node {
 
-extern int WRITE_UTF8_FLAGS;
-
 class StringBytes {
  public:
   class InlineDecoder {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,11 +1,10 @@
 #include "util.h"
-
 #include "string_bytes.h"
 
 namespace node {
 
 Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
-  : length_(0), str_(nullptr) {
+    : length_(0), str_(str_st_) {
   if (value.IsEmpty())
     return;
 
@@ -15,19 +14,15 @@ Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
 
   // Allocate enough space to include the null terminator
   size_t len = StringBytes::StorageSize(val_, UTF8) + 1;
-
-  char* str;
-  if (len > kStorageSize)
-    str = static_cast<char*>(malloc(len));
-  else
-    str = str_st_;
-  CHECK_NE(str, NULL);
+  if (len > sizeof(str_st_)) {
+    str_ = static_cast<char*>(malloc(len));
+    CHECK_NE(str_, nullptr);
+  }
 
   const int flags =
       v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-  length_ = val_->WriteUtf8(str, len, 0, flags);
-  str[length_] = '\0';
-
-  str_ = reinterpret_cast<char*>(str);
+  length_ = val_->WriteUtf8(str_, len, 0, flags);
+  str_[length_] = '\0';
 }
+
 }  // namespace node

--- a/src/util.cc
+++ b/src/util.cc
@@ -8,12 +8,12 @@ Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
   if (value.IsEmpty())
     return;
 
-  v8::Local<v8::String> val_ = value->ToString(isolate);
-  if (val_.IsEmpty())
+  v8::Local<v8::String> string = value->ToString(isolate);
+  if (string.IsEmpty())
     return;
 
   // Allocate enough space to include the null terminator
-  size_t len = StringBytes::StorageSize(val_, UTF8) + 1;
+  size_t len = StringBytes::StorageSize(string, UTF8) + 1;
   if (len > sizeof(str_st_)) {
     str_ = static_cast<char*>(malloc(len));
     CHECK_NE(str_, nullptr);
@@ -21,7 +21,7 @@ Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
 
   const int flags =
       v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-  length_ = val_->WriteUtf8(str_, len, 0, flags);
+  length_ = string->WriteUtf8(str_, len, 0, flags);
   str_[length_] = '\0';
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -23,12 +23,9 @@ Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value)
     str = str_st_;
   CHECK_NE(str, NULL);
 
-  int flags = WRITE_UTF8_FLAGS;
-
-  length_ = val_->WriteUtf8(str,
-                            len,
-                            0,
-                            flags);
+  const int flags =
+      v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+  length_ = val_->WriteUtf8(str, len, 0, flags);
   str[length_] = '\0';
 
   str_ = reinterpret_cast<char*>(str);

--- a/src/util.h
+++ b/src/util.h
@@ -190,10 +190,9 @@ class Utf8Value {
     };
 
   private:
-    static const int kStorageSize = 1024;
     size_t length_;
-    char str_st_[kStorageSize];
     char* str_;
+    char str_st_[1024];
 };
 
 }  // namespace node

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -106,3 +106,16 @@ var PRE_3OF4_APEX = Math.ceil((EXTERN_APEX / 4) * 3) - RADIOS;
     }
   }
 })();
+
+// https://github.com/iojs/io.js/issues/1024
+(function() {
+  var a = Array(1 << 20).join('x');
+  var b = Buffer(a, 'ucs2').toString('ucs2');
+  var c = Buffer(b, 'utf8').toString('utf8');
+
+  assert.equal(a.length, b.length);
+  assert.equal(b.length, c.length);
+
+  assert.equal(a, b);
+  assert.equal(b, c);
+})();

--- a/test/parallel/test-stringbytes-external.js
+++ b/test/parallel/test-stringbytes-external.js
@@ -15,15 +15,10 @@ assert.equal(b[0], 0x61);
 assert.equal(b[1], 0);
 assert.equal(ucs2_control, c);
 
-
-// grow the strings to proper length
-while (write_str.length <= EXTERN_APEX) {
-  write_str += write_str;
-  ucs2_control += ucs2_control;
-}
-write_str += write_str.substr(0, EXTERN_APEX - write_str.length);
-ucs2_control += ucs2_control.substr(0, EXTERN_APEX * 2 - ucs2_control.length);
-
+// now create big strings
+var size = 1 + (1 << 20);
+write_str = Array(size).join(write_str);
+ucs2_control = Array(size).join(ucs2_control);
 
 // check resultant buffer and output string
 var b = new Buffer(write_str, 'ucs2');


### PR DESCRIPTION
This is the fix for #1024.  I still need to turn the last four commits into a coherent narrative.

I'm going to go over src/string_bytes.cc one more time because I suspect there are still more bugs lurking.

R=@trevnorris