### PR TITLE
deps: backport 1f8555 from v8's upstream

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1006,6 +1006,24 @@ class ScriptOrigin {
   Handle<Integer> script_id_;
 };
 
+class V8_EXPORT SealHandleScope {
+ public:
+  SealHandleScope(Isolate* isolate);
+  ~SealHandleScope();
+
+ private:
+  // Make it hard to create heap-allocated or illegal handle scopes by
+  // disallowing certain operations.
+  SealHandleScope(const SealHandleScope&);
+  void operator=(const SealHandleScope&);
+  void* operator new(size_t size);
+  void operator delete(void*, size_t);
+
+  internal::Isolate* isolate_;
+  int prev_level_;
+  internal::Object** prev_limit_;
+};
+
 
 /**
  * A compiled JavaScript script, not yet tied to a Context.

--- a/deps/v8/src/api.h
+++ b/deps/v8/src/api.h
@@ -650,7 +650,7 @@ void HandleScopeImplementer::DeleteExtensions(internal::Object** prev_limit) {
   while (!blocks_.is_empty()) {
     internal::Object** block_start = blocks_.last();
     internal::Object** block_limit = block_start + kHandleBlockSize;
-#ifdef DEBUG
+
     // SealHandleScope may make the prev_limit to point inside the block.
     if (block_start <= prev_limit && prev_limit <= block_limit) {
 #ifdef ENABLE_HANDLE_ZAPPING
@@ -658,9 +658,6 @@ void HandleScopeImplementer::DeleteExtensions(internal::Object** prev_limit) {
 #endif
       break;
     }
-#else
-    if (prev_limit == block_limit) break;
-#endif
 
     blocks_.RemoveLast();
 #ifdef ENABLE_HANDLE_ZAPPING

--- a/deps/v8/test/cctest/cctest.status
+++ b/deps/v8/test/cctest/cctest.status
@@ -40,6 +40,7 @@
   # they don't fail then test.py has failed.
   'test-serialize/TestThatAlwaysFails': [FAIL],
   'test-serialize/DependentTestThatAlwaysFails': [FAIL],
+  'test-api/SealHandleScope': [FAIL],
 
   # This test always fails.  It tests that LiveEdit causes abort when turned off.
   'test-debug/LiveEditDisabled': [FAIL],

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -21895,6 +21895,38 @@ void CallCompletedCallbackException() {
 }
 
 
+TEST(SealHandleScope) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope handle_scope(isolate);
+  LocalContext env;
+
+  v8::SealHandleScope seal(isolate);
+
+  // Should fail
+  v8::Local<v8::Object> obj = v8::Object::New(isolate);
+
+  USE(obj);
+}
+
+
+TEST(SealHandleScopeNested) {
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope handle_scope(isolate);
+  LocalContext env;
+
+  v8::SealHandleScope seal(isolate);
+
+  {
+    v8::HandleScope handle_scope(isolate);
+
+    // Should work
+    v8::Local<v8::Object> obj = v8::Object::New(isolate);
+
+    USE(obj);
+  }
+}
+
+
 TEST(CallCompletedCallbackOneException) {
   LocalContext env;
   v8::HandleScope scope(env->GetIsolate());

--- a/src/node.cc
+++ b/src/node.cc
@@ -101,6 +101,7 @@ using v8::ObjectTemplate;
 using v8::Promise;
 using v8::PromiseRejectMessage;
 using v8::PropertyCallbackInfo;
+using v8::SealHandleScope;
 using v8::String;
 using v8::TryCatch;
 using v8::Uint32;
@@ -3822,22 +3823,25 @@ static void StartNodeInstance(void* arg) {
     if (instance_data->use_debug_agent())
       EnableDebug(env);
 
-    bool more;
-    do {
-      v8::platform::PumpMessageLoop(default_platform, isolate);
-      more = uv_run(env->event_loop(), UV_RUN_ONCE);
-
-      if (more == false) {
+    {
+      SealHandleScope seal(isolate);
+      bool more;
+      do {
         v8::platform::PumpMessageLoop(default_platform, isolate);
-        EmitBeforeExit(env);
+        more = uv_run(env->event_loop(), UV_RUN_ONCE);
 
-        // Emit `beforeExit` if the loop became alive either after emitting
-        // event, or after running some callbacks.
-        more = uv_loop_alive(env->event_loop());
-        if (uv_run(env->event_loop(), UV_RUN_NOWAIT) != 0)
-          more = true;
-      }
-    } while (more == true);
+        if (more == false) {
+          v8::platform::PumpMessageLoop(default_platform, isolate);
+          EmitBeforeExit(env);
+
+          // Emit `beforeExit` if the loop became alive either after emitting
+          // event, or after running some callbacks.
+          more = uv_loop_alive(env->event_loop());
+          if (uv_run(env->event_loop(), UV_RUN_NOWAIT) != 0)
+            more = true;
+        }
+      } while (more == true);
+    }
 
     int exit_code = EmitExit(env);
     if (instance_data->is_main())


### PR DESCRIPTION
Original commit message:

    api: introduce SealHandleScope

    When debugging Handle leaks in io.js we found it very convenient to be
    able to Seal some specific (root in our case) scope to prevent Handle
    allocations in it, and easily find leakage.

    R=yangguo
    BUG=

    Review URL: https://codereview.chromium.org/1079713002

    Cr-Commit-Position: refs/heads/master@{#27766}

Should help us identify and fix Handle leaks in core and user-space code.

NOTE: Works only in Debug build now, but is still better than nothing.

R=@bnoordhuis