### PR TITLE
node: ensure that streams2 won't `.end()` stdin

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -630,6 +630,8 @@
               writable: false
             });
           }
+          // Ensure that Streams2 won't try to `.end()` the stream
+          stdin._writableState.ended = true;
           break;
 
         default:

--- a/test/parallel/test-regress-GH-io-1068.js
+++ b/test/parallel/test-regress-GH-io-1068.js
@@ -1,1 +1,2 @@
+debugger;
 process.stdin.emit('end');

--- a/test/parallel/test-regress-GH-io-1068.js
+++ b/test/parallel/test-regress-GH-io-1068.js
@@ -1,2 +1,1 @@
-debugger;
 process.stdin.emit('end');


### PR DESCRIPTION
Stdin is purely read-only stream. Although, `net.Socket` might be used
to create it if stdin is in fact a Pipe or TCP socket, the
`stream.Duplex` should not try to call `.end()` on it.

Fix: https://github.com/iojs/io.js/issues/1068

cc @rvagg