### PR TITLE
test: double test timeouts on arm machines

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -729,8 +729,8 @@ FLAGS = {
     'debug'   : ['--enable-slow-asserts', '--debug-code', '--verify-heap'],
     'release' : []}
 TIMEOUT_SCALEFACTOR = {
-    'debug'   : 4,
-    'release' : 1 }
+    'arm'  : { 'debug' : 8, 'release' : 2 },  # The ARM buildbots are slow.
+    'ia32' : { 'debug' : 4, 'release' : 1 } }
 
 
 class Context(object):
@@ -770,7 +770,7 @@ class Context(object):
     return testcase.variant_flags + FLAGS[mode]
 
   def GetTimeout(self, mode):
-    return self.timeout * TIMEOUT_SCALEFACTOR[mode]
+    return self.timeout * TIMEOUT_SCALEFACTOR[ARCH_GUESS or 'ia32'][mode]
 
 def RunTestCases(cases_to_run, progress, tasks):
   progress = PROGRESS_INDICATORS[progress](cases_to_run)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -73,7 +73,7 @@ def GuessOS():
 def GuessArchitecture():
   id = platform.machine()
   id = id.lower()  # Windows 7 capitalizes 'AMD64'.
-  if id.startswith('arm'):
+  if id.startswith('arm') or id == 'aarch64':
     return 'arm'
   elif (not id) or (not re.match('(x|i[3-6])86$', id) is None):
     return 'ia32'


### PR DESCRIPTION
The ARM buildbots are notoriously slow.  Update the test runner to
double the per-test time limit when it's running on one of them.

R=@iojs/build

CI: https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/448/