### PR TITLE
build: Remove building against a shared V8

### DIFF
--- a/configure
+++ b/configure
@@ -148,26 +148,6 @@ parser.add_option('--shared-openssl-libpath',
     dest='shared_openssl_libpath',
     help='a directory to search for the shared OpenSSL DLLs')
 
-parser.add_option('--shared-v8',
-    action='store_true',
-    dest='shared_v8',
-    help='link to a shared V8 DLL instead of static linking')
-
-parser.add_option('--shared-v8-includes',
-    action='store',
-    dest='shared_v8_includes',
-    help='directory containing V8 header files')
-
-parser.add_option('--shared-v8-libname',
-    action='store',
-    dest='shared_v8_libname',
-    help='alternative lib name to link to (default: \'v8\')')
-
-parser.add_option('--shared-v8-libpath',
-    action='store',
-    dest='shared_v8_libpath',
-    help='a directory to search for the shared V8 DLL')
-
 parser.add_option('--shared-zlib',
     action='store_true',
     dest='shared_zlib',
@@ -656,23 +636,11 @@ def configure_libuv(o):
 
 
 def configure_v8(o):
-  o['variables']['node_shared_v8'] = b(options.shared_v8)
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_use_snapshot'] = b(options.with_snapshot)
-
-  # assume shared_v8 if one of these is set?
-  if options.shared_v8_libpath:
-    o['libraries'] += ['-L%s' % options.shared_v8_libpath]
-  if options.shared_v8_libname:
-    o['libraries'] += ['-l%s' % options.shared_v8_libname]
-  elif options.shared_v8:
-    o['libraries'] += ['-lv8', '-lv8_platform']
-  if options.shared_v8_includes:
-    o['include_dirs'] += [options.shared_v8_includes]
-
 
 def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)

--- a/doc/api/process.markdown
+++ b/doc/api/process.markdown
@@ -594,7 +594,6 @@ An example of the possible output looks like:
          node_shared_cares: 'false',
          node_shared_http_parser: 'false',
          node_shared_libuv: 'false',
-         node_shared_v8: 'false',
          node_shared_zlib: 'false',
          node_use_dtrace: 'false',
          node_use_openssl: 'true',

--- a/node.gyp
+++ b/node.gyp
@@ -81,16 +81,16 @@
       'dependencies': [
         'node_js2c#host',
         'deps/cares/cares.gyp:cares',
-        'deps/v8/tools/gyp/v8.gyp:v8'
+        'deps/v8/tools/gyp/v8.gyp:v8',
+        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
       ],
 
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
-        'deps/v8' # v8_platform
-
-        '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+        '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
+        'deps/v8' # include/v8_platform.h
       ],
 
       'sources': [
@@ -608,7 +608,8 @@
       'type': 'executable',
       'dependencies': [ 
         'deps/gtest/gtest.gyp:gtest',
-        'deps/v8/tools/gyp/v8.gyp:v8'
+        'deps/v8/tools/gyp/v8.gyp:v8',
+        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
       ],
       'include_dirs': [
         'src',

--- a/node.gyp
+++ b/node.gyp
@@ -6,7 +6,6 @@
     'node_use_etw%': 'false',
     'node_use_perfctr%': 'false',
     'node_has_winsdk%': 'false',
-    'node_shared_v8%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
     'node_shared_libuv%': 'false',
@@ -81,13 +80,16 @@
 
       'dependencies': [
         'node_js2c#host',
-        'deps/cares/cares.gyp:cares'
+        'deps/cares/cares.gyp:cares',
+        'deps/v8/tools/gyp/v8.gyp:v8'
       ],
 
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
+        'deps/v8' # v8_platform
+
         '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
       ],
 
@@ -163,6 +165,8 @@
         'src/util-inl.h',
         'src/util.cc',
         'deps/http_parser/http_parser.h',
+        'deps/v8/include/v8.h',
+        'deps/v8/include/v8-debug.h',
         '<(SHARED_INTERMEDIATE_DIR)/node_natives.h',
         # javascript files to make for an even more pleasant IDE experience
         '<@(library_files)',
@@ -306,19 +310,6 @@
             ],
           },
         }],
-        [ 'node_shared_v8=="false"', {
-          'sources': [
-            'deps/v8/include/v8.h',
-            'deps/v8/include/v8-debug.h',
-          ],
-          'dependencies': [
-            'deps/v8/tools/gyp/v8.gyp:v8',
-            'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
-          ],
-          # libplatform/libplatform.h includes include/v8platform.h
-          'include_dirs': [ 'deps/v8' ],
-        }],
-
         [ 'node_shared_zlib=="false"', {
           'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
         }],
@@ -381,16 +372,12 @@
           ],
         }],
         [ 'OS=="freebsd" or OS=="linux"', {
-          'ldflags': [ '-Wl,-z,noexecstack' ],
+          'ldflags': [ '-Wl,-z,noexecstack',
+                       '-Wl,--whole-archive <(V8_BASE)',
+                       '-Wl,--no-whole-archive' ]
         }],
         [ 'OS=="sunos"', {
           'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
-        }],
-        [
-          'OS in "linux freebsd" and node_shared_v8=="false"', {
-            'ldflags': [
-              '-Wl,--whole-archive <(V8_BASE) -Wl,--no-whole-archive',
-            ],
         }],
       ],
       'msvs_settings': {
@@ -619,14 +606,13 @@
     {
       'target_name': 'cctest',
       'type': 'executable',
-      'dependencies': [ 'deps/gtest/gtest.gyp:gtest' ],
-      'conditions': [
-        [ 'node_shared_v8=="false"', {
-          'dependencies': [ 'deps/v8/tools/gyp/v8.gyp:v8' ],
-        }],
+      'dependencies': [ 
+        'deps/gtest/gtest.gyp:gtest',
+        'deps/v8/tools/gyp/v8.gyp:v8'
       ],
       'include_dirs': [
         'src',
+        'deps/v8/include'
       ],
       'defines': [
         # gtest's ASSERT macros conflict with our own.

--- a/tools/install.py
+++ b/tools/install.py
@@ -168,6 +168,7 @@ def files(action):
   ], 'include/node/')
 
   subdir_files('deps/cares/include', 'include/node/', action)
+  subdir_files('deps/v8/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_libuv'):
     subdir_files('deps/uv/include', 'include/node/', action)
@@ -176,8 +177,6 @@ def files(action):
     action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
     subdir_files('deps/openssl/include/openssl', 'include/node/openssl/', action)
 
-  if 'false' == variables.get('node_shared_v8'):
-    subdir_files('deps/v8/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_zlib'):
     action([


### PR DESCRIPTION
This action is to encourage packagers to not build against a shared V8 library since even minor bumps of V8 can create issues. For people that know what they're doing -- revert this commit.

/R=@bnoordhuis, ?