### PR TITLE
node: add support for --interactive-eval (-ie) flag

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -70,7 +70,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     return new REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined);
   }
 
-  var options, input, output, dom;
+  var options, input, output, dom, evalString;
   if (prompt !== null && typeof prompt === 'object') {
     // an options object was given
     options = prompt;
@@ -82,6 +82,7 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
     ignoreUndefined = options.ignoreUndefined;
     prompt = options.prompt;
     dom = options.domain;
+    evalString = options.evalString;
   } else if (typeof prompt !== 'string') {
     throw new Error('An options Object, or a prompt String are required');
   } else {
@@ -324,6 +325,10 @@ function REPLServer(prompt, stream, eval_, useGlobal, ignoreUndefined) {
   self.on('SIGCONT', function() {
     self.displayPrompt(true);
   });
+
+  if ('string' === typeof evalString) {
+    self.emit('line', evalString);
+  }
 
   self.displayPrompt();
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -3094,7 +3094,9 @@ static void ParseArgs(int* argc,
                strcmp(arg, "-e") == 0 ||
                strcmp(arg, "--print") == 0 ||
                strcmp(arg, "-pe") == 0 ||
-               strcmp(arg, "-p") == 0) {
+               strcmp(arg, "-p") == 0 ||
+               strcmp(arg, "--interactive-eval") == 0 ||
+               strcmp(arg, "-ie") == 0) {
       bool is_eval = strchr(arg, 'e') != nullptr;
       bool is_print = strchr(arg, 'p') != nullptr;
       print_eval = print_eval || is_print;
@@ -3105,6 +3107,9 @@ static void ParseArgs(int* argc,
         if (eval_string == nullptr) {
           fprintf(stderr, "%s: %s requires an argument\n", argv[0], arg);
           exit(9);
+        }
+        if (strcmp(arg, "--interactive-eval") == 0 || strcmp(arg, "-ie") == 0) {
+          force_repl = true;
         }
       } else if ((index + 1 < nargs) &&
                  argv[index + 1] != nullptr &&

--- a/src/node.js
+++ b/src/node.js
@@ -79,7 +79,27 @@
         });
       }
 
-      if (process._eval != null) {
+      if (process._eval != null && process._forceRepl) {
+        var Module = NativeModule.require('module');
+
+        // interactive-eval REPL
+        var opts = {
+          useGlobal: true,
+          ignoreUndefined: false,
+          evalString: process._eval
+        };
+        if (parseInt(process.env['NODE_NO_READLINE'], 10)) {
+          opts.terminal = false;
+        }
+        if (parseInt(process.env['NODE_DISABLE_COLORS'], 10)) {
+          opts.useColors = false;
+        }
+        var repl = Module.requireRepl().start(opts);
+        repl.on('exit', function() {
+          process.exit();
+        });
+
+      } else if (process._eval != null) {
         // User passed '-e' or '--eval' arguments to Node.
         evalScript('[eval]');
       } else if (process.argv[1]) {


### PR DESCRIPTION
Fixes #1197

This achieves the desired `-ie` behaviour of pre-loading the eval expression into, and opening the repl.

```
iojs -ie "var life = 42"
undefined
> life
42
> 
```

```
iojs -ie "console.log('hello world')"
hello world
undefined
> 
```

I'll setup a test in `test-repl-options` if this looks reasonable, also, not sure if this needs to be documented in `--help` or not.

Edit: another thing, what `subsystem:` should this be?

/cc @bnoordhuis
/first time I've ever touched C++ \o/