### PR TITLE
src: don't error at startup when cwd doesn't exist

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -40,8 +40,16 @@ function hasOwnProperty(obj, prop) {
 }
 
 
-// hack for require.resolve("./relative") to work properly.
-module.filename = path.resolve('repl');
+try {
+  // hack for require.resolve("./relative") to work properly.
+  module.filename = path.resolve('repl');
+} catch (e) {
+  // path.resolve('repl') fails when the current working directory has been
+  // deleted.  Fall back to the directory name of the (absolute) executable
+  // path.  It's not really correct but what are the alternatives?
+  const dirname = path.dirname(process.execPath);
+  module.filename = path.resolve(dirname, 'repl');
+}
 
 // hack for repl require to work properly with node_modules folders
 module.paths = require('module')._nodeModulePaths(module.filename);

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -1,0 +1,26 @@
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var spawn = require('child_process').spawn;
+
+// Fails with EINVAL on SmartOS, EBUSY on Windows.
+if (process.platform === 'sunos' || process.platform === 'win32') {
+  console.log('1..0 # Skipped: cannot rmdir current working directory');
+  return;
+}
+
+var dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+var proc = spawn(process.execPath, ['--interactive']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+proc.stdin.write('require("path");\n');
+proc.stdin.write('process.exit(42);\n');
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.equal(exitCode, 42);
+  assert.equal(signalCode, null);
+}));

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -1,0 +1,24 @@
+var common = require('../common');
+var assert = require('assert');
+var fs = require('fs');
+var spawn = require('child_process').spawn;
+
+// Fails with EINVAL on SmartOS, EBUSY on Windows.
+if (process.platform === 'sunos' || process.platform === 'win32') {
+  console.log('1..0 # Skipped: cannot rmdir current working directory');
+  return;
+}
+
+var dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+var proc = spawn(process.execPath, ['-e', '0']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.equal(exitCode, 0);
+  assert.equal(signalCode, null);
+}));

--- a/test/parallel/test-process-argv-0.js
+++ b/test/parallel/test-process-argv-0.js
@@ -22,12 +22,7 @@ if (process.argv[2] !== "child") {
   });
   child.on('exit', function () {
     console.error('CHILD: %s', childErr.trim().split('\n').join('\nCHILD: '));
-    if (process.platform === 'win32') {
-      // On Windows argv[0] is not expanded into full path
-      assert.equal(childArgv0, './iojs');
-    } else {
-      assert.equal(childArgv0, process.execPath);
-    }
+    assert.equal(childArgv0, process.execPath);
   });
 }
 else {


### PR DESCRIPTION
The current working directory may not exist when iojs starts up.  Don't
treat that as an error because it's still possible to do many useful
things, like evaluating a command line script or starting a REPL.

Fixes: #1184

R=@mscdex?

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/326/