### PR TITLE
v8: back-port openbsd build fix

### DIFF
--- a/deps/v8/src/base/macros.h
+++ b/deps/v8/src/base/macros.h
@@ -333,7 +333,7 @@ inline void USE(T) { }
 # define V8_INTPTR_C(x)   (x ## LL)
 # define V8_PTR_PREFIX    "I64"
 #elif V8_HOST_ARCH_64_BIT
-# if V8_OS_MACOSX
+# if V8_OS_MACOSX || V8_OS_OPENBSD
 #  define V8_UINT64_C(x)   (x ## ULL)
 #  define V8_INT64_C(x)    (x ## LL)
 # else


### PR DESCRIPTION
Cherry-pick https://codereview.chromium.org/856553002 from upstream.

Refs: https://github.com/iojs/io.js/pull/1312

R=@indutny?  /cc @kaspars @qbit