### PR TITLE
Add a flag for IOJS to distinguish versioning from NodeJS

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_VERSION_H_
 #define SRC_NODE_VERSION_H_
 
+#define IS_IOJS 1
+
 #define NODE_MAJOR_VERSION 1
 #define NODE_MINOR_VERSION 6
 #define NODE_PATCH_VERSION 5


### PR DESCRIPTION
Introduce a new flag rather than overloading existing `NODE_` flags. This will make version checks more clear and robust.