### PR TITLE
doc: update clang version prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the binary verification command above.
 Prerequisites:
 
 * `gcc` and `g++` 4.8 or newer, or
-* `clang` and `clang++` 3.3 or newer
+* `clang` and `clang++` 3.4 or newer
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer
 * libexecinfo (FreeBSD and OpenBSD only)


### PR DESCRIPTION
See commit [`4877ec0`](https://github.com/iojs/io.js/commit/48774ec027a28cca17656659d316bb7ed8d6f33c), where it now warns on a clang++ version older than
3.4.