### PR TITLE
build: make check aliases test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ distclean:
 	-rm -rf deps/icu4c*.tgz deps/icu4c*.zip deps/icu-tmp
 	-rm -f $(BINARYTAR).* $(TARBALL).*
 
+check: test
+
 test: all
 	$(PYTHON) tools/test.py --mode=release message parallel sequential -J
 	$(MAKE) jslint


### PR DESCRIPTION
A common convention in auto* is to call make check rather than make test. Let one alias the other.

This has been bugging me _forever_.

/R=@bnoordhuis