### PR TITLE
test: double timeout in tls-wrap-timeout.js

### DIFF
--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -21,13 +21,13 @@ var server = tls.createServer(options, function(c) {
     setTimeout(function() {
       c.destroy();
       server.close();
-    }, 75);
-  }, 75);
+    }, 150);
+  }, 150);
 });
 
 server.listen(common.PORT, function() {
   var socket = net.connect(common.PORT, function() {
-    socket.setTimeout(120, assert.fail);
+    socket.setTimeout(240, assert.fail);
 
     var tsocket = tls.connect({
       socket: socket,


### PR DESCRIPTION
The test is timing dependent, ensure that it won't fail on the busy CI
boxes.

Fix: https://github.com/iojs/io.js/issues/1200