### PR TITLE
src: add missing Context::Scope

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -233,6 +233,7 @@ void StreamWrap::OnReadCommon(uv_stream_t* handle,
                               uv_handle_type pending) {
   StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
   HandleScope scope(wrap->env()->isolate());
+  Context::Scope context_scope(wrap->env()->context());
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.


### PR DESCRIPTION
Add a Context::Scope that was overlooked in commit 583a868
("stream_wrap: add HandleScope's in uv callbacks").

R=@indutny