### PR TITLE
test: Introduce knowledge of FreeBSD jails

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -21,6 +21,35 @@ exports.tmpDir = path.join(exports.testDir, exports.tmpDirName);
 
 var opensslCli = null;
 
+Object.defineProperty(exports, 'inFreeBSDJail', {
+  get: function() {
+    if (process.platform === 'freebsd' &&
+      child_process.execSync('sysctl -n security.jail.jailed').toString() ===
+      '1\n') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+});
+
+Object.defineProperty(exports, 'localhost_ipv4', {
+  get: function() {
+    if (exports.inFreeBSDJail) {
+      // Jailed network interfaces are a bit special - since we need to jump
+      // through loops, as well as this being an exception case, assume the
+      // user will provide this instead.
+      if (process.env.LOCALHOST)
+        return process.env.LOCALHOST;
+
+      console.error('Looks like we\'re in a FreeBSD Jail. ' +
+                    'Please provide your default interface address ' +
+                    'as LOCALHOST or expect some tests to fail.');
+    }
+    return '127.0.0.1';
+  }
+});
+
 // opensslCli defined lazily to reduce overhead of spawnSync
 Object.defineProperty(exports, 'opensslCli', {get: function() {
   if (opensslCli !== null) return opensslCli;

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var dgram = require('dgram');
 
 // IPv4 Test
-var localhost_ipv4 = '127.0.0.1';
+var localhost_ipv4 = common.localhost_ipv4;
 var socket_ipv4 = dgram.createSocket('udp4');
 var family_ipv4 = 'IPv4';
 

--- a/test/parallel/test-dgram-bind-default-address.js
+++ b/test/parallel/test-dgram-bind-default-address.js
@@ -2,6 +2,12 @@ var common = require('../common');
 var assert = require('assert');
 var dgram = require('dgram');
 
+// skip test in FreeBSD jails since 0.0.0.0 will resolve to default interface
+if (common.inFreeBSDJail) {
+  console.log('1..0 # Skipped: In a FreeBSD jail');
+  process.exit();
+}
+
 dgram.createSocket('udp4').bind(common.PORT + 0, common.mustCall(function() {
   assert.equal(this.address().port, common.PORT + 0);
   assert.equal(this.address().address, '0.0.0.0');

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -11,7 +11,7 @@ server = dgram.createSocket('udp4');
 server.on('message', function(msg, rinfo) {
   console.log('server got: ' + msg +
               ' from ' + rinfo.address + ':' + rinfo.port);
-  assert.strictEqual(rinfo.address, '127.0.0.1');
+  assert.strictEqual(rinfo.address, common.localhost_ipv4);
   assert.strictEqual(msg.toString(), message_to_send.toString());
   server.send(msg, 0, msg.length, rinfo.port, rinfo.address);
 });
@@ -22,7 +22,7 @@ server.on('listening', function() {
   client.on('message', function(msg, rinfo) {
     console.log('client got: ' + msg +
                 ' from ' + rinfo.address + ':' + address.port);
-    assert.strictEqual(rinfo.address, '127.0.0.1');
+    assert.strictEqual(rinfo.address, common.localhost_ipv4);
     assert.strictEqual(rinfo.port, server_port);
     assert.strictEqual(msg.toString(), message_to_send.toString());
     client.close();

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -6,7 +6,7 @@ var conns = 0, conns_closed = 0;
 
 var server = net.createServer(function(socket) {
   conns++;
-  assert.equal('127.0.0.1', socket.localAddress);
+  assert.equal(common.localhost_ipv4, socket.localAddress);
   assert.equal(socket.localPort, common.PORT);
   socket.on('end', function() {
     server.close();
@@ -14,8 +14,8 @@ var server = net.createServer(function(socket) {
   socket.resume();
 });
 
-server.listen(common.PORT, '127.0.0.1', function() {
-  var client = net.createConnection(common.PORT, '127.0.0.1');
+server.listen(common.PORT, common.localhost_ipv4, function() {
+  var client = net.createConnection(common.PORT, common.localhost_ipv4);
   client.on('connect', function() {
     client.end();
   });

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -5,7 +5,7 @@ var net = require('net');
 
 var conns = 0, conns_closed = 0;
 
-var remoteAddrCandidates = [ '127.0.0.1'];
+var remoteAddrCandidates = [ common.localhost_ipv4 ];
 if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
 
 var remoteFamilyCandidates = ['IPv4'];

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var net = require('net');
 
 // Test on IPv4 Server
-var localhost_ipv4 = '127.0.0.1';
+var localhost_ipv4 = common.localhost_ipv4;
 var family_ipv4 = 'IPv4';
 var server_ipv4 = net.createServer();
 


### PR DESCRIPTION
FreeBSD jails act differently than your average vm or similar application container. All routing passes through one ip address, which makes things like localhost or 0.0.0.0 resolve differently.

Introduce a helper that allows us to verify if we're in a jail and another one for returning an ip address for localhost.

Also, skip one test instead of trading additional complexity in common.js for one specific user scenario.

R=@indutny