### PR TITLE
build: avoid passing private flags from pmake

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,8 +1,11 @@
+# pmake might add -J (private)
+FLAGS=${.MAKEFLAGS:C/\-J ([0-9]+,?)+//W}
+
 all: .DEFAULT
 .DEFAULT:
 	@which gmake > /dev/null 2>&1 ||\
 		(echo "GMake is required for io.js to build.\
 			Install and try again" && exit 1)
-	@gmake ${.MAKEFLAGS} ${.TARGETS}
+	@gmake ${.FLAGS} ${.TARGETS}
 
 .PHONY: test


### PR DESCRIPTION
pmake introduces private flags (`-J`) when passing certain arguments to it (such as `-j`). Filter these out before passing to gmake.

/R=@iojs/platform-freebsd