### PR TITLE
configure: use gcc and g++ as CC and CXX defaults

### DIFF
--- a/configure
+++ b/configure
@@ -9,8 +9,9 @@ import sys
 import shutil
 import string
 
-CC = os.environ.get('CC', 'cc')
-CXX = os.environ.get('CXX', 'c++')
+# gcc and g++ as defaults matches what GYP's Makefile generator does.
+CC = os.environ.get('CC', 'gcc')
+CXX = os.environ.get('CXX', 'g++')
 
 root_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root_dir, 'tools', 'gyp', 'pylib'))


### PR DESCRIPTION
It matches what GYP's Makefile generator does and it should improve
compiler detection because cc and c++ are not always gcc and g++.

Fixes: https://github.com/iojs/io.js/issues/1173

R=@Fishrock123