### PR TITLE
doc: clarify real name requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,11 @@ $ git checkout -b my-feature-branch -t origin/v1.x
 
 ### Step 3: Commit
 
-Make sure git knows your name and email address:
+Make sure git knows your real name and email address:
 
 ```text
-$ git config --global user.name "J. Random User"
-$ git config --global user.email "j.random.user@example.com"
+$ git config --global user.name "Jon Doe"
+$ git config --global user.email "jon.doe@example.com"
 ```
 
 Writing good commit logs is important.  A commit log should describe what


### PR DESCRIPTION
This should hopefully make it more clear that git's `user.name` should be set to the real name before committing a pull request. I'm open to suggestions of witty placeholder names ;)

related: #1246
cc: @MayhemYDG