### PR TITLE
src: ignore ENOTCONN on shutdown race with child

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -321,6 +321,14 @@ void SyncProcessStdioPipe::WriteCallback(uv_write_t* req, int result) {
 void SyncProcessStdioPipe::ShutdownCallback(uv_shutdown_t* req, int result) {
   SyncProcessStdioPipe* self =
       reinterpret_cast<SyncProcessStdioPipe*>(req->handle->data);
+
+  // On AIX, OS X and the BSDs, calling shutdown() on one end of a pipe
+  // when the other end has closed the connection fails with ENOTCONN.
+  // Libuv is not the right place to handle that because it can't tell
+  // if the error is genuine but we here can.
+  if (result == UV_ENOTCONN)
+    result = 0;
+
   self->OnShutdownDone(result);
 }
 


### PR DESCRIPTION
On AIX, OS X and the BSDs, calling shutdown() on one end of a pipe
when the other end has closed the connection fails with ENOTCONN.

The sequential/test-child-process-execsync test failed sporadically
because of a race between the parent and the child where one closed
its end of the pipe before the other got around to calling shutdown()
on its end of the pipe.

Libuv is not the right place to handle that because it can't tell if
the ENOTCONN error is genuine but io.js can.

Refs: https://github.com/libuv/libuv/pull/268

R=@piscisaureus, /cc @gireeshpunathil @mdawsonibm

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/347/