### PR TITLE
doc: remove keepAlive options from http.request

### DIFF
--- a/doc/api/http.markdown
+++ b/doc/api/http.markdown
@@ -478,11 +478,6 @@ Options:
  - `Agent` object: explicitly use the passed in `Agent`.
  - `false`: opts out of connection pooling with an Agent, defaults request to
    `Connection: close`.
- - `keepAlive`: {Boolean} Keep sockets around in a pool to be used
-  by other requests in the future. Default = `false`
- - `keepAliveMsecs`: {Integer} When using HTTP KeepAlive, how often to
-  send TCP KeepAlive packets over sockets being kept alive.  Default =
-  `1000`.  Only relevant if `keepAlive` is set to `true`.
 
 The optional `callback` parameter will be added as a one time listener for
 the ['response'][] event.


### PR DESCRIPTION
These can only actually be specified in the options for http.Agent

Onus is on me for not waiting long enough to merge 69bc1382b7b0a1271a5f344be7574c55addc99e8

Properly fixes #1300

R=@cjihrig, etc