### PR TITLE
test: fix race in parallel/test-vm-debug-context

### DIFF
--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -58,11 +58,13 @@ var proc = spawn(process.execPath, [script]);
 var data = [];
 proc.stdout.on('data', assert.fail);
 proc.stderr.on('data', data.push.bind(data));
+proc.stderr.once('end', common.mustCall(function() {
+  var haystack = Buffer.concat(data).toString('utf8');
+  assert(/SyntaxError: Unexpected token \*/.test(haystack));
+}));
 proc.once('exit', common.mustCall(function(exitCode, signalCode) {
   assert.equal(exitCode, 1);
   assert.equal(signalCode, null);
-  var haystack = Buffer.concat(data).toString('utf8');
-  assert(/SyntaxError: Unexpected token \*/.test(haystack));
 }));
 
 var proc = spawn(process.execPath, [script, 'handle-fatal-exception']);


### PR DESCRIPTION
Fix a race condition in parallel/test-vm-debug-context where the 'exit'
event for the child process is emitted before the first and only 'data'
event for the child process's stderr stream.

I considered deferring the 'exit' event in lib/child_process.js until
all stdio streams have been closed but I realized that's not going to
work when the child process spins off grandchildren that keep the stdio
file descriptors alive.

Fixes: https://github.com/iojs/io.js/issues/1291

R=@brendanashworth

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/402/