### PR TITLE
fs: fix unmatched free/delete/delete[] in file.cc

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -212,7 +212,7 @@ static void After(uv_fs_t *req) {
   req_wrap->MakeCallback(env->oncomplete_string(), argc, argv);
 
   uv_fs_req_cleanup(&req_wrap->req_);
-  delete req_wrap;
+  delete[] reinterpret_cast<char*>(req_wrap);
 }
 
 // This struct is only used on sync fs calls.


### PR DESCRIPTION
Found with valgrind:

==27140== Mismatched free() / delete / delete []
==27140==    at 0x4C2C2E0: operator delete(void*)
==27140==    by 0xCDE9C1: node::After(uv_fs_s*)
==27140==    by 0xD452CC: uv__work_done (threadpool.c:236)
==27140==    by 0xD46F85: uv__async_event (async.c:92)
==27140==    by 0xD47062: uv__async_io (async.c:132)
==27140==    by 0xD56569: uv__io_poll (linux-core.c:319)
==27140==    by 0xD47B33: uv_run (core.c:324)
==27140==    by 0xCCFD10: node::Start(int, char**)
==27140==    by 0x5CAEEC4: (below main) (libc-start.c:287)
==27140==  Address 0x9432510 is 0 bytes inside a block of size 512 alloc'd
==27140==    at 0x4C2B820: operator new[](unsigned long)
==27140==    by 0xCE66F8: node::Open(v8::FunctionCallbac...
==27140==    by 0x7FBD56: v8::internal::FunctionCallback...
==27140==    by 0x824114: v8::internal::Builtin_HandleA...
==27140==    by 0x4C13DF060BA: ???
==27140==    by 0x4C13E04CB68: ???
==27140==    by 0x4C13E04BA4A: ???
==27140==    by 0x4C13E047F97: ???
==27140==    by 0x4C13DF1EA54: ???
==27140==    by 0x4C13E047589: ???
==27140==    by 0x4C13E046CC8: ???
==27140==    by 0x4C13E04660A: ???
==27140==

cc @bnoordhuis 