### PR TITLE
lib: remove `:` from protocol in Url.parse().

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -133,7 +133,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   if (proto) {
     proto = proto[0];
     var lowerProto = proto.toLowerCase();
-    this.protocol = lowerProto;
+    this.protocol = lowerProto.replace(/.$/, '');
     rest = rest.substr(proto.length);
   }
 


### PR DESCRIPTION
I only removed `:` from parsed protocol.