### PR TITLE
fix install source path for openssl headers

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -173,8 +173,8 @@ def files(action):
     subdir_files('deps/uv/include', 'include/node/', action)
 
   if 'false' == variables.get('node_shared_openssl'):
-    action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
     subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
+    action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
 
   if 'false' == variables.get('node_shared_v8'):
     subdir_files('deps/v8/include', 'include/node/', action)

--- a/tools/install.py
+++ b/tools/install.py
@@ -174,7 +174,7 @@ def files(action):
 
   if 'false' == variables.get('node_shared_openssl'):
     action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')
-    subdir_files('deps/openssl/include/openssl', 'include/node/openssl/', action)
+    subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
 
   if 'false' == variables.get('node_shared_v8'):
     subdir_files('deps/v8/include', 'include/node/', action)


### PR DESCRIPTION
This part is broken for a very long time. We noticed the problem while using jxcore native interface with embedded openssl. I've also sent a pull request to node.js repo. The problem may affect a native addon using builtin openssl.