### PR TITLE
win,test: fix test-stdin-from-file

### DIFF
--- a/test/fixtures/echo-close-check.js
+++ b/test/fixtures/echo-close-check.js
@@ -1,6 +1,7 @@
 var common = require('../common');
 var assert = require('assert');
 var net = require('net');
+var fs = require('fs');
 
 process.stdout.write('hello world\r\n');
 
@@ -11,10 +12,8 @@ stdin.on('data', function(data) {
 });
 
 stdin.on('end', function() {
-  // If stdin's fd will be closed - createServer may get it
-  var server = net.createServer(function() {
-  }).listen(common.PORT, function() {
-    assert(typeof server._handle.fd !== 'number' || server._handle.fd > 2);
-    server.close();
-  });
+  // If stdin's fd was closed, the next open() call would return 0.
+  var fd = fs.openSync(process.argv[1], 'r');
+  assert(fd > 2);
+  fs.closeSync(fd);
 });


### PR DESCRIPTION
The test-stdin-from-from-file test runs a subprocess that verifies stdin
can be piped from a file.

The subprocess additionally attempts to verify that the file descriptor
for stdin never gets closed. It used to do this by creating a TCP server
and asserting that the associated file descriptor is greater than two.
However this strategy doesn't work on windows, because servers don't
have an associated file descriptor. With this patch an ordinary file is
opened instead of creating a server.

R=@indutny
R=@iojs/platform-windows
cc @rvagg 