### PR TITLE
Crypto tests overhaul

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -43,6 +43,9 @@ Object.defineProperty(exports, 'opensslCli', {get: function() {
   return opensslCli;
 }, enumerable: true });
 
+Object.defineProperty(exports, 'hasCrypto', {get: function() {
+  return process.versions.openssl ? true : false;
+}});
 
 if (process.platform === 'win32') {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';

--- a/test/internet/test-http-https-default-ports.js
+++ b/test/internet/test-http-https-default-ports.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var http = require('http');
 var gotHttpsResp = false;
 var gotHttpResp = false;

--- a/test/internet/test-tls-reuse-host-from-socket.js
+++ b/test/internet/test-tls-reuse-host-from-socket.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var net = require('net');
 var connected = false;
 var secure = false;

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1108,16 +1108,20 @@ assert.throws(function () {
   new SlowBuffer(smalloc.kMaxLength + 1);
 }, RangeError);
 
-// Test truncation after decode
-var crypto = require('crypto');
+if (common.hasCrypto) {
+  // Test truncation after decode
+  var crypto = require('crypto');
 
-var b1 = new Buffer('YW55=======', 'base64');
-var b2 = new Buffer('YW55', 'base64');
+  var b1 = new Buffer('YW55=======', 'base64');
+  var b2 = new Buffer('YW55', 'base64');
 
-assert.equal(
-  crypto.createHash('sha1').update(b1).digest('hex'),
-  crypto.createHash('sha1').update(b2).digest('hex')
-);
+  assert.equal(
+    crypto.createHash('sha1').update(b1).digest('hex'),
+    crypto.createHash('sha1').update(b2).digest('hex')
+  );
+} else {
+  console.log('1..0 # Skipped: missing crypto');
+}
 
 // Test Compare
 var b = new Buffer(1).fill('a');

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -6,13 +6,11 @@ var common = require('../common');
 var assert = require('assert');
 var constants = require('constants');
 
-try {
-  var crypto = require('crypto');
-  var tls = require('tls');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'binary';
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -1,6 +1,10 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 function testCipher1(key) {
   // Test encryption and decryption

--- a/test/parallel/test-crypto-dh-odd-key.js
+++ b/test/parallel/test-crypto-dh-odd-key.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
+
 var odd = new Buffer(39);
 odd.fill('A');
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -2,12 +2,11 @@ var common = require('../common');
 var assert = require('assert');
 var constants = require('constants');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along

--- a/test/parallel/test-crypto-domain.js
+++ b/test/parallel/test-crypto-domain.js
@@ -2,12 +2,11 @@ var common = require('../common');
 var assert = require('assert');
 var domain = require('domain');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Skipping test, compiled without crypto support.');
-  return;
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
 }
+var crypto = require('crypto');
 
 function test(fn) {
   var ex = new Error('BAM');

--- a/test/parallel/test-crypto-domains.js
+++ b/test/parallel/test-crypto-domains.js
@@ -1,9 +1,15 @@
-var crypto = require('crypto');
+var common = require('../common');
 var domain = require('domain');
 var assert = require('assert');
 var d = domain.create();
 var expect = ['pbkdf2', 'randomBytes', 'pseudoRandomBytes']
 var errors = 0;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var crypto = require('crypto');
 
 process.on('exit', function() {
   assert.equal(errors, 3);

--- a/test/parallel/test-crypto-ecb.js
+++ b/test/parallel/test-crypto-ecb.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto-from-binary.js
+++ b/test/parallel/test-crypto-from-binary.js
@@ -5,12 +5,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 var EXTERN_APEX = 0xFBEE9;
 

--- a/test/parallel/test-crypto-hash-stream-pipe.js
+++ b/test/parallel/test-crypto-hash-stream-pipe.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
+
 var stream = require('stream')
 var s = new stream.PassThrough();
 var h = crypto.createHash('sha1');

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -3,12 +3,11 @@ var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Test hashing
 var a0 = crypto.createHash('sha1').update('Test123').digest('hex');

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Test HMAC
 var h1 = crypto.createHmac('sha1', 'Node')

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OpenSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 //
 // Test PBKDF2 with RFC 6070 test vectors (except #4)

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -1,12 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -3,12 +3,11 @@ var assert = require('assert');
 var fs = require('fs');
 var constants = require('constants');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Test certificates
 var certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -2,12 +2,11 @@ var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Test certificates
 var certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -3,12 +3,11 @@ var assert = require('assert');
 var stream = require('stream');
 var util = require('util');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 // Small stream to buffer converter
 function Stream2buffer(callback) {

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -1,13 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
-try {
-  var crypto = require('crypto');
-  var tls = require('tls');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
+var tls = require('tls');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -2,12 +2,11 @@ var common = require('../common');
 var assert = require('assert');
 var util = require('util');
 
-try {
-  var crypto = require('crypto');
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
   process.exit();
 }
+var crypto = require('crypto');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 

--- a/test/parallel/test-http-curl-chunk-problem.js
+++ b/test/parallel/test-http-curl-chunk-problem.js
@@ -1,11 +1,11 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
+var common = require('../common');
+var assert = require('assert');
+if (!common.opensslCli) {
+  console.error('Skipping because node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 
 // http://groups.google.com/group/nodejs/browse_thread/thread/f66cd3c960406919
-var common = require('../common');
-var assert = require('assert');
 var http = require('http');
 var cp = require('child_process');
 var fs = require('fs');
@@ -16,7 +16,7 @@ var count = 0;
 function maybeMakeRequest() {
   if (++count < 2) return;
   console.log('making curl request');
-  var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | openssl sha1';
+  var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | ' + common.opensslCli + ' sha1';
   cp.exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;
     var hex = stdout.match(/([A-Fa-f0-9]{40})/)[0];

--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -2,7 +2,12 @@ var common = require('../common');
 var assert = require('assert');
 
 var http = require('http');
-var https = require('https');
+
+if (common.hasCrypto) {
+  var https = require('https');
+} else {
+  console.log('1..0 # Skipped: missing crypto');
+}
 
 var expected_bad_requests = 0;
 var actual_bad_requests = 0;
@@ -38,10 +43,14 @@ function test(mod) {
   req.end();
 }
 
-test(https);
+if (common.hasCrypto) {
+  test(https);
+} else {
+  console.log('1..0 # Skipped: missing crypto');
+}
+
 test(http);
 
 process.on('exit', function() {
   assert.equal(actual_bad_requests, expected_bad_requests);
 });
-

--- a/test/parallel/test-http-host-headers.js
+++ b/test/parallel/test-http-host-headers.js
@@ -1,5 +1,4 @@
 var http = require('http'),
-    https = require('https'),
     fs = require('fs'),
     common = require('../common'),
     assert = require('assert'),
@@ -7,8 +6,14 @@ var http = require('http'),
       key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
       cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
     },
-    httpServer = http.createServer(reqHandler),
-    httpsServer = https.createServer(options, reqHandler);
+    httpServer = http.createServer(reqHandler);
+
+if(common.hasCrypto) {
+  var https = require('https'),
+      httpsServer = https.createServer(options, reqHandler);
+} else {
+  console.log('1..0 # Skipped: missing crypto');
+}
 
 function reqHandler(req, res) {
   console.log('Got request: ' + req.headers.host + ' ' + req.url);
@@ -41,7 +46,9 @@ function testHttp() {
     console.log('back from http request. counter = ' + counter);
     if (counter === 0) {
       httpServer.close();
-      testHttps();
+      if(common.hasCrypto) {
+        testHttps();
+      }
     }
     res.resume();
   }

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var url = require('url');
 var fs = require('fs');
 var clientRequest;

--- a/test/parallel/test-http-url.parse-post.js
+++ b/test/parallel/test-http-url.parse-post.js
@@ -1,7 +1,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var https = require('https');
 var url = require('url');
 
 var testURL = url.parse('http://localhost:' + common.PORT + '/asdf?qwer=zxcv');

--- a/test/parallel/test-http-url.parse-search.js
+++ b/test/parallel/test-http-url.parse-search.js
@@ -1,7 +1,6 @@
 var common = require('../common');
 var assert = require('assert');
 var http = require('http');
-var https = require('https');
 var url = require('url');
 
 var testURL = url.parse('http://localhost:' + common.PORT + '/asdf?qwer=zxcv');

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -1,12 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
 var fs = require('fs');
 var http = require('http');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
 
 var options = {

--- a/test/parallel/test-https-client-checkServerIdentity.js
+++ b/test/parallel/test-https-client-checkServerIdentity.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -1,14 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 // disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 
 var seen_req = false;

--- a/test/parallel/test-https-client-reject.js
+++ b/test/parallel/test-https-client-reject.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -1,15 +1,15 @@
 // Create an ssl server.  First connection, validate that not resume.
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
-
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-https-connecting-to-http.js
+++ b/test/parallel/test-https-connecting-to-http.js
@@ -2,9 +2,13 @@
 // to an http server. You should get an error and exit.
 var common = require('../common');
 var assert = require('assert');
-var https = require('https');
 var http = require('http');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 var reqCount = 0;
 var resCount = 0;

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -5,15 +5,17 @@
 //
 // This test is to be sure that the https client is handling this case
 // correctly.
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
 
 var common = require('../common');
 var assert = require('assert');
-var tls = require('tls');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+var tls = require('tls');
+
 var fs = require('fs');
 
 var options = {
@@ -77,4 +79,3 @@ process.on('exit', function() {
   assert.ok(gotEnd);
   assert.equal('hello world\nhello world\n', bodyBuffer);
 });
-

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -11,6 +11,10 @@ var join = require('path').join;
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
 
 var options = {

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
-var https = require('https');
 var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -1,7 +1,12 @@
-var common = require('../common');
-var https = require('https'),
+var common = require('../common'),
     fs = require('fs'),
     assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 if (!common.hasMultiLocalhost()) {
   console.log('Skipping platform-specific test.');

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
-var https = require('https');
 var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 var pfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
 

--- a/test/parallel/test-https-req-split.js
+++ b/test/parallel/test-https-req-split.js
@@ -1,14 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 // disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -1,15 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
+
 var fs = require('fs');
 var exec = require('child_process').exec;
-
-var https = require('https');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -1,16 +1,16 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 var fs = require('fs');
 var exec = require('child_process').exec;
 
 var http = require('http');
-var https = require('https');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -1,17 +1,17 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 // disable strict server certificate validation by the client
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
+
 var fs = require('fs');
 var path = require('path');
-var https = require('https');
 
 function file(fname) {
   return path.resolve(common.fixturesDir, 'keys', fname);

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -1,8 +1,13 @@
-if (!process.versions.openssl) process.exit();
 
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var net = require('net');
 var tls = require('tls');
 var fs = require('fs');

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -1,8 +1,12 @@
-if (!process.versions.openssl) process.exit();
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var net = require('net');
 var tls = require('tls');
 var fs = require('fs');

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -1,13 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
+
 var fs = require('fs');
 var exec = require('child_process').exec;
-var https = require('https');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -1,8 +1,13 @@
 var common = require('../common');
 var assert = require('assert');
 
-var fs = require('fs');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
+var fs = require('fs');
 var path = require('path');
 
 var resultFile = path.resolve(common.tmpDir, 'result');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var expected_keys = ['ares', 'http_parser', 'modules', 'node',
                      'uv', 'v8', 'zlib'];
 
-if(common.hasCrypto) {
+if (common.hasCrypto) {
   expected_keys.push('openssl');
 }
 

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -1,7 +1,11 @@
-require('../common');
+var common = require('../common');
 var assert = require('assert');
 
 var expected_keys = ['ares', 'http_parser', 'modules', 'node',
-                     'openssl', 'uv', 'v8', 'zlib'];
+                     'uv', 'v8', 'zlib'];
 
-assert.deepEqual(Object.keys(process.versions).sort(), expected_keys);
+if(common.hasCrypto) {
+  expected_keys.push('openssl');
+}
+
+assert.deepEqual(Object.keys(process.versions).sort(), expected_keys.sort());

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -1,6 +1,11 @@
 var common = require('../common');
 var assert = require('assert');
 var stream = require('stream');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
 
 var util = require('util');

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -1,12 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 var fs = require('fs');
 var net = require('net');
-var tls = require('tls');
 
 var common = require('../common');
 

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -1,13 +1,18 @@
 var common = require('../common');
+var assert = require('assert');
 
 if (!common.opensslCli) {
   console.error('Skipping because node compiled without OpenSSL CLI.');
   process.exit(0);
 }
 
-var assert = require('assert');
-var fs = require('fs');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var fs = require('fs');
 var spawn = require('child_process').spawn;
 
 var success = false;

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -1,12 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
-var tls = require('tls');
-
 var assert = require('assert');
 var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 
 var cert = '-----BEGIN CERTIFICATE-----\n' +
   'MIIBfjCCASgCCQDmmNjAojbDQjANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJB\n' +

--- a/test/parallel/test-tls-check-server-identity.js
+++ b/test/parallel/test-tls-check-server-identity.js
@@ -1,7 +1,13 @@
 var common = require('../common');
 var assert = require('assert');
 var util = require('util');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 
 var tests = [
   // Basic CN handling

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var fs = require('fs');
 var path = require('path');
 
 var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
@@ -20,4 +21,3 @@ conn.on('error', function() {
 assert.doesNotThrow(function() {
   conn.destroy();
 });
-

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -1,10 +1,10 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 var errors = 0;

--- a/test/parallel/test-tls-client-default-ciphers.js
+++ b/test/parallel/test-tls-client-default-ciphers.js
@@ -1,5 +1,10 @@
 var assert = require('assert');
 var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 function Done() {}

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -2,14 +2,15 @@
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
 
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -2,14 +2,15 @@
 // Cache session and close connection.  Use session on second connection.
 // ASSERT resumption.
 
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -1,8 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
+var common = require('../common');
+var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
+var fs = require('fs');
 
 var hosterr = /Hostname\/IP doesn\'t match certificate\'s altnames/g;
 var testCases =
@@ -36,13 +41,6 @@ var testCases =
        ]
      }
     ];
-
-
-var common = require('../common');
-var assert = require('assert');
-var fs = require('fs');
-var tls = require('tls');
-
 
 function filenamePEM(n) {
   return require('path').join(common.fixturesDir, 'keys', n + '.pem');

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -1,14 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var assert = require('assert');
-var fs = require('fs');
-var net = require('net');
+var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
-var common = require('../common');
+var fs = require('fs');
+var net = require('net');
 
 var ended = 0;
 

--- a/test/parallel/test-tls-connect-given-socket.js
+++ b/test/parallel/test-tls-connect-given-socket.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var net = require('net');
 var fs = require('fs');
 var path = require('path');

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var clientConnected = 0;

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var clientConnected = 0;

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var fs = require('fs');
 var path = require('path');
 
 // https://github.com/joyent/node/issues/1218

--- a/test/parallel/test-tls-delayed-attach.js
+++ b/test/parallel/test-tls-delayed-attach.js
@@ -1,14 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
-var net = require('net');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
-var common = require('../common');
+var fs = require('fs');
+var net = require('net');
 
 var sent = 'hello world';
 var received = '';

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -1,13 +1,13 @@
 var common = require('../common');
-
-if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
-  process.exit(0);
-}
-
 var assert = require('assert');
-var spawn = require('child_process').spawn;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var spawn = require('child_process').spawn;
 var fs = require('fs');
 var key =  fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -1,13 +1,13 @@
 var common = require('../common');
-
-if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
-  process.exit(0);
-}
-
 var assert = require('assert');
-var exec = require('child_process').exec;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var exec = require('child_process').exec;
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -1,13 +1,13 @@
 var common = require('../common');
-
-if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
-  process.exit(0);
-}
-
 var assert = require('assert');
-var exec = require('child_process').exec;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var exec = require('child_process').exec;
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-econnreset.js
+++ b/test/parallel/test-tls-econnreset.js
@@ -1,10 +1,10 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 var cacert = '-----BEGIN CERTIFICATE-----\n' +

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var PORT = common.PORT;

--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var fs = require('fs');
 
 var key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
 var cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var cipher_list = ['RC4-SHA', 'AES256-SHA'];
 var cipher_version_pattern = /TLS|SSL/;

--- a/test/parallel/test-tls-handshake-nohang.js
+++ b/test/parallel/test-tls-handshake-nohang.js
@@ -1,5 +1,10 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 // neither should hang

--- a/test/parallel/test-tls-hello-parser-failure.js
+++ b/test/parallel/test-tls-hello-parser-failure.js
@@ -1,8 +1,14 @@
 var common = require('../common');
+var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var net = require('net');
 var fs = require('fs');
-var assert = require('assert');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/test_key.pem'),

--- a/test/parallel/test-tls-inception.js
+++ b/test/parallel/test-tls-inception.js
@@ -1,14 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
+var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 var fs = require('fs');
 var path = require('path');
 var net = require('net');
-var tls = require('tls');
-var assert = require('assert');
 
 var options, a, b, portA, portB;
 var gotHello = false;

--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -1,7 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var PORT = common.PORT;

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -1,14 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
-var net = require('net');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
-var common = require('../common');
+var fs = require('fs');
+var net = require('net');
+
 
 var received = '';
 var ended = 0;

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -1,10 +1,15 @@
+var common = require('../common');
 var assert = require('assert');
-var stream = require('stream');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var stream = require('stream');
 var fs = require('fs');
 var net = require('net');
-
-var common = require('../common');
 
 var connected = {
   client: 0,

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -1,10 +1,11 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var net = require('net');
 
@@ -30,4 +31,3 @@ server.listen(common.PORT, function() {
   });
 
 });
-

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -1,12 +1,11 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
-var fs = require('fs');
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -1,12 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 var fs = require('fs');
 var net = require('net');
-var tls = require('tls');
 
 var common = require('../common');
 

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -1,10 +1,10 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -1,9 +1,9 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 // Omitting the cert or pfx option to tls.createServer() should not throw.

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -1,12 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
-var fs = require('fs');
+
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-no-sslv23.js
+++ b/test/parallel/test-tls-no-sslv23.js
@@ -1,10 +1,10 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
 assert.throws(function() {

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -1,13 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-var tls = require('tls');
 
 if (common.opensslCli === false) {
   console.error('Skipping because openssl command cannot be executed');

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -6,8 +6,14 @@ if (!process.features.tls_npn) {
 
 var common = require('../common'),
     assert = require('assert'),
-    fs = require('fs'),
-    tls = require('tls');
+    fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 
 function filenamePEM(n) {
   return require('path').join(common.fixturesDir, 'keys', n + '.pem');

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -10,8 +10,13 @@ if (!common.opensslCli) {
   process.exit(0);
 }
 
-var assert = require('assert');
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var assert = require('assert');
 var constants = require('constants');
 var fs = require('fs');
 var join = require('path').join;

--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -1,14 +1,14 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
-var net = require('net');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 
-var common = require('../common');
+var fs = require('fs');
+var net = require('net');
 
 var out = '';
 

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -1,15 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
 
 var fs = require('fs');
 var net = require('net');
 var http = require('http');
-var https = require('https');
 
 var proxyPort = common.PORT + 1;
 var gotRequest = false;

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var path = require('path');
 

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var util = require('util');
 var join = require('path').join;

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var hadTimeout = false;

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -1,16 +1,15 @@
 var common = require('../common');
-
-if (!common.opensslCli) {
-  console.error('Skipping because node compiled without OpenSSL CLI.');
-  process.exit(0);
-}
-
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
 
 var join = require('path').join;
 var net = require('net');
 var fs = require('fs');
-var tls = require('tls');
 var spawn = require('child_process').spawn;
 
 var connections = 0;

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -98,11 +98,15 @@ var testCases =
     }
     ];
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
 
 var constants = require('constants');
 var assert = require('assert');
 var fs = require('fs');
-var tls = require('tls');
 var spawn = require('child_process').spawn;
 
 

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -5,6 +5,11 @@ if (!common.opensslCli) {
   process.exit(0);
 }
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 doTest({ tickets: false } , function() {
   doTest({ tickets: true } , function() {
     console.error('all done');

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -5,6 +5,11 @@ if (!common.opensslCli) {
   process.exit(0);
 }
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 var assert = require('assert');
 var exec = require('child_process').exec;
 var tls = require('tls');

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -6,8 +6,13 @@ if (!process.features.tls_sni) {
 
 var common = require('../common'),
     assert = require('assert'),
-    fs = require('fs'),
-    tls = require('tls');
+    fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
 
 function filenamePEM(n) {
   return require('path').join(common.fixturesDir, 'keys', n + '.pem');

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -6,8 +6,13 @@ if (!process.features.tls_sni) {
 
 var common = require('../common'),
     assert = require('assert'),
-    fs = require('fs'),
-    tls = require('tls');
+    fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
 
 function filenamePEM(n) {
   return require('path').join(common.fixturesDir, 'keys', n + '.pem');

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
-var cluster = require('cluster');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var cluster = require('cluster');
 var fs = require('fs');
 var join = require('path').join;
 

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -1,15 +1,15 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
+var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
 var fs = require('fs');
 var net = require('net');
-var tls = require('tls');
 var crypto = require('crypto');
-
-var common = require('../common');
 
 var keys = crypto.randomBytes(48);
 var serverLog = [];

--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -1,8 +1,12 @@
-if (!process.versions.openssl) process.exit();
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -1,9 +1,13 @@
-if (!process.versions.openssl) process.exit();
-
 var common = require('../common');
 var assert = require('assert');
-var net = require('net');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var net = require('net');
 var fs = require('fs');
 
 var clientErrors = 0;

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -1,9 +1,13 @@
-if (!process.versions.openssl) process.exit();
-
 var common = require('../common');
 var assert = require('assert');
-var net = require('net');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var net = require('net');
 var fs = require('fs');
 
 var options = {

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
-var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
+var fs = require('fs');
 var path = require('path');
 
 var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));

--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -1,9 +1,15 @@
 var common = require('../common');
+var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
+
 var stream = require('stream');
 var Stream = stream.Stream;
 var util = require('util');
-var assert = require('assert');
 var zlib = require('zlib');
 
 

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -1,6 +1,10 @@
 var common = require('../common');
 var assert = require('assert');
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var crypto = require('crypto');
 
 var p = crypto.createDiffieHellman(256).getPrime();

--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -1,8 +1,14 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 var https = require('https');
+
 var fs = require('fs');
 
 if (!common.opensslCli) {

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -2,6 +2,11 @@ var common = require('../common');
 var assert = require('assert');
 
 var fs = require('fs');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
 
 var options = {
@@ -60,4 +65,3 @@ process.on('exit', function() {
   assert.equal(body.length, count);
   assert.ok(gotResEnd);
 });
-

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -1,11 +1,12 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var Buffer = require('buffer').Buffer;
 var fs = require('fs');
 var path = require('path');

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -7,7 +7,13 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var https = require('https');
+
 var fs = require('fs');
 
 var PORT = 8000;

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -1,7 +1,13 @@
 var common = require('../common');
 var assert = require('assert');
 var spawn = require('child_process').spawn;
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 if (!common.opensslCli) {

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -2,7 +2,13 @@
 
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 
 assert(typeof gc === 'function', 'Run this test with --expose-gc');

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -7,6 +7,11 @@ if (!common.opensslCli) {
   process.exit(0);
 }
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 var join = require('path').join;
 var net = require('net');
 var assert = require('assert');

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var stream = require('stream');
 var util = require('util');

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -5,6 +5,11 @@ if (!common.opensslCli) {
   process.exit(0);
 }
 
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+
 doTest();
 
 // This test consists of three TLS requests --

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -3,6 +3,11 @@
 
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
 var fs = require('fs');
 

--- a/test/sequential/test-regress-GH-1531.js
+++ b/test/sequential/test-regress-GH-1531.js
@@ -1,12 +1,13 @@
-if (!process.versions.openssl) {
-  console.error('Skipping because node compiled without OpenSSL.');
-  process.exit(0);
-}
-
-var https = require('https');
-var assert = require('assert');
-var fs = require('fs');
 var common = require('../common');
+var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var https = require('https');
+
+var fs = require('fs');
 
 var options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
@@ -42,4 +43,3 @@ process.on('exit', function() {
   assert.ok(gotCallback);
   console.log('ok');
 });
-

--- a/test/sequential/test-tls-honorcipherorder.js
+++ b/test/sequential/test-tls-honorcipherorder.js
@@ -1,6 +1,12 @@
 var common = require('../common');
 var assert = require('assert');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
 var tls = require('tls');
+
 var fs = require('fs');
 var nconns = 0;
 // test only in TLSv1 to use DES which is no longer supported TLSv1.2


### PR DESCRIPTION
So, based on the situation we introduced in #1035 (someone actually running tests with `./configure --without-ssl`), I rewrote the way we look for crypto/tls/https support.

A few things:

1. Introduce a helper in common.js that checks for `process.versions.openssl`. This could potentially be changed to try importing crypto instead.
2. Review all tests that fail (and the one's that imported tls, https or crypto) to use the new check
3. Unify tests that had their own way of checking for various types of crypto support
4. Have a few tests do partial runs (one or two) -- for instance tests that checks both against http and https servers. These should probably be moved out to their own tests
5. Fix fallout found in for instance testing `process.versions` ([my bad](https://github.com/iojs/io.js/commit/fce1acd748ed4ea77a345e882a5275c58cdedd75))
6. Avoid style/lint changes as much as possible, but update two tests (2a4a51d) that broke because they imported https while not using it.

Since this affects a lot of files I'd appreciate a quicker feedback round; can see myself rebasing this a fair few times otherwise.