### PR TITLE
dgram: call send callback asynchronously

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -336,7 +336,10 @@ function afterSend(err) {
   if (err) {
     err = exceptionWithHostPort(err, 'send', this.address, this.port);
   }
-  this.callback(err, this.length);
+  var self = this;
+  setImmediate(function() {
+    self.callback(err, self.length);
+  });
 }
 
 

--- a/test/parallel/test-dgram-send-callback-recursive.js
+++ b/test/parallel/test-dgram-send-callback-recursive.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const dgram = require('dgram');
+const client = dgram.createSocket('udp4');
+const chunk = 'abc';
+var recursiveCount = 0;
+var received = 0;
+const limit = 10;
+
+function onsend() {
+  if (recursiveCount > limit) {
+    throw new Error('infinite loop detected');
+  }
+  if (received < limit) {
+    client.send(
+      chunk, 0, chunk.length, common.PORT, common.localhostIPv4, onsend);
+  }
+  recursiveCount++;
+}
+
+client.on('listening', function() {
+  onsend();
+});
+
+client.on('message', function(buf, info) {
+  received++;
+  if (received === limit) {
+    client.close();
+  }
+});
+
+client.on('close', common.mustCall(function() {
+  assert.equal(received, limit);
+}));
+
+client.bind(common.PORT);


### PR DESCRIPTION
According to this issue https://github.com/iojs/io.js/pull/486, every callbacks should be called asynchronously, But `dgram.send` callback is not called asynchronously.

We can not run full benchmark test.  `benchmark/net/dgram.js` uses send callback recursively.
But send callback is not asynchronous, the recursive callback goes __infinite loop__.

If this fix is accepted, we could run full benchmark test on every release.

I think libuv changes the uv_udp_send API on this commit https://github.com/libuv/libuv/commit/41891222bca4e985bef45515fe131fbdbec3f969. 

So I just fixed callback asynchronously using `setImmediate`.