### PR TITLE
doc: fix spelling error in feature flags

### DIFF
--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -167,7 +167,7 @@ DEFINE_BOOL(use_strict, false, "enforce strict mode")
 
 DEFINE_BOOL(es_staging, false, "enable all completed harmony features")
 DEFINE_BOOL(harmony, false, "enable all completed harmony features")
-DEFINE_BOOL(harmony_shipping, true, "enable all shipped harmony fetaures")
+DEFINE_BOOL(harmony_shipping, true, "enable all shipped harmony features")
 DEFINE_IMPLICATION(harmony, es_staging)
 DEFINE_IMPLICATION(es_staging, harmony)
 

--- a/doc/iojs.1
+++ b/doc/iojs.1
@@ -81,7 +81,7 @@ If set to 1 then colors will not be used in the REPL.
         type: bool  default: false
   --harmony (enable all completed harmony features)
         type: bool  default: false
-  --harmony_shipping (enable all shipped harmony fetaures)
+  --harmony_shipping (enable all shipped harmony features)
         type: bool  default: true
   --harmony_modules (enable "harmony modules (implies block scoping)" (in progress))
         type: bool  default: false


### PR DESCRIPTION
Harmony Shipping flag had "fetaures" instead of "features". 

```
--harmony_shipping (enable all shipped harmony fetaures)
```

So long cheese pun.