### PR TITLE
 test: fix variables quoated when path has spaces on Windows

### DIFF
--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -6,7 +6,7 @@ var exec = require('child_process').exec;
 var success_count = 0;
 var error_count = 0;
 
-var cmd = [process.execPath, '-e', '"console.error(process.argv)"',
+var cmd = ['"' + process.execPath + '"', '-e', '"console.error(process.argv)"',
            'foo', 'bar'].join(' ');
 var expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
 var child = exec(cmd, function(err, stdout, stderr) {

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -14,7 +14,7 @@ var callbacks = 0;
 
 function test(env, cb) {
   var filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
-  var execPath = process.execPath + ' ' + filename;
+  var execPath = '"' + process.execPath + '" "' + filename + '"';
   var options = { env: env || {} };
   exec(execPath, options, function(err, stdout, stderr) {
     assert(err);

--- a/test/parallel/test-http-curl-chunk-problem.js
+++ b/test/parallel/test-http-curl-chunk-problem.js
@@ -16,7 +16,8 @@ var count = 0;
 function maybeMakeRequest() {
   if (++count < 2) return;
   console.log('making curl request');
-  var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | ' + common.opensslCli + ' sha1';
+  var cmd = 'curl http://127.0.0.1:' + common.PORT + '/ | ' +
+            '"' + common.opensslCli + '" sha1';
   cp.exec(cmd, function(err, stdout, stderr) {
     if (err) throw err;
     var hex = stdout.match(/([A-Fa-f0-9]{40})/)[0];

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -29,7 +29,7 @@ var server = tls.createServer(options, function(conn) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var cmd = common.opensslCli + ' s_client -cipher ' + options.ciphers +
+  var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
   exec(cmd, function(err, stdout, stderr) {

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -32,7 +32,7 @@ var server = tls.createServer(options, function(conn) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var cmd = common.opensslCli + ' s_client -cipher ' + options.ciphers +
+  var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
   exec(cmd, function(err, stdout, stderr) {

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -36,7 +36,7 @@ var server = tls.createServer(options, function(conn) {
 });
 
 server.listen(common.PORT, '127.0.0.1', function() {
-  var cmd = common.opensslCli + ' s_client -cipher ' + options.ciphers +
+  var cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
             ' -connect 127.0.0.1:' + common.PORT;
 
   exec(cmd, function(err, stdout, stderr) {

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -16,7 +16,7 @@ var success_count = 0;
 var error_count = 0;
 
 
-exec(process.execPath + ' -p -e process.versions',
+exec('"' + process.execPath + '" -p -e process.versions',
      function(err, stdout, stderr) {
   if (err) {
     error_count++;

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -14,7 +14,7 @@ var err;
 var caught = false;
 try
 {
-  var cmd = util.format('%s -e "setTimeout(function(){}, %d);"',
+  var cmd = util.format('"%s" -e "setTimeout(function(){}, %d);"',
                         process.execPath, SLEEP);
   var ret = execSync(cmd, {timeout: TIMER});
 } catch (e) {
@@ -37,7 +37,7 @@ var msg = 'foobar';
 var msgBuf = new Buffer(msg + '\n');
 
 // console.log ends every line with just '\n', even on Windows.
-cmd = util.format('%s -e "console.log(\'%s\');"', process.execPath, msg);
+cmd = util.format('"%s" -e "console.log(\'%s\');"', process.execPath, msg);
 
 var ret = execSync(cmd);
 

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -14,12 +14,12 @@
     var envCopy = JSON.parse(JSON.stringify(process.env));
     envCopy.TEST_INIT = 1;
 
-    child.exec(process.execPath + ' test-init', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init` failed!');
         });
-    child.exec(process.execPath + ' test-init.js', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init.js', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init.js` failed!');
@@ -28,7 +28,7 @@
     // test-init-index is in fixtures dir as requested by ry, so go there
     process.chdir(common.fixturesDir);
 
-    child.exec(process.execPath + ' test-init-index', {env: envCopy},
+    child.exec('"' + process.execPath + '" test-init-index', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'Loaded successfully!',
                        '`node test-init-index failed!');
@@ -39,7 +39,7 @@
     // expected in node
     process.chdir(common.fixturesDir + '/test-init-native/');
 
-    child.exec(process.execPath + ' fs', {env: envCopy},
+    child.exec('"' + process.execPath + '" fs', {env: envCopy},
         function(err, stdout, stderr) {
           assert.equal(stdout, 'fs loaded successfully',
                        '`node fs` failed!');

--- a/test/sequential/test-regress-GH-4015.js
+++ b/test/sequential/test-regress-GH-4015.js
@@ -2,10 +2,8 @@ var common = require('../common');
 var assert = require('assert');
 var exec = require('child_process').exec;
 
-var cmd = process.execPath
-        + ' '
-        + common.fixturesDir
-        + '/test-regress-GH-4015.js';
+var cmd = '"' + process.execPath + '" ' +
+          '"' + common.fixturesDir + '/test-regress-GH-4015.js"';
 
 exec(cmd, function(err, stdout, stderr) {
   assert(/RangeError: Maximum call stack size exceeded/.test(stderr));


### PR DESCRIPTION
This fixes test failures when a path of the repository has spaces on Windows as it was pointed out in 
https://github.com/iojs/io.js/commit/c7ad320472d69962b48e10e564682f24dd31d1d1#commitcomment-10043315
and also fixes missed `set` in vcbuild.bat

r= @piscisaureus 