### PR TITLE
src: wrap MIN definition in infdef

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -39,7 +39,9 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#ifndef MIN
+# define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
 
 #define TYPE_ERROR(msg) env->ThrowTypeError(msg)
 


### PR DESCRIPTION
Some platforms already define this; avoid redefining if that's the case. Found on OpenBSD 5.6.

/R=@bnoordhuis 