### PR TITLE
test: fix crypto-binary-default bad crypto check

### DIFF
--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -11,6 +11,7 @@ if (!common.hasCrypto) {
   process.exit();
 }
 var crypto = require('crypto');
+var tls = require('tls');
 
 crypto.DEFAULT_ENCODING = 'binary';
 
@@ -26,18 +27,6 @@ var rsaPubPem = fs.readFileSync(common.fixturesDir + '/test_rsa_pubkey.pem',
     'ascii');
 var rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
     'ascii');
-
-// TODO(indutny): Move to a separate test eventually
-try {
-  var context = tls.createSecureContext({
-    key: keyPem,
-    cert: certPem,
-    ca: caPem
-  });
-} catch (e) {
-  console.log('Not compiled with OPENSSL support.');
-  process.exit();
-}
 
 // PFX tests
 assert.doesNotThrow(function() {


### PR DESCRIPTION
This commit fixes a small bug introduced in [`671fbd5`](https://github.com/iojs/io.js/commit/671fbd5a9de03c5ede968ef6c6b365965a546a55)
that caused the test to not be run. `crypto` was properly
checked, but since `tls` was not imported, a `TypeError`
would be thrown in the `try {} catch {}` block and
falsely reported as no crypto.

This is now fixed.

cc @jbergstroem