### PR TITLE
readline: fix calling constructor without new

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -26,7 +26,10 @@ exports.createInterface = function(input, output, completer, terminal) {
 
 function Interface(input, output, completer, terminal) {
   if (!(this instanceof Interface)) {
-    return new Interface(input, output, completer, terminal);
+    // call the constructor preserving original number of arguments
+    const self = Object.create(Interface.prototype);
+    Interface.apply(self, arguments);
+    return self;
   }
 
   this._sawReturn = false;

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -216,6 +216,18 @@ function isWarned(emitter) {
     fi.emit('data', ''); // removes listener
   });
 
+  // calling readline without `new`
+  fi = new FakeInput();
+  rli = readline.Interface({ input: fi, output: fi, terminal: terminal });
+  called = false;
+  rli.on('line', function(line) {
+    called = true;
+    assert.equal(line, 'asdf');
+  });
+  fi.emit('data', 'asdf\n');
+  assert.ok(called);
+  rli.close();
+
   if (terminal) {
     // question
     fi = new FakeInput();


### PR DESCRIPTION
This works:

```sh
$ iojs -e 'new (require("readline").Interface)({ input: process.stdin, output: process.stdout })'
```

This doesn't:

```sh
$ iojs -e 'require("readline").Interface({ input: process.stdin, output: process.stdout })'
readline.js:98
    input.on('data', ondata);
          ^
TypeError: undefined is not a function
    at new Interface (readline.js:98:11)
    at Object.Interface (readline.js:29:12)
    at [eval]:1:21
    at Object.exports.runInThisContext (vm.js:54:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:446:26)
    at evalScript (node.js:413:25)
    at startup (node.js:72:7)
    at node.js:799:3
```

The reason is that `option` object detection [here](https://github.com/iojs/io.js/blob/69bc1382b7b0a1271a5f344be7574c55addc99e8/lib/readline.js#L36-L42) relies on a number of arguments passed to the constructor.

But `instanceof` guard [here](https://github.com/iojs/io.js/blob/69bc1382b7b0a1271a5f344be7574c55addc99e8/lib/readline.js#L29) always makes it four arguments.

------

So the issue happens when usual `instanceof` check is combined with logic based on `arguments.length`.

There are two places in `io.js` core when it matters. Second one is in [buffer.js](https://github.com/iojs/io.js/blob/69bc1382b7b0a1271a5f344be7574c55addc99e8/lib/buffer.js#L29-L33) and it's already handled correctly.