### PR TITLE
http: add flushHeaders and deprecate flush

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -866,7 +866,7 @@ the client should send the request body.
 Emitted when the request has been aborted by the client. This event is only
 emitted on the first call to `abort()`.
 
-### request.flush()
+### request.flushHeaders()
 
 Flush the request headers.
 
@@ -875,7 +875,7 @@ call `request.end()` or write the first chunk of request data.  It then tries
 hard to pack the request headers and data into a single TCP packet.
 
 That's usually what you want (it saves a TCP round-trip) but not when the first
-data isn't sent until possibly much later.  `request.flush()` lets you bypass
+data isn't sent until possibly much later.  `request.flushHeaders()` lets you bypass
 the optimization and kickstart the request.
 
 ### request.write(chunk[, encoding][, callback])

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -630,10 +630,14 @@ OutgoingMessage.prototype._flush = function() {
 };
 
 
-OutgoingMessage.prototype.flush = function() {
+OutgoingMessage.prototype.flushHeaders = function() {
   if (!this._header) {
     // Force-flush the headers.
     this._implicitHeader();
     this._send('');
   }
 };
+
+OutgoingMessage.prototype.flush = util.deprecate(function() {
+  this.flushHeaders();
+}, 'flush is deprecated. Use flushHeaders instead.');

--- a/test/parallel/test-http-flush-headers.js
+++ b/test/parallel/test-http-flush-headers.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer();
+server.on('request', function(req, res){
+  assert(req.headers['foo'], 'bar');
+  res.end('ok');
+  server.close();
+});
+server.listen(common.PORT, '127.0.0.1', function() {
+  let req = http.request({
+    method: 'GET',
+    host: '127.0.0.1',
+    port: common.PORT,
+  });
+  req.setHeader('foo', 'bar');
+  req.flushHeaders();
+});


### PR DESCRIPTION
I found a different API from Node.js v0.12 and io.js.
the detail is here https://github.com/joyent/node/commit/89f3c9037faf19eb32c464b2e02a0a9191156c36

`http` module in io.js has a method `req.flush`.
Node.js v0.12 also has a same behavior method but the different name `req.flushHeaders`.

the difference may cause to block migrations from Node.js v0.12 to io.js.
But if we rename `req.flush` to `req.flushHeaders` now, we should update the major version.

So I add `req.flushHeaders` method and deprecate `req.flush`.

If we bump the io.js master version, we would be better to rethink `req.flush` is removed.