### PR TITLE
events: optimize listener array cloning

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -384,7 +384,7 @@ EventEmitter.prototype.listeners = function listeners(type) {
     else if (typeof evlistener === 'function')
       ret = [evlistener];
     else
-      ret = arrayClone(evlistener);
+      ret = arrayClone(evlistener, evlistener.length);
   }
 
   return ret;
@@ -413,16 +413,9 @@ function spliceOne(list, index) {
   list.pop();
 }
 
-function arrayClone(arr, len) {
-  var ret;
-  if (len === undefined)
-    len = arr.length;
-  if (len >= 50)
-    ret = arr.slice();
-  else {
-    ret = new Array(len);
-    for (var i = 0; i < len; i += 1)
-      ret[i] = arr[i];
-  }
-  return ret;
+function arrayClone(arr, i) {
+  var copy = new Array(i);
+  while (i--)
+    copy[i] = arr[i];
+  return copy;
 }


### PR DESCRIPTION
This both switches to a single algorithm for array cloning and also
speeds up (by ~100% in the ee-listeners-many benchmark) the
"many elements"  case that was previously handled by
`array.slice()`.