### PR TITLE
lib: remove broken NODE_MODULE_CONTEXTS feature

### DIFF
--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -68,9 +68,6 @@ and servers.
 .IP NODE_PATH
 \':\'\-separated list of directories prefixed to the module search path.
 
-.IP NODE_MODULE_CONTEXTS
-If set to 1 then modules will load in their own global contexts.
-
 .IP NODE_DISABLE_COLORS
 If set to 1 then colors will not be used in the REPL.
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,6 @@
 const NativeModule = require('native_module');
 const util = require('util');
 const runInThisContext = require('vm').runInThisContext;
-const runInNewContext = require('vm').runInNewContext;
 const assert = require('assert').ok;
 const fs = require('fs');
 const path = require('path');
@@ -31,9 +30,6 @@ function Module(id, parent) {
 }
 module.exports = Module;
 
-// Set the environ variable NODE_MODULE_CONTEXTS=1 to make node load all
-// modules in their own context.
-Module._contextLoad = (+process.env['NODE_MODULE_CONTEXTS'] > 0);
 Module._cache = {};
 Module._pathCache = {};
 Module._extensions = {};
@@ -390,36 +386,6 @@ Module.prototype._compile = function(content, filename) {
   require.cache = Module._cache;
 
   var dirname = path.dirname(filename);
-
-  if (Module._contextLoad) {
-    if (self.id !== '.') {
-      debug('load submodule');
-      // not root module
-      var sandbox = {};
-      for (var k in global) {
-        sandbox[k] = global[k];
-      }
-      sandbox.require = require;
-      sandbox.exports = self.exports;
-      sandbox.__filename = filename;
-      sandbox.__dirname = dirname;
-      sandbox.module = self;
-      sandbox.global = sandbox;
-      sandbox.root = root;
-
-      return runInNewContext(content, sandbox, { filename: filename });
-    }
-
-    debug('load root module');
-    // root module
-    global.require = require;
-    global.exports = self.exports;
-    global.__filename = filename;
-    global.__dirname = dirname;
-    global.module = self;
-
-    return runInThisContext(content, { filename: filename });
-  }
 
   // create wrapper function
   var wrapper = Module.wrap(content);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3012,8 +3012,6 @@ static void PrintHelp() {
          "NODE_PATH              ':'-separated list of directories\n"
 #endif
          "                       prefixed to the module search path.\n"
-         "NODE_MODULE_CONTEXTS   Set to 1 to load modules in their own\n"
-         "                       global contexts.\n"
          "NODE_DISABLE_COLORS    Set to 1 to disable colors in the REPL\n"
 #if defined(NODE_HAVE_I18N_SUPPORT)
          "NODE_ICU_DATA          Data path for ICU (Intl object) data\n"

--- a/src/node.js
+++ b/src/node.js
@@ -465,17 +465,15 @@
     module.filename = path.join(cwd, name);
     module.paths = Module._nodeModulePaths(cwd);
     var script = process._eval;
-    if (!Module._contextLoad) {
-      var body = script;
-      script = 'global.__filename = ' + JSON.stringify(name) + ';\n' +
-               'global.exports = exports;\n' +
-               'global.module = module;\n' +
-               'global.__dirname = __dirname;\n' +
-               'global.require = require;\n' +
-               'return require("vm").runInThisContext(' +
-               JSON.stringify(body) + ', { filename: ' +
-               JSON.stringify(name) + ' });\n';
-    }
+    var body = script;
+    script = 'global.__filename = ' + JSON.stringify(name) + ';\n' +
+             'global.exports = exports;\n' +
+             'global.module = module;\n' +
+             'global.__dirname = __dirname;\n' +
+             'global.require = require;\n' +
+             'return require("vm").runInThisContext(' +
+             JSON.stringify(body) + ', { filename: ' +
+             JSON.stringify(name) + ' });\n';
     var result = module._compile(script, name + '-wrapper');
     if (process._print_eval) console.log(result);
   }


### PR DESCRIPTION
This feature has no tests and has been broken for ages, see for example
https://github.com/iojs/io.js/pull/1160.  Don't bother fixing it, it's
pretty much broken by design and there can't be too many users because
it's almost undocumented.  A quick Google search suggests that it causes
more grief than joy to the few that do use it.  Remove it.

R=@iojs/tc

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/306/