### PR TITLE
doc: update curl usage in COLLABORATOR_GUIDE

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -132,7 +132,7 @@ $ git merge --ff-only origin/v1.x
 Apply external patches
 
 ```text
-$ curl https://github.com/iojs/io.js/pull/xxx.patch | git am --whitespace=fix
+$ curl -L https://github.com/iojs/io.js/pull/xxx.patch | git am --whitespace=fix
 ```
 
 Check and re-review the changes


### PR DESCRIPTION
Looks like Github now redirects the patch urls from

```
https://github.com/iojs/io.js/pull/1382.patch
```
to 
```
https://patch-diff.githubusercontent.com/raw/iojs/io.js/pull/1382.patch
```
so curl now needs to follow that redirect.