### PR TITLE
buffer: align chunks on 8-byte boundary

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -157,6 +157,12 @@ function palloc(that, length) {
   var buf = sliceOnto(allocPool, that, start, end);
   poolOffset = end;
 
+  // Ensure aligned slices
+  if (poolOffset & 0x7) {
+    poolOffset |= 0x7;
+    poolOffset++;
+  }
+
   return buf;
 }
 


### PR DESCRIPTION
When slicing global pool - ensure that the underlying buffer's data ptr
is 8-byte alignment to do not ruin expectations of 3rd party C++ addons.

NOTE: 0.10 node.js always returned aligned pointers and io.js should do
this to for compatibility.