### PR TITLE
test: increase timeouts on arm

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -180,7 +180,7 @@ exports.spawnPwd = function(options) {
 };
 
 exports.platformTimeout = function(ms) {
-  if (process.platform !== 'arm')
+  if (process.arch !== 'arm')
     return ms;
 
   if (process.config.variables.arm_version === '6')

--- a/test/common.js
+++ b/test/common.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var fs = require('fs');
 var assert = require('assert');
@@ -176,6 +178,34 @@ exports.spawnPwd = function(options) {
     return spawn('cmd.exe', ['/c', 'cd'], options);
   } else {
     return spawn('pwd', [], options);
+  }
+};
+
+const PLATFORM_TIMOUT_FACTORS = {
+  armv6: 6.0,
+  armv7: 2.0
+};
+
+exports.platformTimeout = function (ms) {
+  if (process.arch !== 'arm')
+    return ms;
+
+  let cpuinfo;
+
+  // arm version detection based on v8
+  try {
+    cpuinfo = fs.readFileSync('/proc/cpuinfo').toString();
+  } catch (e) {
+    return ms;
+  }
+
+  if (/\nCPU architecture:\s7\n/.test(cpuinfo)) {
+    return ms * PLATFORM_TIMOUT_FACTORS[/\(v6l\)/.test(cpuinfo) ?
+      'armv6' : 'armv7'];
+  } else if (/\nCPU architecture:\s6\n/.test(cpuinfo)) {
+    return ms * PLATFORM_TIMOUT_FACTORS['armv6'];
+  } else {
+    return ms;
   }
 };
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var path = require('path');
 var fs = require('fs');
 var assert = require('assert');
@@ -181,32 +179,14 @@ exports.spawnPwd = function(options) {
   }
 };
 
