### PR TITLE
build: remove incorrect arg in vcbuild.bat

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -172,7 +172,7 @@ if "%test_args%"=="" goto jslint
 if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'python tools/test.py %test_args%'
-python tools/test.py --timeout=50 %test_args%
+python tools/test.py %test_args%
 goto jslint
 
 :jslint


### PR DESCRIPTION
Looks like this was wrongly committed in f19e9b6a7603c852bc9cec9516c0fe70fc8db173

R=@rvagg