### PR TITLE
win,node-gyp: make delay-load hook optional

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -1,7 +1,9 @@
 {
   'target_defaults': {
     'type': 'loadable_module',
+    'win_delay_load_hook': 'false',
     'product_prefix': '',
+
     'include_dirs': [
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',
@@ -13,10 +15,33 @@
         'product_extension': 'node',
         'defines': [ 'BUILDING_NODE_EXTENSION' ],
       }],
+
       ['_type=="static_library"', {
         # set to `1` to *disable* the -T thin archive 'ld' flag.
         # older linkers don't support this flag.
         'standalone_static_library': '<(standalone_static_library)'
+      }],
+
+      ['_win_delay_load_hook=="true"', {
+        # If the has the 'win_delay_load_hook' option set to 'true', link a
+        # delay-load hook into the DLL. That hook ensures that the addon
+        # will work regardless of whether the node/iojs binary is named
+        # node.exe, iojs.exe, or something else.
+        'conditions': [
+          [ 'OS=="win"', {
+            'sources': [
+              'src/win_delay_load_hook.c',
+            ],
+            'msvs_settings': {
+              'VCLinkerTool': {
+                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
+                # Don't print a linker warning when no imports from either .exe
+                # are used.
+                'AdditionalOptions': [ '/ignore:4199' ],
+              },
+            },
+          }],
+        ],
       }],
     ],
 
@@ -29,9 +54,6 @@
         },
       }],
       [ 'OS=="win"', {
-        'sources': [
-          'src/win_delay_load_hook.c',
-        ],
         'libraries': [
           '-lkernel32.lib',
           '-luser32.lib',
@@ -50,15 +72,6 @@
         # warning C4251: 'node::ObjectWrap::handle_' : class 'v8::Persistent<T>'
         # needs to have dll-interface to be used by clients of class 'node::ObjectWrap'
         'msvs_disabled_warnings': [ 4251 ],
-        # Set up delay-loading for node.exe/iojs.exe so the loadable module
-        # will still be able to find it's imports if the binary is renamed.
-        'msvs_settings': {
-          'VCLinkerTool': {
-            'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
-            # Don't print a linker warning when no imports from either .exe are used.
-            'AdditionalOptions': [ '/ignore:4199' ],
-          }
-        },
       }, {
         # OS!="win"
         'defines': [ '_LARGEFILE_SOURCE', '_FILE_OFFSET_BITS=64' ],


### PR DESCRIPTION
The delay-load hook that was supposed to make compiled addons work on
Windows regardless of the iojs.exe/node.exe filename causes issues with
a small amount of compiled addons.

It seems a bit irresponsible to land it as part of a patch release.

Therefore this patch makes it an opt-in feature. An addon may set the
'win_delay_load_hook' option to 'true' in its binding.gyp to enable this
feature.

Example:

```js
{
  'targets': [
    {
      'target_name': 'ernie',
      'win_delay_load_hook': 'true',
      ...
```

R=@rvagg (FYI as the release Meister)
R=@am11 (could you test this with node-sass?)
R=@bnoordhuis, @TooTallNate 