### PR TITLE
buffer: Don't assign .parent if none exists

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -141,7 +141,10 @@ function fromJsonObject(that, object) {
 
 function allocate(that, length) {
   var fromPool = length !== 0 && length <= Buffer.poolSize >>> 1;
-  that.parent = fromPool ? palloc(that, length) : alloc(that, length);
+  if (fromPool)
+    that.parent = palloc(that, length);
+  else
+    alloc(that, length);
   that.length = length;
 }
 

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1174,3 +1174,8 @@ assert.throws(function() {
 
 // Regression test for https://github.com/iojs/io.js/issues/649.
 assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
+
+var ps = Buffer.poolSize;
+Buffer.poolSize = 0;
+assert.equal(Buffer(1).parent, undefined);
+Buffer.poolSize = ps;


### PR DESCRIPTION
The .parent property of the allocated buffer should remain undefined in
the case that it's not a slice.

R=@bnoordhuis 