### PR TITLE
Fail verbosely on invalid use of util.inherits

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -622,11 +622,16 @@ exports.log = function() {
 exports.inherits = function(ctor, superCtor) {
 
   if (ctor === undefined || ctor === null)
-    throw new TypeError('The constructor to `inherits` must not be null.');
+    throw new TypeError('The constructor to `inherits` must not be ' +
+                        'null or undefined.');
+
   if (superCtor === undefined || superCtor === null)
-    throw new TypeError('The super constructor to `inherits` must not be null.');
+    throw new TypeError('The super constructor to `inherits` must not ' +
+                        'be null or undefined.');
+
   if (superCtor.prototype === undefined)
-    throw new TypeError('The super constructor must have a prototype.');
+    throw new TypeError('The super constructor to `inherits` must ' +
+                        'have a prototype.');
 
   ctor.super_ = superCtor;
   ctor.prototype = Object.create(superCtor.prototype, {

--- a/lib/util.js
+++ b/lib/util.js
@@ -625,7 +625,7 @@ exports.inherits = function(ctor, superCtor) {
     throw new TypeError('The constructor to `inherits` must not be null.');
   if (isNullOrUndefined(superCtor))
     throw new TypeError('The super constructor to `inherits` must not be null.');
-  if (isNullOrUndefined(superCtor.prototype))
+  if (isUndefined(superCtor.prototype))
     throw new TypeError('The super constructor must have a prototype.');
 
   ctor.super_ = superCtor;

--- a/lib/util.js
+++ b/lib/util.js
@@ -616,8 +616,18 @@ exports.log = function() {
  * @param {function} ctor Constructor function which needs to inherit the
  *     prototype.
  * @param {function} superCtor Constructor function to inherit prototype from.
+ * @throws {TypeError} Will error if either constructor is null, or if
+ *     the super constructor lacks a prototype.
  */
 exports.inherits = function(ctor, superCtor) {
+
+  if (isNullOrUndefined(ctor))
+    throw new TypeError('The constructor to `inherits` must not be null.');
+  if (isNullOrUndefined(superCtor))
+    throw new TypeError('The super constructor to `inherits` must not be null.');
+  if (isNullOrUndefined(superCtor.prototype))
+    throw new TypeError('The super constructor must have a prototype.');
+
   ctor.super_ = superCtor;
   ctor.prototype = Object.create(superCtor.prototype, {
     constructor: {

--- a/lib/util.js
+++ b/lib/util.js
@@ -621,11 +621,11 @@ exports.log = function() {
  */
 exports.inherits = function(ctor, superCtor) {
 
-  if (isNullOrUndefined(ctor))
+  if (ctor === undefined || ctor === null)
     throw new TypeError('The constructor to `inherits` must not be null.');
-  if (isNullOrUndefined(superCtor))
+  if (superCtor === undefined || superCtor === null)
     throw new TypeError('The super constructor to `inherits` must not be null.');
-  if (isUndefined(superCtor.prototype))
+  if (superCtor.prototype === undefined)
     throw new TypeError('The super constructor must have a prototype.');
 
   ctor.super_ = superCtor;

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -78,3 +78,10 @@ assert.deepEqual(util._extend({a:1}, true),       {a:1});
 assert.deepEqual(util._extend({a:1}, false),      {a:1});
 assert.deepEqual(util._extend({a:1}, {b:2}),      {a:1, b:2});
 assert.deepEqual(util._extend({a:1, b:2}, {b:3}), {a:1, b:3});
+
+// inherits
+var ctor = function() {};
+assert.throws(function() { util.inherits(ctor, {}) }, TypeError);
+assert.throws(function() { util.inherits(ctor, null) }, TypeError);
+assert.throws(function() { util.inherits(null, ctor) }, TypeError);
+assert.doesNotThrow(function() { util.inherits(ctor, ctor) }, TypeError);


### PR DESCRIPTION
Previously, passing an undefined or invalid constructor into inherits failed with an error related to the implementation of the function -- one that may not be immediately obvious to a consumer. I think that it is better say exactly what's wrong!