### PR TITLE
Support for building io.js as a static library

### DIFF
--- a/configure
+++ b/configure
@@ -315,9 +315,9 @@ parser.add_option('--xcode',
     dest='use_xcode',
     help='generate build files for use with xcode')
 
-parser.add_option('--target-static',
+parser.add_option('--enable-static',
     action='store_true',
-    dest='target_static',
+    dest='enable_static',
     help='build as static library')
 
 (options, args) = parser.parse_args()
@@ -614,7 +614,7 @@ def configure_node(o):
   if options.v8_options:
     o['variables']['node_v8_options'] = options.v8_options.replace('"', '\\"')
 
-  if options.target_static:
+  if options.enable_static:
     o['variables']['node_target_type'] = 'static_library'
 
 

--- a/configure
+++ b/configure
@@ -315,6 +315,11 @@ parser.add_option('--xcode',
     dest='use_xcode',
     help='generate build files for use with xcode')
 
+parser.add_option('--target-static',
+    action='store_true',
+    dest='target_static',
+    help='build as static library')
+
 (options, args) = parser.parse_args()
 
 # set up auto-download list
@@ -608,6 +613,9 @@ def configure_node(o):
 
   if options.v8_options:
     o['variables']['node_v8_options'] = options.v8_options.replace('"', '\\"')
+
+  if options.target_static:
+    o['variables']['node_target_type'] = 'static_library'
 
 
 def configure_libz(o):


### PR DESCRIPTION
One static library could not be bundled into another, that's why
it's necessary to skip `-force_load` and `--whole-archive` linker
options to build io.js itself as a static library.

`node_target_type` variable has been added to node.gyp, along
with `--target-static` option in configure script.

https://github.com/iojs/io.js/issues/686 for more information.