### PR TITLE
querystring: parse numbers correctly

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -147,8 +147,10 @@ QueryString.escape = function(str) {
 };
 
 var stringifyPrimitive = function(v) {
-  if (typeof v === 'string' || (typeof v === 'number' && isFinite(v)))
+  if (typeof v === 'string')
     return v;
+  if (typeof v === 'number' && isFinite(v))
+    return '' + v;
   if (typeof v === 'boolean')
     return v ? 'true' : 'false';
   return '';

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -90,6 +90,9 @@ var hexTable = new Array(256);
 for (var i = 0; i < 256; ++i)
   hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
 QueryString.escape = function(str) {
+  // replaces encodeURIComponent
+  // http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.3.4
+  str = '' + str;
   var len = str.length;
   var out = '';
   var i, c;

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -138,6 +138,14 @@ qsWeirdObjects.forEach(function(testCase) {
   assert.equal(testCase[1], qs.stringify(testCase[0]));
 });
 
+// coerce numbers to string
+assert.strictEqual('foo=0', qs.stringify({ foo: 0 }));
+assert.strictEqual('foo=0', qs.stringify({ foo: -0 }));
+assert.strictEqual('foo=3', qs.stringify({ foo: 3 }));
+assert.strictEqual('foo=-72.42', qs.stringify({ foo: -72.42 }));
+assert.strictEqual('foo=', qs.stringify({ foo: NaN }));
+assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
+
 // nested
 var f = qs.stringify({
   a: 'b',


### PR DESCRIPTION
Fixes: https://github.com/iojs/io.js/issues/1208

I dunno if the test cases need to be any more thorough.

cc @rvagg @mscdex