### PR TITLE
src: fix crypto bio integer wraparound on 32 bits

### DIFF
--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -107,8 +107,10 @@ class NodeBIO {
 
     ~Buffer() {
       delete[] data_;
-      if (env_ != nullptr)
-        env_->isolate()->AdjustAmountOfExternalAllocatedMemory(-len_);
+      if (env_ != nullptr) {
+        const int64_t len = static_cast<int64_t>(len_);
+        env_->isolate()->AdjustAmountOfExternalAllocatedMemory(-len);
+      }
     }
 
     Environment* env_;


### PR DESCRIPTION
Fix a bug where a size_t was negated and passed to a function that takes
an int64_t.  It works by accident when sizeof(size_t) == sizeof(int64_t)
but it causes the value to underflow when size_t is a 32 bits type.

v8::Isolate::AdjustAmountOfExternalAllocatedMemory() is the function I'm
talking about.  The goal of that call is to tell V8 that some memory has
been freed but due to that underflow, we were actually reporting that we
had just allocated gigabytes of memory.  It set off a garbage collector
frenzy and essentially brought the VM to a standstill.

Fixes: https://github.com/iojs/io.js/issues/1188

R=@indutny

/cc @Nibbler999 – can you confirm that the patch fixes your issue?

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/323/