### PR TITLE
url: remove redundant assignment in url.parse

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -276,7 +276,6 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     var p = this.port ? ':' + this.port : '';
     var h = this.hostname || '';
     this.host = h + p;
-    this.href += this.host;
 
     // strip [ and ] from the hostname
     // the host field still retains them, though


### PR DESCRIPTION
Just a nitpick.

`this.href` is set later in [url.js#L345](https://github.com/iojs/io.js/blob/fe36076c78f60e61b67e6439eb7b759c4596faab/lib/url.js#L345), so I believe this assignment does nothing except wastes CPU time.