### PR TITLE
module: restore and warn on require('.') usage with NODE_PATH

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -127,7 +127,7 @@ function tryExtensions(p, exts) {
 
 const noopDeprecateRequireDot = util.deprecate(function() {},
   "warning: require('.') resolved outside the package directory. " +
-  "This functionality will be deprecated soon.");
+  "This functionality is deprecated and will be removed soon.");
 
 
 Module._findPath = function(request, paths) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -205,11 +205,16 @@ Module._resolveLookupPaths = function(request, parent) {
   }
 
   var start = request.substring(0, 2);
-  if (start !== '.' && start !== './' && start !== '..') {
+  if (start !== './' && start !== '..') {
     var paths = modulePaths;
     if (parent) {
       if (!parent.paths) parent.paths = [];
       paths = parent.paths.concat(paths);
+      // For '.', put PWD at the front of the resolve paths
+      // TODO(silverwind): Treat '.' exactly the same as './'
+      if (request === '.') {
+        paths.splice(0, 0, path.resolve(request));
+      }
     }
     return [request, paths];
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -126,8 +126,8 @@ function tryExtensions(p, exts) {
 
 
 const noopDeprecateRequireDot = util.deprecate(function() {},
-  `warning: require('.') did resolve outside the package directory. ` +
-  `This functionality will be deprecated soon.`);
+  "warning: require('.') resolved outside the package directory. " +
+  "This functionality will be deprecated soon.");
 
 
 Module._findPath = function(request, paths) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -125,6 +125,11 @@ function tryExtensions(p, exts) {
 }
 
 
+const noopDeprecateRequireDot = util.deprecate(function() {},
+  `warning: require('.') did resolve outside the package directory. ` +
+  `This functionality will be deprecated soon.`);
+
+
 Module._findPath = function(request, paths) {
   var exts = Object.keys(Module._extensions);
 
@@ -169,9 +174,8 @@ Module._findPath = function(request, paths) {
     }
 
     if (filename) {
-      if (request === '.' && i > 0) {
-        console.error(`(node) warning: require('.') resolved to ${filename}`);
-      }
+      // Warn once if '.' resolved outside the module dir
+      if (request === '.' && i > 0) noopDeprecateRequireDot();
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
@@ -215,11 +219,14 @@ Module._resolveLookupPaths = function(request, parent) {
       paths = parent.paths.concat(paths);
     }
 
-    // For '.', put the module's dir at the front of the resolve paths
-    // TODO(silverwind): Treat '.' exactly the same as './'
+    // Maintain backwards compat with certain broken uses of require('.')
+    // by putting the module's directory in front of the lookup paths.
     if (request === '.') {
-      paths.splice(0, 0, parent && parent.filename ?
-          path.dirname(parent.filename) : path.resolve(request));
+      if (parent && parent.filename) {
+        paths.splice(0, 0, path.dirname(parent.filename));
+      } else {
+        paths.splice(0, 0, path.resolve(request));
+      }
     }
 
     return [request, paths];

--- a/lib/module.js
+++ b/lib/module.js
@@ -169,6 +169,9 @@ Module._findPath = function(request, paths) {
     }
 
     if (filename) {
+      if (request === '.' && i > 0) {
+        console.error(`(node) warning: require('.') resolved to ${filename}`);
+      }
       Module._pathCache[cacheKey] = filename;
       return filename;
     }
@@ -210,12 +213,15 @@ Module._resolveLookupPaths = function(request, parent) {
     if (parent) {
       if (!parent.paths) parent.paths = [];
       paths = parent.paths.concat(paths);
-      // For '.', put PWD at the front of the resolve paths
-      // TODO(silverwind): Treat '.' exactly the same as './'
-      if (request === '.') {
-        paths.splice(0, 0, path.resolve(request));
-      }
     }
+
+    // For '.', put the module's dir at the front of the resolve paths
+    // TODO(silverwind): Treat '.' exactly the same as './'
+    if (request === '.') {
+      paths.splice(0, 0, parent && parent.filename ?
+          path.dirname(parent.filename) : path.resolve(request));
+    }
+
     return [request, paths];
   }
 

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -1,0 +1,15 @@
+var common = require('../common');
+var assert = require('assert');
+
+var a = require(common.fixturesDir + '/module-require/relative/dot.js');
+var b = require(common.fixturesDir + '/module-require/relative/dot-slash.js');
+
+assert.equal(a.value, 42);
+assert.equal(a, b, 'require(".") should resolve like require("./")');
+
+process.env.NODE_PATH = common.fixturesDir + '/module-require/relative';
+module._initPaths();
+
+var c = require('.');
+
+assert.equal(c, 42, 'require(".") should honor NODE_PATH');

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -1,5 +1,6 @@
 var common = require('../common');
 var assert = require('assert');
+var module = require('module');
 
 var a = require(common.fixturesDir + '/module-require/relative/dot.js');
 var b = require(common.fixturesDir + '/module-require/relative/dot-slash.js');
@@ -12,4 +13,4 @@ module._initPaths();
 
 var c = require('.');
 
-assert.equal(c, 42, 'require(".") should honor NODE_PATH');
+assert.equal(c.value, 42, 'require(".") should honor NODE_PATH');

--- a/test/parallel/test-require-extensions-main.js
+++ b/test/parallel/test-require-extensions-main.js
@@ -2,9 +2,3 @@ var common = require('../common');
 var assert = require('assert');
 
 require(common.fixturesDir + '/require-bin/bin/req.js');
-
-var a = require(common.fixturesDir + '/module-require/relative/dot.js');
-var b = require(common.fixturesDir + '/module-require/relative/dot-slash.js');
-
-assert.equal(a.value, 42);
-assert.equal(a, b, 'require(".") should resolve like require("./")');


### PR DESCRIPTION
related: #1356, #1358

`require('.')`, like `require('./')` did not use module search paths, which inself is probably alright, as it is unexpected that `.` would refer to anything outside PWD.

It appears some users (#1356) were relying on unintended (and in my eyes bugged) behaviour when NODE_PATH contains a `index.js`, and surprisingly, `require('.')` *did* resolve to that module (which it probably never should have done).

This patch fixes the case of `require('.')` + `NODE_PATH` by letting `require('.')` look up the search paths. `require('.')` still works as expected when `NODE_PATH` doesn't contain a `index.js`.

If both NODE_PATH and PWD contain `index.js`, PWD is preferred (as it comes first in the array of search paths), which I think is the more sane way to fix that conflict, as it doesn't encourage relying on undefined behaviour.