### PR TITLE
linux: fix epoll_pwait() fallback on arm64

### DIFF
--- a/deps/uv/src/unix/linux-core.c
+++ b/deps/uv/src/unix/linux-core.c
@@ -210,7 +210,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
       if (pthread_sigmask(SIG_BLOCK, &sigset, NULL))
         abort();
 
-    if (sigmask != 0 && no_epoll_pwait == 0) {
+    if (no_epoll_wait != 0 || (sigmask != 0 && no_epoll_pwait == 0)) {
       nfds = uv__epoll_pwait(loop->backend_fd,
                              events,
                              ARRAY_SIZE(events),


### PR DESCRIPTION
arm64 doesn't have a epoll_wait() system call but a logic error stopped
libuv from falling back to epoll_pwait().

This bug was introduced in commit libuv/libuv@67bb2b5 ("linux: fix
epoll_pwait() regression with < 2.6.19") which sadly exchanged one
regression for another.

This commit is a back-port of libuv/libuv@1d8332f and should help
get the ARMv8 buildbot in better shape.

Original-PR-URL: https://github.com/libuv/libuv/pull/308

R=@indutny maybe?

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/456/