### PR TITLE
timers: cleanup interval handling

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -85,6 +85,7 @@ function listOnTimeout() {
         if (domain)
           domain.enter();
         threw = true;
+        first._called = true;
         first._onTimeout();
         if (domain)
           domain.exit();
@@ -293,6 +294,7 @@ exports.clearInterval = function(timer) {
 
 
 const Timeout = function(after) {
+  this._called = false;
   this._idleTimeout = after;
   this._idlePrev = this;
   this._idleNext = this;
@@ -310,6 +312,10 @@ Timeout.prototype.unref = function() {
     var delay = this._idleStart + this._idleTimeout - now;
     if (delay < 0) delay = 0;
     exports.unenroll(this);
+
+    // Prevent running cb again when unref() is called during the same cb
+    if (this._called && !this._repeat) return;
+
     this._handle = new Timer();
     this._handle[kOnTimeout] = this._onTimeout;
     this._handle.start(delay, 0);
@@ -492,6 +498,7 @@ function unrefTimeout() {
       if (domain) domain.enter();
       threw = true;
       debug('unreftimer firing timeout');
+      first._called = true;
       first._onTimeout();
       threw = false;
       if (domain)

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -272,8 +272,6 @@ exports.setInterval = function(callback, repeat) {
 
   function wrapper() {
     timer._repeat.call(this);
-    // If callback called clearInterval().
-    if (timer._repeat === null) return;
     // If timer is unref'd (or was - it's permanently removed from the list.)
     if (this._handle) {
       this._handle.start(repeat, 0);
@@ -287,7 +285,7 @@ exports.setInterval = function(callback, repeat) {
 
 exports.clearInterval = function(timer) {
   if (timer && timer._repeat) {
-    timer._repeat = false;
+    timer._repeat = null;
     clearTimeout(timer);
   }
 };
@@ -300,7 +298,7 @@ const Timeout = function(after) {
   this._idleNext = this;
   this._idleStart = null;
   this._onTimeout = null;
-  this._repeat = false;
+  this._repeat = null;
 };
 
 Timeout.prototype.unref = function() {

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -5,6 +5,7 @@ var interval_fired = false,
     timeout_fired = false,
     unref_interval = false,
     unref_timer = false,
+    unref_callbacks = 0,
     interval, check_unref, checks = 0;
 
 var LONG_TIME = 10 * 1000;
@@ -34,6 +35,16 @@ check_unref = setInterval(function() {
   checks += 1;
 }, 100);
 
+setTimeout(function() {
+  unref_callbacks++;
+  this.unref();
+}, SHORT_TIME);
+
+// Should not timeout the test
+setInterval(function() {
+  this.unref();
+}, SHORT_TIME);
+
 // Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
 (function() {
   var t = setInterval(function() {}, 1);
@@ -46,4 +57,5 @@ process.on('exit', function() {
   assert.strictEqual(timeout_fired, false, 'Timeout should not fire');
   assert.strictEqual(unref_timer, true, 'An unrefd timeout should still fire');
   assert.strictEqual(unref_interval, true, 'An unrefd interval should still fire');
+  assert.strictEqual(unref_callbacks, 1, 'Callback should only run once');
 });


### PR DESCRIPTION
Uses `null` as the false-y value for `_repeat` as like other properties.


Removes un-reachable statement in setInterval’s `wrapper()`.

The path that clearing an interval takes is this:

- https://github.com/iojs/io.js/blob/v1.x/lib/timers.js#L291
- https://github.com/iojs/io.js/blob/v1.x/lib/timers.js#L225
- https://github.com/iojs/io.js/blob/v1.x/lib/timers.js#L333
  - https://github.com/iojs/io.js/blob/v1.x/lib/timers.js#L73
  - (or)
  - https://github.com/iojs/io.js/blob/v1.x/lib/timers.js#L494

As such, it will never be called. If someone were to manually set it in the callback, `timer._repeat.call(this);` would throw anyways.

R=@trevnorris / @bnoordhuis / @silverwind