### PR TITLE
build: Pass BSDmakefile args to gmake

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,2 +1,8 @@
-all:
-	@echo "I need GNU make. Please run \`gmake\` instead."
+all: .DEFAULT
+.DEFAULT:
+	@which gmake > /dev/null 2>&1 ||\
+		(echo "GMake is required for io.js to build.\
+			Install and try again" && exit 1)
+	@gmake ${.MAKEFLAGS} ${.TARGETS}
+
+.PHONY: test


### PR DESCRIPTION
Minor convenience for platforms that doesn't have gmake installed but prefer the habit of writing make instead of gmake.

test needs to live in .PHONY to get passed on to gmake.

/R=@indutny?