-const PLATFORM_TIMOUT_FACTORS = {
-  armv6: 6.0,
-  armv7: 2.0
-};
-
-exports.platformTimeout = function (ms) {
-  if (process.arch !== 'arm')
+exports.platformTimeout = function(ms) {
+  if (process.platform !== 'arm')
     return ms;
 
-  let cpuinfo;
+  if (process.config.variables.arm_version === '6')
+    return 6 * ms;  // ARMv6
 
-  // arm version detection based on v8
-  try {
-    cpuinfo = fs.readFileSync('/proc/cpuinfo').toString();
-  } catch (e) {
-    return ms;
-  }
-
-  if (/\nCPU architecture:\s7\n/.test(cpuinfo)) {
-    return ms * PLATFORM_TIMOUT_FACTORS[/\(v6l\)/.test(cpuinfo) ?
-      'armv6' : 'armv7'];
-  } else if (/\nCPU architecture:\s6\n/.test(cpuinfo)) {
-    return ms * PLATFORM_TIMOUT_FACTORS['armv6'];
-  } else {
-    return ms;
-  }
+  return 2 * ms;  // ARMv7 and up.
 };
 
 var knownGlobals = [setTimeout,

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -128,13 +128,13 @@ if (process.argv[2] === 'child') {
 
   server.listen(common.PORT, '127.0.0.1');
 
-  var timeElasped = 0;
+  var timeElapsed = 0;
   var closeServer = function() {
     console.error('[m] closeServer');
     var startTime = Date.now();
     server.on('close', function() {
       console.error('[m] emit(close)');
-      timeElasped = Date.now() - startTime;
+      timeElapsed = Date.now() - startTime;
     });
 
     console.error('[m] calling server.close');
@@ -149,11 +149,14 @@ if (process.argv[2] === 'child') {
     }, 200);
   };
 
+  var min = 190;
+  var max = common.platformTimeout(1000);
   process.on('exit', function() {
     assert.equal(disconnected, count);
     assert.equal(connected, count);
     assert.ok(closeEmitted);
-    assert.ok(timeElasped >= 190 && timeElasped <= 1000,
-              'timeElasped was not between 190 and 1000 ms');
+    assert.ok(timeElapsed >= min && timeElapsed <= max,
+              `timeElapsed was not between ${min} and ${max} ms:` +
+              `${timeElapsed}`);
   });
 }

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -150,7 +150,7 @@ if (process.argv[2] === 'child') {
   };
 
   var min = 190;
-  var max = common.platformTimeout(1000);
+  var max = common.platformTimeout(1500);
   process.on('exit', function() {
     assert.equal(disconnected, count);
     assert.equal(connected, count);

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -51,7 +51,7 @@ function onNoMoreLines() {
 
 setTimeout(function testTimedOut() {
   assert(false, 'test timed out.');
-}, 6000).unref();
+}, common.platformTimeout(3000)).unref();
 
 process.on('exit', function onExit() {
   // Kill processes in reverse order to avoid timing problems on Windows where

--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -22,7 +22,7 @@ fs.open(emptyFile, 'r', function (error, fd) {
 
   setTimeout(function () {
     assert.equal(readEmit, true);
-  }, 50);
+  }, common.platformTimeout(50));
 });
 
 fs.open(emptyFile, 'r', function (error, fd) {
@@ -43,5 +43,5 @@ fs.open(emptyFile, 'r', function (error, fd) {
 
   setTimeout(function () {
     assert.equal(readEmit, false);
-  }, 50);
+  }, common.platformTimeout(50));
 });

--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -32,7 +32,7 @@ server.listen(common.PORT, function() {
 setTimeout(function() {
   process.removeListener('uncaughtException', catcher);
   throw new Error('Taking too long!');
-}, 1000).unref();
+}, common.platformTimeout(1000)).unref();
 
 process.on('uncaughtException', catcher);
 var errors = 0;

--- a/test/parallel/test-repl-timeout-throw.js
+++ b/test/parallel/test-repl-timeout-throw.js
@@ -44,7 +44,7 @@ child.stdout.once('data', function() {
                       '  });\n' +
                       '});"";\n');
 
-    setTimeout(child.stdin.end.bind(child.stdin), 200);
+    setTimeout(child.stdin.end.bind(child.stdin), common.platformTimeout(200));
   }
 });
 

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -22,7 +22,7 @@ var gotDrain = false;
 var timer = setTimeout(function() {
   console.log('not ok - timed out');
   process.exit(1);
-}, 500);
+}, common.platformTimeout(500));
 
 function onconnection(conn) {
   conn.on('data', function(c) {

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -27,7 +27,9 @@ var server = tls.createServer(options, function(c) {
 
 server.listen(common.PORT, function() {
   var socket = net.connect(common.PORT, function() {
-    socket.setTimeout(240, assert.fail);
+    socket.setTimeout(common.platformTimeout(240), function () {
+      throw new Error('timeout');
+    });
 
     var tsocket = tls.connect({
       socket: socket,

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -27,7 +27,7 @@ var server = tls.createServer(options, function(c) {
 
 server.listen(common.PORT, function() {
   var socket = net.connect(common.PORT, function() {
-    socket.setTimeout(common.platformTimeout(240), function () {
+    socket.setTimeout(common.platformTimeout(240), function() {
       throw new Error('timeout');
     });
 

--- a/test/sequential/test-force-repl.js
+++ b/test/sequential/test-force-repl.js
@@ -7,7 +7,7 @@ var cp = spawn(process.execPath, ['-i']);
 var gotToEnd = false;
 var timeoutId = setTimeout(function() {
   throw new Error('timeout!');
-}, 1000); // give node + the repl 1 second to boot up
+}, common.platformTimeout(1000)); // give node + the repl 1 second to boot up
 
 cp.stdout.setEncoding('utf8');
 

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -72,7 +72,7 @@ function parent() {
     setTimeout(function() {
       throw new Error('hang');
     });
-  }, 4000).unref();
+  }, common.platformTimeout(2000)).unref();
 
   var s = spawn(node, [__filename, 'server'], opt);
   var c;

--- a/tools/test.py
+++ b/tools/test.py
@@ -729,8 +729,9 @@ FLAGS = {
     'debug'   : ['--enable-slow-asserts', '--debug-code', '--verify-heap'],
     'release' : []}
 TIMEOUT_SCALEFACTOR = {
-    'arm'  : { 'debug' : 8, 'release' : 2 },  # The ARM buildbots are slow.
-    'ia32' : { 'debug' : 4, 'release' : 1 } }
+    'armv6' : { 'debug' : 12, 'release' : 3 },  # The ARM buildbots are slow.
+    'arm'   : { 'debug' :  8, 'release' : 2 },
+    'ia32'  : { 'debug' :  4, 'release' : 1 } }
 
 
 class Context(object):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -73,7 +73,9 @@ def GuessOS():
 def GuessArchitecture():
   id = platform.machine()
   id = id.lower()  # Windows 7 capitalizes 'AMD64'.
-  if id.startswith('arm') or id == 'aarch64':
+  if id.startswith('armv6') # Can return 'armv6l'.
+    return 'armv6'
+  elif id.startswith('arm') or id == 'aarch64':
     return 'arm'
   elif (not id) or (not re.match('(x|i[3-6])86$', id) is None):
     return 'ia32'

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -73,7 +73,7 @@ def GuessOS():
 def GuessArchitecture():
   id = platform.machine()
   id = id.lower()  # Windows 7 capitalizes 'AMD64'.
-  if id.startswith('armv6') # Can return 'armv6l'.
+  if id.startswith('armv6'): # Can return 'armv6l'.
     return 'armv6'
   elif id.startswith('arm') or id == 'aarch64':
     return 'arm'


### PR DESCRIPTION
Related: #1343

The static factors are still subject to change, and I think I'll look into benchmarking to obtain them dynamically. ARMv8 gets no special treatment as I think it won't need it. The ARMv6 factor is probably too low for some boards. My RPi does fine with around 2-3x, but it is overclocked and has a pretty fast SD.

If someone could start off a CI run with this PR, I'd be grateful as this should green out CI for ARMv6 and ARMv7.