### PR TITLE
correct text

### DIFF
--- a/doc/api/cluster.markdown
+++ b/doc/api/cluster.markdown
@@ -24,7 +24,7 @@ all share server ports.
       });
     } else {
       // Workers can share any TCP connection
-      // In this case its a HTTP server
+      // In this case it is an HTTP server
       http.createServer(function(req, res) {
         res.writeHead(200);
         res.end("hello world\n");


### PR DESCRIPTION
its -> it's -> it is
a HTTP -> we read 'H' as 'eich' -> an HTTP