### PR TITLE
benchmark: fix `wrk` check

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -39,7 +39,7 @@ if (module === require.main) {
 
 function hasWrk() {
   var result = child_process.spawnSync('wrk', ['-h']);
-  if (result.error.code === 'ENOENT') {
+  if (result.error && result.error.code === 'ENOENT') {
     console.error('Couldn\'t locate `wrk` which is needed for running ' +
       'benchmarks. Check benchmark/README.md for further instructions.');
       process.exit(-1);


### PR DESCRIPTION
Evidently `.error` is `undefined` if there was no error.