### PR TITLE
WIP src: don't check closing handles on beforeExit

### DIFF
--- a/test/parallel/test-beforeexit-event-hang.js
+++ b/test/parallel/test-beforeexit-event-hang.js
@@ -1,0 +1,8 @@
+var assert = require('assert');
+var common = require('../common');
+var i = 0;
+
+process.on('beforeExit', function() {
+  assert.ok(++i <= 1);
+  setTimeout(function() { }, 100).unref();
+});

--- a/test/parallel/test-beforeexit-event.js
+++ b/test/parallel/test-beforeexit-event.js
@@ -37,6 +37,6 @@ function tryListen() {
 }
 
 process.on('exit', function() {
-  assert.equal(4, deaths);
+  assert.equal(3, deaths);
   assert.equal(3, revivals);
 });


### PR DESCRIPTION
uv_loop_alive() returns true if there are closing handles. This causes
an issue running the beforeExit event and a timer has been unref'd:

    process.on('beforeExit', function() {
      setTimeout(function() { }, 100).unref();
    });

The event loop also shouldn't run one additional time or else the timer
may execute an additional time.

This is a WIP commit, and mainly opened to raise discussion around the problem at hand.

R=@bnoordhuis 