### PR TITLE
path: reduce type checking on some methods

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -302,8 +302,6 @@ win32._makeLong = function(path) {
 
 
 win32.dirname = function(path) {
-  assertPath(path);
-
   var result = win32SplitPath(path),
       root = result[0],
       dir = result[1];
@@ -323,8 +321,6 @@ win32.dirname = function(path) {
 
 
 win32.basename = function(path, ext) {
-  assertPath(path);
-
   if (ext !== undefined && typeof ext !== 'string')
     throw new TypeError('ext must be a string');
 
@@ -338,7 +334,6 @@ win32.basename = function(path, ext) {
 
 
 win32.extname = function(path) {
-  assertPath(path);
   return win32SplitPath(path)[3];
 };
 
@@ -536,8 +531,6 @@ posix._makeLong = function(path) {
 
 
 posix.dirname = function(path) {
-  assertPath(path);
-
   var result = posixSplitPath(path),
       root = result[0],
       dir = result[1];
@@ -557,8 +550,6 @@ posix.dirname = function(path) {
 
 
 posix.basename = function(path, ext) {
-  assertPath(path);
-
   if (ext !== undefined && typeof ext !== 'string')
     throw new TypeError('ext must be a string');
 
@@ -572,7 +563,6 @@ posix.basename = function(path, ext) {
 
 
 posix.extname = function(path) {
-  assertPath(path);
   return posixSplitPath(path)[3];
 };
 

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -270,12 +270,15 @@ typeErrorTests.forEach(function(test) {
   fail(path.resolve, test);
   fail(path.normalize, test);
   fail(path.isAbsolute, test);
-  fail(path.dirname, test);
   fail(path.relative, test, 'foo');
   fail(path.relative, 'foo', test);
-  fail(path.basename, test);
-  fail(path.extname, test);
   fail(path.parse, test);
+
+  // These methods should throw a TypeError, but do not for backwards
+  // compatibility. Uncommenting these lines in the future should be a goal.
+  // fail(path.dirname, test);
+  // fail(path.basename, test);
+  // fail(path.extname, test);
 
   // undefined is a valid value as the second argument to basename
   if (test !== undefined) {


### PR DESCRIPTION
a465840313f548b913eb2bd8ea3d26c2ab5dcebb added strict type checking for the methods in the `path` module. However, `dirname()`, `basename()`, and `extname()` actually had some undocumented uses
in the wild. This commit loosens the type checking on those methods. Fixes #1215.

R=@rvagg 