### PR TITLE
configure: use cc and c++ as defaults on os x

### DIFF
--- a/configure
+++ b/configure
@@ -9,9 +9,10 @@ import sys
 import shutil
 import string
 
-# gcc and g++ as defaults matches what GYP's Makefile generator does.
-CC = os.environ.get('CC', 'gcc')
-CXX = os.environ.get('CXX', 'g++')
+# gcc and g++ as defaults matches what GYP's Makefile generator does,
+# except on OS X.
+CC = os.environ.get('CC', 'cc' if sys.platform == 'darwin' else 'gcc')
+CXX = os.environ.get('CXX', 'c++' if sys.platform == 'darwin' else 'g++')
 
 root_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(root_dir, 'tools', 'gyp', 'pylib'))


### PR DESCRIPTION
Commit 8b2363d ("configure: use gcc and g++ as CC and CXX defaults")
switches the CC and CXX defaults but it turns out that GYP uses cc
and c++ as defaults on OS X.

It also made the configure script complain about old compilers because
the xcode gcc identifies as v4.2.1, whereas cc is less ambiguous about
it being a clang hybrid.

R=@jbergstroem?