### PR TITLE
repl: fix auto-complete crash in REPL mode when set env `NODE_MODULE_CONTEXTS`

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -35,7 +35,12 @@ const debug = util.debuglog('repl');
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
+
+// Don't write as `function hasOwnProperty() { ... }`,  
+// or this custom function will never be executed.
+// Because it is overrided by origin `hasOwnProperty`,
+// and run origin `hasOwnProperty(anyObject)` directly will always go into crash.
+var hasOwnProperty = function (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
@@ -667,6 +672,7 @@ REPLServer.prototype.complete = function(line, callback) {
         group.sort();
         for (var j = 0; j < group.length; j++) {
           c = group[j];
+          // the custom `hasOwnProperty`
           if (!hasOwnProperty(uniq, c)) {
             completions.push(c);
             uniq[c] = true;


### PR DESCRIPTION
see commit