### PR TITLE
src: fix minor memleak in preload-modules

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2761,6 +2761,10 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process,
                       "_preload_modules",
                       array);
+
+    delete[] preload_modules;
+    preload_modules = nullptr;
+    preload_module_count = 0;
   }
 
   // --no-deprecation


### PR DESCRIPTION
Free the preload_modules array once we are done with it.