### PR TITLE
test: fix preload fixtures path

### DIFF
--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -15,7 +15,7 @@ var preloadOption = function(preloads) {
 }
 
 var fixture = function(name) {
-  return path.join(__dirname, '../fixtures/' + name);
+  return path.join(__dirname, '..', 'fixtures', name);
 }
 
 var fixtureA = fixture('printA.js');


### PR DESCRIPTION
Running tests on [this now](https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/298/nodes=iojs-win2008r2/console). It *should* clear up the test failure from #881, mentioned in #1005.