### PR TITLE
doc: decouple sidebar scrolling

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -356,13 +356,22 @@ span.type {
   overflow-y: scroll;
 }
 
+#column2.interior:after {
+  content: '';
+  position: fixed;
+  bottom: 0;
+  width: 234px;
+  height: 5em;
+  background: linear-gradient(rgba(242,245,240, 0), rgba(242,245,240, 1));
+}
+
 #column2 ul {
   list-style: none;
   margin-left: 0em;
   margin-top: 1.25em;
   background: #f2f5f0;
   margin-bottom: 0;
-  padding-bottom: 2.5em;
+  padding-bottom: 5em;
 }
 
 #column2 ul li {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -363,6 +363,7 @@ span.type {
   width: 234px;
   height: 5em;
   background: linear-gradient(rgba(242,245,240, 0), rgba(242,245,240, 1));
+  pointer-events: none;
 }
 
 #column2 ul {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -360,6 +360,7 @@ span.type {
   content: '';
   position: fixed;
   bottom: 0;
+  left: 0;
   width: 234px;
   height: 5em;
   background: linear-gradient(rgba(242,245,240, 0), rgba(242,245,240, 1));

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -372,7 +372,7 @@ span.type {
   margin-top: 1.25em;
   background: #f2f5f0;
   margin-bottom: 0;
-  padding-bottom: 5em;
+  padding-bottom: 4em;
 }
 
 #column2 ul li {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -351,7 +351,9 @@ span.type {
 
 #column2.interior {
   width: 234px;
-  float: left;
+  position: fixed;
+  height: 100%;
+  overflow-y: scroll;
 }
 
 #column2 ul {


### PR DESCRIPTION
Small usability change for the doc website here.

This lets the navigation sidebar have its own scrollable area, so it always stays on screen, making it easier to navigate from section to section, especially when the page itself is scrolled off by many screens, which would otherwise require the user to scroll to the far top to navigate to another section.

Should work in IE7 and above (The limiting factor being `position:fixed`).

cc: @chrisdickinson 