### PR TITLE
node-gyp: allow node.exe/iojs.exe to be renamed

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -29,6 +29,9 @@
         },
       }],
       [ 'OS=="win"', {
+        'sources': [
+          'src/win_delay_load_hook.c',
+        ],
         'libraries': [
           '-lkernel32.lib',
           '-luser32.lib',
@@ -47,6 +50,15 @@
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'
         'msvs_disabled_warnings': [ 4251 ],
+        # Set up delay-loading for node.exe/iojs.exe so the loadable module
+        # will still be able to find it's imports if the binary is renamed.
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
+            # Don't print a linker warning when no imports from either .exe are used.
+            'AdditionalOptions': [ '/ignore:4199' ],
+          }
+        },
       }, {
         # OS!="win"
         'defines': [ '_LARGEFILE_SOURCE', '_FILE_OFFSET_BITS=64' ],

--- a/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c
+++ b/deps/npm/node_modules/node-gyp/src/win_delay_load_hook.c
@@ -1,0 +1,32 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ */
+
+#ifdef _MSC_VER
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+      _stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+
+  HMODULE m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+
+#endif


### PR DESCRIPTION
On Windows, when node or io.js attempts to dynamically load a compiled
addon, the compiled addon tries to load node.exe or iojs.exe again -
depending on which import library the module used when it was linked.
This makes it impossible to rename node.exe or iojs.exe, because when
that happens the module can't find its dependencies.

With this patch, a delay-load hook is added to all modules that are
compiled with node-gyp. The delay-load hook ensures that whenever a
module tries to load imports from node.exe/iojs.exe, it'll just refer
back to the process image, thus making it possible to rename the
iojs/node binary.

Bug: (amongst others) https://github.com/iojs/io.js/issues/751
Upstream PR: https://github.com/TooTallNate/node-gyp/pull/599

R=@bnoordhuis
R=@rvagg
R=@iojs/platform-windows