### PR TITLE
tls: re-enable `.writev()` on TLSWrap

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -825,7 +825,7 @@ void TLSWrap::Initialize(Handle<Object> target,
   env->SetProtoMethod(t, "enableSessionCallbacks", EnableSessionCallbacks);
   env->SetProtoMethod(t, "enableHelloParser", EnableHelloParser);
 
-  StreamBase::AddMethods<TLSWrap>(env, t);
+  StreamBase::AddMethods<TLSWrap>(env, t, StreamBase::kFlagHasWritev);
   SSLWrap<TLSWrap>::AddMethods(env, t);
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB


### PR DESCRIPTION
Fix the `parallel/test-tls-over-http-tunnel.js` on Windows by
re-enabling the accidentally disabled `.writev()` method on TLSWrap.

It appears that there is some subtle issue with shutdown timing and it
manifests itself when the chunks are written in separate packets. This
leads to concurrent `shutdown`/`destroy`, which breaks the test.

cc @piscisaureus 

It appears that removing `writev` in io.js prior to StreamBase does not introduce this problem, but this patch fixes the problem without touching the test. I propose landing it, and meanwhile I'll investigate more.