### PR TITLE
test: cache lazy properties, fix style nits

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -20,33 +20,44 @@ if (process.env.TEST_THREAD_ID) {
 exports.tmpDir = path.join(exports.testDir, exports.tmpDirName);
 
 var opensslCli = null;
+var inFreeBSDJail = null;
+var localhostIPv4 = null;
 
 Object.defineProperty(exports, 'inFreeBSDJail', {
   get: function() {
+    if (inFreeBSDJail !== null) return inFreeBSDJail;
+
     if (process.platform === 'freebsd' &&
       child_process.execSync('sysctl -n security.jail.jailed').toString() ===
       '1\n') {
-      return true;
+      inFreeBSDJail = true;
     } else {
-      return false;
+      inFreeBSDJail = false;
     }
+    return inFreeBSDJail;
   }
 });
 
-Object.defineProperty(exports, 'localhost_ipv4', {
+Object.defineProperty(exports, 'localhostIPv4', {
   get: function() {
+    if (localhostIPv4 !== null) return localhostIPv4;
+
     if (exports.inFreeBSDJail) {
       // Jailed network interfaces are a bit special - since we need to jump
       // through loops, as well as this being an exception case, assume the
       // user will provide this instead.
-      if (process.env.LOCALHOST)
-        return process.env.LOCALHOST;
-
-      console.error('Looks like we\'re in a FreeBSD Jail. ' +
-                    'Please provide your default interface address ' +
-                    'as LOCALHOST or expect some tests to fail.');
+      if (process.env.LOCALHOST) {
+        localhostIPv4 = process.env.LOCALHOST;
+      } else {
+        console.error('Looks like we\'re in a FreeBSD Jail. ' +
+                      'Please provide your default interface address ' +
+                      'as LOCALHOST or expect some tests to fail.');
+      }
     }
-    return '127.0.0.1';
+
+    if (localhostIPv4 === null) localhostIPv4 = '127.0.0.1';
+
+    return localhostIPv4;
   }
 });
 

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -3,13 +3,12 @@ var assert = require('assert');
 var dgram = require('dgram');
 
 // IPv4 Test
-var localhost_ipv4 = common.localhost_ipv4;
 var socket_ipv4 = dgram.createSocket('udp4');
 var family_ipv4 = 'IPv4';
 
 socket_ipv4.on('listening', function() {
   var address_ipv4 = socket_ipv4.address();
-  assert.strictEqual(address_ipv4.address, localhost_ipv4);
+  assert.strictEqual(address_ipv4.address, common.localhostIPv4);
   assert.strictEqual(address_ipv4.port, common.PORT);
   assert.strictEqual(address_ipv4.family, family_ipv4);
   socket_ipv4.close();
@@ -20,7 +19,7 @@ socket_ipv4.on('error', function(e) {
   socket_ipv4.close();
 });
 
-socket_ipv4.bind(common.PORT, localhost_ipv4);
+socket_ipv4.bind(common.PORT, common.localhostIPv4);
 
 // IPv6 Test
 var localhost_ipv6 = '::1';

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -11,7 +11,7 @@ server = dgram.createSocket('udp4');
 server.on('message', function(msg, rinfo) {
   console.log('server got: ' + msg +
               ' from ' + rinfo.address + ':' + rinfo.port);
-  assert.strictEqual(rinfo.address, common.localhost_ipv4);
+  assert.strictEqual(rinfo.address, common.localhostIPv4);
   assert.strictEqual(msg.toString(), message_to_send.toString());
   server.send(msg, 0, msg.length, rinfo.port, rinfo.address);
 });
@@ -22,7 +22,7 @@ server.on('listening', function() {
   client.on('message', function(msg, rinfo) {
     console.log('client got: ' + msg +
                 ' from ' + rinfo.address + ':' + address.port);
-    assert.strictEqual(rinfo.address, common.localhost_ipv4);
+    assert.strictEqual(rinfo.address, common.localhostIPv4);
     assert.strictEqual(rinfo.port, server_port);
     assert.strictEqual(msg.toString(), message_to_send.toString());
     client.close();

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -6,7 +6,7 @@ var conns = 0, conns_closed = 0;
 
 var server = net.createServer(function(socket) {
   conns++;
-  assert.equal(common.localhost_ipv4, socket.localAddress);
+  assert.equal(common.localhostIPv4, socket.localAddress);
   assert.equal(socket.localPort, common.PORT);
   socket.on('end', function() {
     server.close();
@@ -14,8 +14,8 @@ var server = net.createServer(function(socket) {
   socket.resume();
 });
 
-server.listen(common.PORT, common.localhost_ipv4, function() {
-  var client = net.createConnection(common.PORT, common.localhost_ipv4);
+server.listen(common.PORT, common.localhostIPv4, function() {
+  var client = net.createConnection(common.PORT, common.localhostIPv4);
   client.on('connect', function() {
     client.end();
   });

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -5,7 +5,7 @@ var net = require('net');
 
 var conns = 0, conns_closed = 0;
 
-var remoteAddrCandidates = [ common.localhost_ipv4 ];
+var remoteAddrCandidates = [ common.localhostIPv4 ];
 if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
 
 var remoteFamilyCandidates = ['IPv4'];

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 var net = require('net');
 
 // Test on IPv4 Server
-var localhost_ipv4 = common.localhost_ipv4;
 var family_ipv4 = 'IPv4';
 var server_ipv4 = net.createServer();
 
@@ -11,9 +10,9 @@ server_ipv4.on('error', function(e) {
   console.log('Error on ipv4 socket: ' + e.toString());
 });
 
-server_ipv4.listen(common.PORT, localhost_ipv4, function() {
+server_ipv4.listen(common.PORT, common.localhostIPv4, function() {
   var address_ipv4 = server_ipv4.address();
-  assert.strictEqual(address_ipv4.address, localhost_ipv4);
+  assert.strictEqual(address_ipv4.address, common.localhostIPv4);
   assert.strictEqual(address_ipv4.port, common.PORT);
   assert.strictEqual(address_ipv4.family, family_ipv4);
   server_ipv4.close();


### PR DESCRIPTION
_(addressing the concerns I raised too late in #1167)_

`inFreeBSDJail` involves an `execSync()` and is used by `localhost_ipv4` so will be unnecessarily expensive, so cache both values and reuse rather than re-evaluate each time.

Renamed `localhost_ipv4` to `localhostIPv4` for style consistency.

/R=@jbergstroem 
/R=@bnoordhuis 