### PR TITLE
timers: fix unref() memory leak

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -304,7 +304,7 @@ const Timeout = function(after) {
 
 function unrefdHandle() {
   this.owner._onTimeout();
-  if (!this.owner.repeat)
+  if (!this.owner._repeat)
     this.owner.close();
 }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -301,6 +301,14 @@ const Timeout = function(after) {
   this._repeat = null;
 };
 
+
+function unrefdHandle() {
+  this.owner._onTimeout();
+  if (!this.owner.repeat)
+    this.owner.close();
+}
+
+
 Timeout.prototype.unref = function() {
   if (this._handle) {
     this._handle.unref();
@@ -315,7 +323,8 @@ Timeout.prototype.unref = function() {
     if (this._called && !this._repeat) return;
 
     this._handle = new Timer();
-    this._handle[kOnTimeout] = this._onTimeout;
+    this._handle.owner = this;
+    this._handle[kOnTimeout] = unrefdHandle;
     this._handle.start(delay, 0);
     this._handle.domain = this.domain;
     this._handle.unref();

--- a/test/parallel/test-timers-unrefd-interval-still-fires.js
+++ b/test/parallel/test-timers-unrefd-interval-still-fires.js
@@ -1,0 +1,18 @@
+/*
+ * This test is a regression test for joyent/node#8900.
+ */
+var assert = require('assert');
+
+var N = 5;
+var nbIntervalFired = 0;
+var timer = setInterval(function() {
+  ++nbIntervalFired;
+  if (nbIntervalFired === N)
+    clearInterval(timer);
+}, 1);
+
+timer.unref();
+
+setTimeout(function onTimeout() {
+  assert.strictEqual(nbIntervalFired, N);
+}, 100);


### PR DESCRIPTION
Port of https://github.com/joyent/node/commit/0d051238be2e07e671d7d9f4f444e0cc1efadf1b

~~Fixes: https://github.com/iojs/io.js/issues/1151~~ (Not really. It's complicated. https://github.com/iojs/io.js/pull/1152#issuecomment-86149840)

Not sure what to call the test, or even if this test is particularly good. (or if it even needs a test)

R=@trevnorris