### PR TITLE
crypto: fix leak in SafeX509ExtPrint

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1132,6 +1132,7 @@ static bool SafeX509ExtPrint(BIO* out, X509_EXTENSION* ext) {
       X509V3_EXT_val_prn(out, nval, 0, 0);
     }
   }
+  sk_GENERAL_NAME_pop_free(names, GENERAL_NAME_free);
 
   return true;
 }


### PR DESCRIPTION
`ASN1_item_d2i`'s return value must be freed by the owner.