### PR TITLE
http: basic cleanup / mini-opt writeHead/server

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -151,38 +151,32 @@ ServerResponse.prototype._implicitHeader = function() {
   this.writeHead(this.statusCode);
 };
 
-ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
-  var headers;
-
-  if (typeof reason === 'string') {
-    // writeHead(statusCode, reasonPhrase[, headers])
-    this.statusMessage = reason;
+ServerResponse.prototype.writeHead = function(statusCode, statusMsg, headers) {
+  if (typeof statusMsg === 'string') {
+    // writeHead(statusCode, statusMessage[, headers])
+    this.statusMessage = statusMsg;
   } else {
     // writeHead(statusCode[, headers])
     this.statusMessage =
         this.statusMessage || STATUS_CODES[statusCode] || 'unknown';
-    obj = reason;
+    headers = statusMsg;
   }
   this.statusCode = statusCode;
 
   if (this._headers) {
     // Slow-case: when progressive API and header fields are passed.
-    if (obj) {
-      var keys = Object.keys(obj);
+    if (headers) {
+      var keys = Object.keys(headers);
       for (var i = 0; i < keys.length; i++) {
-        var k = keys[i];
-        if (k) this.setHeader(k, obj[k]);
+        var key = keys[i];
+        if (key) this.setHeader(key, headers[key]);
       }
     }
     // only progressive api is used
     headers = this._renderHeaders();
-  } else {
-    // only writeHead() called
-    headers = obj;
   }
 
-  var statusLine = 'HTTP/1.1 ' + statusCode.toString() + ' ' +
-                   this.statusMessage + CRLF;
+  var statusLine = 'HTTP/1.1 ' + statusCode + ' ' + this.statusMessage + CRLF;
 
   if (statusCode === 204 || statusCode === 304 ||
       (100 <= statusCode && statusCode <= 199)) {
@@ -208,9 +202,7 @@ ServerResponse.prototype.writeHead = function(statusCode, reason, obj) {
   this._storeHeader(statusLine, headers);
 };
 
-ServerResponse.prototype.writeHeader = function() {
-  this.writeHead.apply(this, arguments);
-};
+ServerResponse.prototype.writeHeader = ServerResponse.prototype.writeHead;
 
 
 function Server(requestListener) {
@@ -281,7 +273,7 @@ function connectionListener(socket) {
   if (self.timeout)
     socket.setTimeout(self.timeout);
   socket.on('timeout', function() {
-    var req = socket.parser && socket.parser.incoming;
+    var req = parser && parser.incoming;
     var reqTimeout = req && !req.complete && req.emit('timeout', socket);
     var res = socket._httpMessage;
     var resTimeout = res && res.emit('timeout', socket);
@@ -354,12 +346,11 @@ function connectionListener(socket) {
     if (socket._paused) {
       // onIncoming paused the socket, we should pause the parser as well
       debug('pause parser');
-      socket.parser.pause();
+      parser.pause();
     }
   }
 
   function socketOnEnd() {
-    var socket = this;
     var ret = parser.finish();
 
     if (ret instanceof Error) {
@@ -390,7 +381,7 @@ function connectionListener(socket) {
     // If we previously paused, then start reading again.
     if (socket._paused) {
       socket._paused = false;
-      socket.parser.resume();
+      parser.resume();
       socket.resume();
     }
   }


### PR DESCRIPTION
This contains a few changes, which include:
- renaming of argument to function (harmless) to match docs and improve
  readability
- removing a useless variable and inlining it with the better
  alternative (headers)
- change .toString() to JS string coersion, which is faster
- alias writeHeader() instead of using .apply()
- remove unnecessary key lookups
- remove unnecessary redeclaration of variable

Sorry, this is a redo of #1293 - I tried to squash / rebase onto `HEAD` / push `--force` and ended up screwing up the history irreversibly. CC'ing those who joined in on the discussion: @Fishrock123 @mscdex @monsanto @dominic @benjamingr