### PR TITLE
tls_wrap: proxy handle methods in prototype

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -271,6 +271,14 @@ var proxiedMethods = [
   'setPendingInstances'
 ];
 
+// Proxy HandleWrap, PipeWrap and TCPWrap methods
+proxiedMethods.forEach(function(name) {
+  tls_wrap.TLSWrap.prototype[name] = function methodProxy() {
+    if (this._parent[name])
+      return this._parent[name].apply(this._parent, arguments);
+  };
+});
+
 TLSSocket.prototype._wrapHandle = function(handle) {
   var res;
 
@@ -295,14 +303,6 @@ TLSSocket.prototype._wrapHandle = function(handle) {
     set: function readingSetter(value) {
       res.reading = value;
     }
-  });
-
-  // Proxy HandleWrap, PipeWrap and TCPWrap methods
-  proxiedMethods.forEach(function(name) {
-    res[name] = function methodProxy() {
-      if (handle[name])
-        return handle[name].apply(handle, arguments);
-    };
   });
 
   return res;

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -809,8 +809,8 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
 
 
 void TLSWrap::Initialize(Handle<Object> target,
-                              Handle<Value> unused,
-                              Handle<Context> context) {
+                         Handle<Value> unused,
+                         Handle<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);
@@ -835,6 +835,9 @@ void TLSWrap::Initialize(Handle<Object> target,
 
   env->set_tls_wrap_constructor_template(t);
   env->set_tls_wrap_constructor_function(t->GetFunction());
+
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "TLSWrap"),
+              t->GetFunction());
 }
 
 }  // namespace node


### PR DESCRIPTION
Set proxied methods wrappers in `TLSWrap` prototype instead of doing it
on every socket allocation. Should speed up things a bit and will
certainly make heapsnapshot less verbose.

cc @iojs/crypto 