### PR TITLE
cluster: disconnect event was not emitted correctly

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -509,6 +509,7 @@ function workerInit() {
     });
     cluster.worker = worker;
     process.once('disconnect', function() {
+      worker.emit('disconnect');
       if (!worker.suicide) {
         // Unexpected disconnect, master exited, or some such nastiness, so
         // worker exits immediately.


### PR DESCRIPTION
Fix for iojs/io.js#1304
Inside of a worker, disconnect event was not emitted on cluster.worker