### PR TITLE
Simplify logic of testing buffer equality

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,6 +25,7 @@
 'use strict';
 
 // UTILITY
+const bufferBinding = process.binding('buffer');
 const util = require('util');
 const pSlice = Array.prototype.slice;
 
@@ -145,7 +146,7 @@ function _deepEqual(actual, expected, strict) {
   if (actual === expected) {
     return true;
   } else if (actual instanceof Buffer && expected instanceof Buffer) {
-    return process.binding('buffer').compare(actual, expected) === 0;
+    return bufferBinding.compare(actual, expected) === 0;
 
   // 7.2. If the expected value is a Date object, the actual value is
   // equivalent if it is also a Date object that refers to the same time.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -145,13 +145,7 @@ function _deepEqual(actual, expected, strict) {
   if (actual === expected) {
     return true;
   } else if (actual instanceof Buffer && expected instanceof Buffer) {
-    if (actual.length != expected.length) return false;
-
-    for (var i = 0; i < actual.length; i++) {
-      if (actual[i] !== expected[i]) return false;
-    }
-
-    return true;
+    return actual.equals(expected);
 
   // 7.2. If the expected value is a Date object, the actual value is
   // equivalent if it is also a Date object that refers to the same time.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -145,7 +145,7 @@ function _deepEqual(actual, expected, strict) {
   if (actual === expected) {
     return true;
   } else if (actual instanceof Buffer && expected instanceof Buffer) {
-    return actual.equals(expected);
+    return process.binding('buffer').compare(actual, expected) === 0;
 
   // 7.2. If the expected value is a Date object, the actual value is
   // equivalent if it is also a Date object that refers to the same time.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,7 +25,7 @@
 'use strict';
 
 // UTILITY
-const bufferBinding = process.binding('buffer');
+const compare = process.binding('buffer').compare;
 const util = require('util');
 const pSlice = Array.prototype.slice;
 
@@ -146,7 +146,7 @@ function _deepEqual(actual, expected, strict) {
   if (actual === expected) {
     return true;
   } else if (actual instanceof Buffer && expected instanceof Buffer) {
-    return bufferBinding.compare(actual, expected) === 0;
+    return compare(actual, expected) === 0;
 
   // 7.2. If the expected value is a Date object, the actual value is
   // equivalent if it is also a Date object that refers to the same time.


### PR DESCRIPTION
Delegate buffer equality check to `buffer.equals()`