### PR TITLE
fs: fix .write() not coercing non-string values

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -629,7 +629,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     return binding.writeBuffer(fd, buffer, offset, length, position, req);
   }
 
-  if (typeof buffer === 'string')
+  if (typeof buffer !== 'string')
     buffer += '';
   if (typeof position !== 'function') {
     if (typeof offset === 'function') {

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -1,0 +1,29 @@
+var common = require('../common');
+var assert = require('assert');
+var path = require('path');
+var Buffer = require('buffer').Buffer;
+var fs = require('fs');
+var fn = path.join(common.tmpDir, 'write-string-coerce.txt');
+var data = true;
+var expected = data + '';
+var found;
+
+fs.open(fn, 'w', 0644, function(err, fd) {
+  if (err) throw err;
+  console.log('open done');
+  fs.write(fd, data, 0, 'utf8', function(err, written) {
+    console.log('write done');
+    if (err) throw err;
+    assert.equal(Buffer.byteLength(expected), written);
+    fs.closeSync(fd);
+    found = fs.readFileSync(fn, 'utf8');
+    console.log('expected: "%s"', expected);
+    console.log('found: "%s"', found);
+    fs.unlinkSync(fn);
+  });
+});
+
+
+process.on('exit', function() {
+  assert.equal(expected, found);
+});


### PR DESCRIPTION
Should fix #1098

relevant docs: https://github.com/iojs/io.js/blob/v1.x/doc/api/fs.markdown#fswritefd-data-position-encoding-callback

R=anyone