### PR TITLE
smalloc: don't mix malloc() and new char[]

### DIFF
--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -314,8 +314,10 @@ void Alloc(Environment* env,
 
   char* data = static_cast<char*>(malloc(length));
   if (data == nullptr) {
-    FatalError("node::smalloc::Alloc(v8::Handle<v8::Object>, size_t,"
-               " v8::ExternalArrayType)", "Out Of Memory");
+    FatalError("node::smalloc::Alloc(node::Environment*, "
+               " v8::Handle<v8::Object>, size_t, v8::ExternalArrayType)",
+               "Out Of Memory");
+    UNREACHABLE();
   }
 
   Alloc(env, obj, data, length, type);
@@ -394,7 +396,14 @@ void Alloc(Environment* env,
 
   length *= type_size;
 
-  char* data = new char[length];
+  char* data = static_cast<char*>(malloc(length));
+  if (data == nullptr) {
+    FatalError("node::smalloc::Alloc(node::Environment*, "
+               " v8::Handle<v8::Object>, size_t, node::FreeCallback,"
+               " void*, v8::ExternalArrayType)", "Out Of Memory");
+    UNREACHABLE();
+  }
+
   Alloc(env, obj, data, length, fn, hint, type);
 }
 


### PR DESCRIPTION
It's technically undefined behavior to mix malloc with delete[] and
new char[] with free().  smalloc was using new char[] in one place and
malloc() in another but in both cases the memory was freed with free().

R=@trevnorris