### PR TITLE
doc: fix confusion markdown in util.markdown

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -54,7 +54,7 @@ argument. Supported placeholders are:
 * `%s` - String.
 * `%d` - Number (both integer and float).
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
-         contains circular references.
+contains circular references.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
 If the placeholder does not have a corresponding argument, the placeholder is


### PR DESCRIPTION
Caught this one in reading the `util` doc, checked the doc of nodej and iojs:

* nodejs: https://nodejs.org/api/util.html#util_util_format_format
* iojs: https://iojs.org/api/util.html#util_util_format_format

But the github markdown worked at https://github.com/iojs/io.js/blob/v1.x/doc/api/util.markdown#utilformatformat-

Well, now I fixed the confusion bug on on this line, but btw, I think we should keep using the markdown parser same to github markdown, so that we needn't another review on website. I'm interested in this proposal if someone could give me the guiding link on how the website are built and working, Thank you :)