### PR TITLE
tty: do not add `shutdown` method to handle

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -37,7 +37,8 @@ void StreamBase::AddMethods(Environment* env,
 
   env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
   env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
-  env->SetProtoMethod(t, "shutdown", JSMethod<Base, &StreamBase::Shutdown>);
+  if ((flags & kFlagNoShutdown) == 0)
+    env->SetProtoMethod(t, "shutdown", JSMethod<Base, &StreamBase::Shutdown>);
   if ((flags & kFlagHasWritev) != 0)
     env->SetProtoMethod(t, "writev", JSMethod<Base, &StreamBase::Writev>);
   env->SetProtoMethod(t,

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -160,7 +160,8 @@ class StreamBase : public StreamResource {
  public:
   enum Flags {
     kFlagNone = 0x0,
-    kFlagHasWritev = 0x1
+    kFlagHasWritev = 0x1,
+    kFlagNoShutdown = 0x2
   };
 
   template <class Base>

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -39,7 +39,7 @@ void TTYWrap::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
 
-  StreamWrap::AddMethods(env, t);
+  StreamWrap::AddMethods(env, t, StreamBase::kFlagNoShutdown);
 
   env->SetProtoMethod(t, "getWindowSize", TTYWrap::GetWindowSize);
   env->SetProtoMethod(t, "setRawMode", SetRawMode);

--- a/test/parallel/test-regress-GH-io-1068.js
+++ b/test/parallel/test-regress-GH-io-1068.js
@@ -1,0 +1,1 @@
+process.stdin.emit('end');


### PR DESCRIPTION
UV_TTY does not support `uv_shutdown()` so adding this method in
StreamBase will cause an `abort()` in C land.

Fix: https://github.com/iojs/io.js/issues/1068