### PR TITLE
doc: fix util.isObject documentation

### DIFF
--- a/doc/api/util.markdown
+++ b/doc/api/util.markdown
@@ -328,7 +328,8 @@ Returns `true` if the given "object" is `undefined`. `false` otherwise.
 
 ## util.isObject(object)
 
-Returns `true` if the given "object" is strictly an `Object`. `false` otherwise.
+Returns `true` if the given "object" is strictly an `Object` __and__ not a
+`Function`. `false` otherwise.
 
     var util = require('util');
 
@@ -338,6 +339,8 @@ Returns `true` if the given "object" is strictly an `Object`. `false` otherwise.
       // false
     util.isObject({})
       // true
+    util.isObject(function(){})
+      // false
 
 
 ## util.isFunction(object)


### PR DESCRIPTION
Puts #743 to rest for good.

The change to fix the functionality would be too radical.

Replaces #822 (arguments for this are also contained in that thread).

These functions should probably be deprecated later. Maybe post-2.0.0?