### PR TITLE
doc: move checkServerIdentity option to tls.connect()

### DIFF
--- a/doc/api/tls.markdown
+++ b/doc/api/tls.markdown
@@ -180,10 +180,6 @@ automatically set as a listener for the [secureConnection][] event.  The
     which is not authorized with the list of supplied CAs. This option only
     has an effect if `requestCert` is `true`. Default: `false`.
 
-  - `checkServerIdentity(servername, cert)`: Provide an override for checking
-    server's hostname against the certificate. Should return an error if verification
-    fails. Return `undefined` if passing.
-
   - `NPNProtocols`: An array or `Buffer` of possible NPN protocols. (Protocols
     should be ordered by their priority).
 
@@ -315,6 +311,10 @@ Creates a new client connection to the given `port` and `host` (old API) or
     usually be much simpler: `['hello', 'world']`.)
 
   - `servername`: Servername for SNI (Server Name Indication) TLS extension.
+
+  - `checkServerIdentity(servername, cert)`: Provide an override for checking
+    server's hostname against the certificate. Should return an error if verification
+    fails. Return `undefined` if passing.
 
   - `secureProtocol`: The SSL method to use, e.g. `SSLv3_method` to force
     SSL version 3. The possible values depend on your installation of


### PR DESCRIPTION
This is obviously an oversight.