### PR TITLE
buffer: add buf.mask for ws

### DIFF
--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -828,6 +828,8 @@ corresponding parameters to
 
 The target region of memory may overlap the source region of memory.
 
+Returns the number of bytes masked and written into `targetBuffer`.
+
 ### buffer.values()
 
 Creates iterator for buffer values (bytes). This function is called automatically

--- a/doc/api/buffer.markdown
+++ b/doc/api/buffer.markdown
@@ -810,6 +810,24 @@ buffer.
     var b = new Buffer(50);
     b.fill("h");
 
+### buf.mask(maskValue, targetBuffer[, targetStart][, sourceStart][, sourceEnd])
+
+* `maskValue` Number
+* `targetBuffer` Buffer
+* `targetStart` Number, optional
+* `sourceStart` Number, optional
+* `sourceEnd` Number, optional
+
+Takes the contents of `buf`, starting at `sourceStart` and ending at
+`sourceEnd`, and XOR's them with `maskValue`. The result is written to
+`targetBuffer`, starting at `targetOffset`. `sourceStart` and `targetStart`
+will default to `0` if not given; `sourceEnd` will default to `buf.length` if
+not given. The start, end, and offset parameters function the same as the
+corresponding parameters to
+[buf.copy](#buffer_buf_copy_targetbuffer_targetstart_sourcestart_sourceend).
+
+The target region of memory may overlap the source region of memory.
+
 ### buffer.values()
 
 Creates iterator for buffer values (bytes). This function is called automatically

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -368,14 +368,14 @@ void Mask(const FunctionCallbackInfo<Value> &args) {
   target_data += written;
   obj_data += written;
 
-  switch(to_copy % 4) {
+  switch (to_copy % 4) {
     case 3:
       target_data[2] = obj_data[2] ^ mask.as_bytes[2];
     case 2:
       target_data[1] = obj_data[1] ^ mask.as_bytes[1];
     case 1:
       target_data[0] = obj_data[0] ^ mask.as_bytes[0];
-    case 0:;
+    case 0: {}
   }
   return args.GetReturnValue().Set(to_copy);
 }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -309,7 +309,8 @@ void Base64Slice(const FunctionCallbackInfo<Value>& args) {
   StringSlice<BASE64>(args);
 }
 
-// source, mask, target, targetOffset, start, end
+
+// bytesCopied = buffer.mask(mask, target, targetOffset, sourceStart, sourceEnd)
 void Mask(const FunctionCallbackInfo<Value> &args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -369,7 +370,7 @@ void Mask(const FunctionCallbackInfo<Value> &args) {
       target_data[0] = obj_data[0] ^ mask[0];
     case 0:;
   }
-  return args.GetReturnValue().Set(0);
+  return args.GetReturnValue().Set(to_copy);
 }
 
 

--- a/test/parallel/test-buffer-mask.js
+++ b/test/parallel/test-buffer-mask.js
@@ -1,0 +1,85 @@
+var common = require('../common');
+var assert = require('assert');
+
+var tests = [
+  testBasic,
+  testBounds,
+  testOverflow,
+  testNonAligned
+]
+
+tests.forEach(Function.prototype.call.bind(Function.prototype.call))
+
+function referenceImplementation(source, maskNum, output, offset, length) {
+  var i = 0;
+  var mask = new Buffer(4);
+  mask.writeUInt32LE(maskNum, 0);
+
+  for (; i < length - 3; i += 4) {
+    var num = (maskNum ^ source.readUInt32LE(i, true)) >>> 0;
+    if (num < 0) num = 4294967296 + num;
+    output.writeUInt32LE(num, offset + i, true);
+  }
+
+  switch (length % 4) {
+    case 3: output[offset + i + 2] = source[i + 2] ^ mask[2];
+    case 2: output[offset + i + 1] = source[i + 1] ^ mask[1];
+    case 1: output[offset + i] = source[i] ^ mask[0];
+  }
+}
+
+function testBasic() {
+  var input = new Buffer(256);
+  var output = new Buffer(256);
+  var refoutput = new Buffer(256);
+  var mask = 0xF0F0F0F0;
+
+  for (var i = 0; i < input.length; ++i)
+    input[i] = i;
+
+  referenceImplementation(input, mask, refoutput, 0, 256);
+  input.mask(mask, output, 256);
+
+  for(var i = 0; i < input.length; ++i)
+    assert.equal(output[i], refoutput[i]);
+}
+
+function testBounds() {
+  var input = new Buffer(16)
+  var output = new Buffer(32)
+  try {
+    input.mask(120120, output, 17)
+    assert.fail('expected error')
+  } catch(err) {
+    assert.ok(err)
+  }
+}
+
+function testOverflow() {
+  var input = new Buffer(16)
+  var output = new Buffer(15)
+  try {
+    input.mask(120120, output)
+    assert.fail('expected error')
+  } catch(err) {
+    assert.ok(err)
+  }
+}
+
+function testNonAligned() {
+  var input = new Buffer(16);
+  var output = new Buffer(16);
+  var refoutput = new Buffer(16);
+  var mask = 0xF0F0F0F0;
+
+  for (var i = 0; i < input.length; ++i)
+    input[i] = i;
+
+  for (var end = 3; end > 0; --end) {
+    referenceImplementation(input, mask, refoutput, 0, end);
+    input.mask(mask, output, end);
+
+    for(var i = 0; i < end; ++i)
+      assert.equal(output[i], refoutput[i]);
+  }
+}

--- a/test/parallel/test-buffer-mask.js
+++ b/test/parallel/test-buffer-mask.js
@@ -9,7 +9,9 @@ var tests = [
   testReturnValue
 ]
 
-tests.forEach(Function.prototype.call.bind(Function.prototype.call))
+tests.forEach(function(fn) {
+  fn();
+});
 
 function referenceImplementation(source, maskNum, output, offset, start, end) {
   var i = 0;

--- a/test/parallel/test-buffer-mask.js
+++ b/test/parallel/test-buffer-mask.js
@@ -5,7 +5,8 @@ var tests = [
   testBasic,
   testBounds,
   testOverflow,
-  testNonAligned
+  testNonAligned,
+  testReturnValue
 ]
 
 tests.forEach(Function.prototype.call.bind(Function.prototype.call))
@@ -78,4 +79,14 @@ function testNonAligned() {
     for (var i = 0; i < end; ++i)
       assert.equal(output[i], refoutput[i]);
   }
+}
+
+function testReturnValue() {
+  var input = new Buffer(16);
+  var output = new Buffer(16);
+  assert.equal(input.mask(0, output), 16)
+  assert.equal(input.mask(0, output, 4), 12)
+  assert.equal(input.mask(0, output, 4, 6), 10)
+  assert.equal(input.mask(0, output, 4, 6, 4), 0)
+  assert.equal(input.mask(0, output, 4, 6, 8), 2)
 }

--- a/test/parallel/test-buffer-mask.js
+++ b/test/parallel/test-buffer-mask.js
@@ -10,21 +10,16 @@ var tests = [
 
 tests.forEach(Function.prototype.call.bind(Function.prototype.call))
 
-function referenceImplementation(source, maskNum, output, offset, length) {
+function referenceImplementation(source, maskNum, output, offset, start, end) {
   var i = 0;
   var mask = new Buffer(4);
+  var length = end - start;
   mask.writeUInt32LE(maskNum, 0);
-
-  for (; i < length - 3; i += 4) {
-    var num = (maskNum ^ source.readUInt32LE(i, true)) >>> 0;
-    if (num < 0) num = 4294967296 + num;
-    output.writeUInt32LE(num, offset + i, true);
-  }
-
-  switch (length % 4) {
-    case 3: output[offset + i + 2] = source[i + 2] ^ mask[2];
-    case 2: output[offset + i + 1] = source[i + 1] ^ mask[1];
-    case 1: output[offset + i] = source[i] ^ mask[0];
+  var toCopy = Math.min(length, output.length - offset);
+  var maskIdx = 0;
+  for (var i = 0; i < toCopy; ++i) {
+    output[i + offset] = source[i + start] ^ mask[maskIdx];
+    maskIdx = (maskIdx + 1) & 3;
   }
 }
 
@@ -37,32 +32,33 @@ function testBasic() {
   for (var i = 0; i < input.length; ++i)
     input[i] = i;
 
-  referenceImplementation(input, mask, refoutput, 0, 256);
-  input.mask(mask, output, 256);
-
-  for(var i = 0; i < input.length; ++i)
+  output[0] = refoutput[0] = 0;
+  referenceImplementation(input, mask, refoutput, 1, 0, 255);
+  input.mask(mask, output, 1, 0, 255);
+  for (var i = 0; i < input.length; ++i) {
     assert.equal(output[i], refoutput[i]);
+  }
 }
 
 function testBounds() {
-  var input = new Buffer(16)
-  var output = new Buffer(32)
+  var input = new Buffer(16);
+  var output = new Buffer(32);
   try {
-    input.mask(120120, output, 17)
-    assert.fail('expected error')
+    input.mask(120120, output, 0, 0, 17);
+    assert.fail('expected error');
   } catch(err) {
-    assert.ok(err)
+    assert.ok(err);
   }
 }
 
 function testOverflow() {
-  var input = new Buffer(16)
-  var output = new Buffer(15)
+  var input = new Buffer(16);
+  var output = new Buffer(15);
   try {
-    input.mask(120120, output)
-    assert.fail('expected error')
+    input.mask(120120, output);
+    assert.fail('expected error');
   } catch(err) {
-    assert.ok(err)
+    assert.ok(err);
   }
 }
 
@@ -76,10 +72,10 @@ function testNonAligned() {
     input[i] = i;
 
   for (var end = 3; end > 0; --end) {
-    referenceImplementation(input, mask, refoutput, 0, end);
-    input.mask(mask, output, end);
+    referenceImplementation(input, mask, refoutput, 0, 0, end);
+    input.mask(mask, output, 0, 0, end);
 
-    for(var i = 0; i < end; ++i)
+    for (var i = 0; i < end; ++i)
       assert.equal(output[i], refoutput[i]);
   }
 }


### PR DESCRIPTION
This patch adds `buf.mask(maskValue, targetBuffer, targetOffset, sourceStart, sourceEnd)`, needed by the ws package for [masking](https://github.com/websockets/ws/blob/ac283f0368375e674fa370cd4b64cef42add2968/lib/Sender.js#L194) and unmasking websocket frames. The original implementation is [here](https://github.com/websockets/bufferutil/blob/3bbb6f23193fae7683b61e2cae1f85ede5fb4469/src/bufferutil.cc#L85). It is implemented as a partially unrolled loop, operating on 32-bit values and dealing with the 0-3 byte remainder at the end – I'm not sure if we want to retain this optimization, since the `sourceStart` and `targetOffset` params make it possible to trigger non-8-byte-aligned copies.

I didn't implement [`Unmask`](https://github.com/websockets/bufferutil/blob/3bbb6f23193fae7683b61e2cae1f85ede5fb4469/src/bufferutil.cc#L64): it should be equivalent to `buf.mask(mask, buf)`. [`Merge`](https://github.com/websockets/bufferutil/blob/3bbb6f23193fae7683b61e2cae1f85ede5fb4469/src/bufferutil.cc#L46) is also omitted. I'll have another PR up for [`Utf8Validate`](https://github.com/websockets/utf-8-validate/blob/master/src/validation.cc) tomorrow.

R=@trevnorris, @piscisaureus 