### PR TITLE
v8: fix build on solaris platforms

### DIFF
--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -260,6 +260,8 @@ int OS::GetCurrentThreadId() {
   return static_cast<int>(syscall(__NR_gettid));
 #elif V8_OS_ANDROID
   return static_cast<int>(gettid());
+#elif V8_OS_SOLARIS
+  return static_cast<int>(pthread_self());
 #else
   return static_cast<int>(reinterpret_cast<intptr_t>(pthread_self()));
 #endif


### PR DESCRIPTION
Not sure what our policy is about patching v8 but my general standpoint is to avoid it at almost all costs. What that out the way, carrying this "one-liner" ([patch sent upstream](https://code.google.com/p/v8/issues/detail?id=3935) and currently in progress, but I'm unsure when or in what branch this will land) adds support for building io.js on smartos/illumos which also passes the test suite.