### PR TITLE
test: reduce sequential/test-fs-watch flakiness

### DIFF
--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -56,7 +56,7 @@ assert.doesNotThrow(
 
 setTimeout(function() {
   fs.writeFileSync(filepathOne, 'world');
-}, 10);
+}, 20);
 
 
 process.chdir(testDir);
@@ -79,7 +79,7 @@ assert.doesNotThrow(
 
 setTimeout(function() {
   fs.writeFileSync(filepathTwoAbs, 'pardner');
-}, 10);
+}, 20);
 
 try { fs.unlinkSync(filepathThree); } catch (e) {}
 try { fs.mkdirSync(testsubdir, 0700); } catch (e) {}
@@ -103,7 +103,7 @@ assert.doesNotThrow(
 setTimeout(function() {
   var fd = fs.openSync(filepathThree, 'w');
   fs.closeSync(fd);
-}, 10);
+}, 20);
 
 // https://github.com/joyent/node/issues/2293 - non-persistent watcher should
 // not block the event loop


### PR DESCRIPTION
It appears that `fs.watch` is sometimes unable to produce watcher events on OS X in the current 10ms timeframe, leading to the test completely timing out. My tests show that 15ms seems to eliminate most of these failures, but I opted to go for 20ms to be on the safe side.

This is probably hardware dependent, and my tests were done on a 2013 MBA. CI was affected too sometimes.