### PR TITLE
buffer: removing duplicate code

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -123,18 +123,7 @@ Local<Object> New(Environment* env, size_t length) {
   Local<Value> arg = Uint32::NewFromUnsigned(env->isolate(), length);
   Local<Object> obj = env->buffer_constructor_function()->NewInstance(1, &arg);
 
-  // TODO(trevnorris): done like this to handle HasInstance since only checks
-  // if external array data has been set, but would like to use a better
-  // approach if v8 provided one.
-  char* data;
-  if (length > 0) {
-    data = static_cast<char*>(malloc(length));
-    if (data == nullptr)
-      FatalError("node::Buffer::New(size_t)", "Out Of Memory");
-  } else {
-    data = nullptr;
-  }
-  smalloc::Alloc(env, obj, data, length);
+  smalloc::Alloc(env, obj, length);
 
   return scope.Escape(obj);
 }


### PR DESCRIPTION
- using an overload of Alloc that does the same that was being done
  inside `Buffer::New`

The overload we now call inside `smalloc.cc` takes care of the same as
the code that was removed:

```cc
if (length == 0)
  return Alloc(env, obj, nullptr, length, type);

char* data = static_cast<char*>(malloc(length));
if (data == nullptr) {
  FatalError("node::smalloc::Alloc(v8::Handle<v8::Object>, size_t,"
              " v8::ExternalArrayType)", "Out Of Memory");
}

Alloc(env, obj, data, length, type);
```

/cc @trevnorris 