### PR TITLE
timers: assure setTimeout callback only runs once

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -85,6 +85,7 @@ function listOnTimeout() {
         if (domain)
           domain.enter();
         threw = true;
+        first._called = true;
         first._onTimeout();
         if (domain)
           domain.exit();
@@ -305,6 +306,9 @@ Timeout.prototype.unref = function() {
   if (this._handle) {
     this._handle.unref();
   } else if (typeof(this._onTimeout) === 'function') {
+    // Prevent running callback multiple times
+    // when unref() is called during the callback
+    if (this._called) return;
     var now = Timer.now();
     if (!this._idleStart) this._idleStart = now;
     var delay = this._idleStart + this._idleTimeout - now;
@@ -492,6 +496,7 @@ function unrefTimeout() {
       if (domain) domain.enter();
       threw = true;
       debug('unreftimer firing timeout');
+      first._called = true;
       first._onTimeout();
       threw = false;
       if (domain)

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -307,14 +307,15 @@ Timeout.prototype.unref = function() {
   if (this._handle) {
     this._handle.unref();
   } else if (typeof(this._onTimeout) === 'function') {
-    // Prevent running callback multiple times
-    // when unref() is called during the callback
-    if (this._called) return;
     var now = Timer.now();
     if (!this._idleStart) this._idleStart = now;
     var delay = this._idleStart + this._idleTimeout - now;
     if (delay < 0) delay = 0;
     exports.unenroll(this);
+
+    // Prevent running cb again when unref() is called during the same cb
+    if (this._called && !this._repeat) return;
+
     this._handle = new Timer();
     this._handle[kOnTimeout] = this._onTimeout;
     this._handle.start(delay, 0);

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -294,6 +294,7 @@ exports.clearInterval = function(timer) {
 
 
 const Timeout = function(after) {
+  this._called = false;
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -5,6 +5,7 @@ var interval_fired = false,
     timeout_fired = false,
     unref_interval = false,
     unref_timer = false,
+    unref_callbacks = 0,
     interval, check_unref, checks = 0;
 
 var LONG_TIME = 10 * 1000;
@@ -34,6 +35,11 @@ check_unref = setInterval(function() {
   checks += 1;
 }, 100);
 
+setTimeout(function() {
+  unref_callbacks++;
+  this.unref();
+}, SHORT_TIME);
+
 // Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
 (function() {
   var t = setInterval(function() {}, 1);
@@ -46,4 +52,5 @@ process.on('exit', function() {
   assert.strictEqual(timeout_fired, false, 'Timeout should not fire');
   assert.strictEqual(unref_timer, true, 'An unrefd timeout should still fire');
   assert.strictEqual(unref_interval, true, 'An unrefd interval should still fire');
+  assert.strictEqual(unref_callbacks, 1, 'Callback should only run once');
 });

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -35,11 +35,12 @@ check_unref = setInterval(function() {
   checks += 1;
 }, 100);
 
-// unref() during the callback
 setTimeout(function() {
   unref_callbacks++;
   this.unref();
 }, SHORT_TIME);
+
+// Should not timeout the test
 setInterval(function() {
   this.unref();
 }, SHORT_TIME);

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -35,8 +35,12 @@ check_unref = setInterval(function() {
   checks += 1;
 }, 100);
 
+// unref() during the callback
 setTimeout(function() {
   unref_callbacks++;
+  this.unref();
+}, SHORT_TIME);
+setInterval(function() {
   this.unref();
 }, SHORT_TIME);
 


### PR DESCRIPTION
This fixes #1191 by adding a property to track if the callback was run, and if so, prevents it from running again during a `.unref()`.

I woul've loved to do it without the property, but couldn't find any way to find out whether the callback already ran.

r=@bnoordhuis @trevnorris