### PR TITLE
streams: use strict on _stream_wrap

### DIFF
--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const util = require('util');
 const Socket = require('net').Socket;
 const JSStream = process.binding('js_stream').JSStream;


### PR DESCRIPTION
A Mostly Harmless™ change to enable 'use strict' mode in _stream_wrap,
bringing it in line with all the other modules.