### PR TITLE
stream_wrap: add HandleScope's in uv callbacks

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -286,6 +286,7 @@ TLSSocket.prototype._wrapHandle = function(handle) {
                 tls.createSecureContext();
   res = tls_wrap.wrap(handle, context.context, options.isServer);
   res._parent = handle;
+  res._secureContext = context;
   res.reading = handle.reading;
   Object.defineProperty(handle, 'reading', {
     get: function readingGetter() {

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -26,6 +26,7 @@ JSStream::JSStream(Environment* env, Handle<Object> obj, AsyncWrap* parent)
     : StreamBase(env),
       AsyncWrap(env, obj, AsyncWrap::PROVIDER_JSSTREAM, parent) {
   node::Wrap(obj, this);
+  MakeWeak<JSStream>(this);
 }
 
 

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -14,6 +14,8 @@ class JSStream : public StreamBase, public AsyncWrap {
                          v8::Handle<v8::Value> unused,
                          v8::Handle<v8::Context> context);
 
+  ~JSStream();
+
   void* Cast() override;
   bool IsAlive() override;
   bool IsClosing() override;
@@ -28,7 +30,6 @@ class JSStream : public StreamBase, public AsyncWrap {
 
  protected:
   JSStream(Environment* env, v8::Handle<v8::Object> obj, AsyncWrap* parent);
-  ~JSStream();
 
   AsyncWrap* GetAsyncWrap() override;
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -145,6 +145,9 @@ void StreamWrap::OnAlloc(uv_handle_t* handle,
                          size_t suggested_size,
                          uv_buf_t* buf) {
   StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
+  HandleScope scope(wrap->env()->isolate());
+  Context::Scope context_scope(wrap->env()->context());
+
   CHECK_EQ(wrap->stream(), reinterpret_cast<uv_stream_t*>(handle));
 
   return static_cast<StreamBase*>(wrap)->OnAlloc(suggested_size, buf);
@@ -229,6 +232,7 @@ void StreamWrap::OnReadCommon(uv_stream_t* handle,
                               const uv_buf_t* buf,
                               uv_handle_type pending) {
   StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
+  HandleScope scope(wrap->env()->isolate());
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
@@ -280,6 +284,7 @@ int StreamWrap::DoShutdown(ShutdownWrap* req_wrap) {
 
 void StreamWrap::AfterShutdown(uv_shutdown_t* req, int status) {
   ShutdownWrap* req_wrap = ContainerOf(&ShutdownWrap::req_, req);
+  HandleScope scope(req_wrap->env()->isolate());
   req_wrap->Done(status);
 }
 
@@ -354,6 +359,8 @@ int StreamWrap::DoWrite(WriteWrap* w,
 
 void StreamWrap::AfterWrite(uv_write_t* req, int status) {
   WriteWrap* req_wrap = ContainerOf(&WriteWrap::req_, req);
+  HandleScope scope(req_wrap->env()->isolate());
+  Context::Scope context_scope(req_wrap->env()->context());
   req_wrap->Done(status);
 }
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -26,7 +26,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Handle;
-using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Null;
@@ -251,8 +250,6 @@ void TLSWrap::SSLInfoCallback(const SSL* ssl_, int where, int ret) {
   SSL* ssl = const_cast<SSL*>(ssl_);
   TLSWrap* c = static_cast<TLSWrap*>(SSL_get_app_data(ssl));
   Environment* env = c->env();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
   Local<Object> object = c->object();
 
   if (where & SSL_CB_HANDSHAKE_START) {
@@ -395,9 +392,6 @@ void TLSWrap::ClearOut() {
   if (eof_)
     return;
 
-  HandleScope handle_scope(env()->isolate());
-  Context::Scope context_scope(env()->context());
-
   CHECK_NE(ssl_, nullptr);
 
   char out[kClearOutChunkSize];
@@ -469,9 +463,6 @@ bool TLSWrap::ClearIn() {
     CHECK_GE(written, 0);
     return true;
   }
-
-  HandleScope handle_scope(env()->isolate());
-  Context::Scope context_scope(env()->context());
 
   // Error or partial write
   int err;
@@ -588,8 +579,6 @@ int TLSWrap::DoWrite(WriteWrap* w,
 
   if (i != count) {
     int err;
-    HandleScope handle_scope(env()->isolate());
-    Context::Scope context_scope(env()->context());
     Local<Value> arg = GetSSLError(written, &err, &error_);
     if (!arg.IsEmpty())
       return UV_EPROTO;
@@ -662,8 +651,6 @@ void TLSWrap::DoRead(ssize_t nread,
       eof_ = true;
     }
 
-    HandleScope handle_scope(env()->isolate());
-    Context::Scope context_scope(env()->context());
     OnRead(nread, nullptr);
     return;
   }
@@ -796,7 +783,6 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   if (servername == nullptr)
     return SSL_TLSEXT_ERR_OK;
 
-  HandleScope scope(env->isolate());
   // Call the SNI callback and use its return value as context
   Local<Object> object = p->object();
   Local<Value> ctx = object->Get(env->sni_context_string());

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -37,14 +37,13 @@ using v8::Value;
 TLSWrap::TLSWrap(Environment* env,
                  Kind kind,
                  StreamBase* stream,
-                 Handle<Object> sc)
-    : SSLWrap<TLSWrap>(env, Unwrap<SecureContext>(sc), kind),
+                 SecureContext* sc)
+    : SSLWrap<TLSWrap>(env, sc, kind),
       StreamBase(env),
       AsyncWrap(env,
                 env->tls_wrap_constructor_function()->NewInstance(),
                 AsyncWrap::PROVIDER_TLSWRAP),
-      sc_(Unwrap<SecureContext>(sc)),
-      sc_handle_(env->isolate(), sc),
+      sc_(sc),
       stream_(stream),
       enc_in_(nullptr),
       enc_out_(nullptr),
@@ -82,7 +81,6 @@ TLSWrap::~TLSWrap() {
   clear_in_ = nullptr;
 
   sc_ = nullptr;
-  sc_handle_.Reset();
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   sni_context_.Reset();
@@ -192,7 +190,7 @@ void TLSWrap::Wrap(const FunctionCallbackInfo<Value>& args) {
   });
   CHECK_NE(stream, nullptr);
 
-  TLSWrap* res = new TLSWrap(env, kind, stream, sc);
+  TLSWrap* res = new TLSWrap(env, kind, stream, Unwrap<SecureContext>(sc));
 
   args.GetReturnValue().Set(res->object());
 }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -37,7 +37,6 @@ using v8::Value;
 TLSWrap::TLSWrap(Environment* env,
                  Kind kind,
                  StreamBase* stream,
-                 Handle<Object> stream_obj,
                  Handle<Object> sc)
     : SSLWrap<TLSWrap>(env, Unwrap<SecureContext>(sc), kind),
       StreamBase(env),
@@ -47,7 +46,6 @@ TLSWrap::TLSWrap(Environment* env,
       sc_(Unwrap<SecureContext>(sc)),
       sc_handle_(env->isolate(), sc),
       stream_(stream),
-      stream_handle_(env->isolate(), stream_obj),
       enc_in_(nullptr),
       enc_out_(nullptr),
       clear_in_(nullptr),
@@ -85,8 +83,6 @@ TLSWrap::~TLSWrap() {
 
   sc_ = nullptr;
   sc_handle_.Reset();
-  stream_handle_.Reset();
-  persistent().Reset();
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   sni_context_.Reset();
@@ -196,9 +192,9 @@ void TLSWrap::Wrap(const FunctionCallbackInfo<Value>& args) {
   });
   CHECK_NE(stream, nullptr);
 
-  TLSWrap* res = new TLSWrap(env, kind, stream, stream_obj, sc);
+  TLSWrap* res = new TLSWrap(env, kind, stream, sc);
 
-  args.GetReturnValue().Set(res->persistent());
+  args.GetReturnValue().Set(res->object());
 }
 
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -78,7 +78,7 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
   TLSWrap(Environment* env,
           Kind kind,
           StreamBase* stream,
-          v8::Handle<v8::Object> sc);
+          crypto::SecureContext* sc);
 
   static void SSLInfoCallback(const SSL* ssl_, int where, int ret);
   void InitSSL();
@@ -140,7 +140,6 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
   crypto::SecureContext* sc_;
-  v8::Persistent<v8::Object> sc_handle_;
   StreamBase* stream_;
   BIO* enc_in_;
   BIO* enc_out_;

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -78,7 +78,6 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
   TLSWrap(Environment* env,
           Kind kind,
           StreamBase* stream,
-          v8::Handle<v8::Object> stream_obj,
           v8::Handle<v8::Object> sc);
 
   static void SSLInfoCallback(const SSL* ssl_, int where, int ret);
@@ -143,7 +142,6 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
   crypto::SecureContext* sc_;
   v8::Persistent<v8::Object> sc_handle_;
   StreamBase* stream_;
-  v8::Persistent<v8::Object> stream_handle_;
   BIO* enc_in_;
   BIO* enc_out_;
   NodeBIO* clear_in_;


### PR DESCRIPTION
Ensure that no handles will leak into global HandleScope by adding
HandleScope's in all JS-calling libuv callbacks in `stream_wrap.cc`.

Fix: https://github.com/iojs/io.js/issues/1075

NOTE: **WIP**