### PR TITLE
src: disable fast math on arm

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3541,6 +3541,14 @@ void Init(int* argc,
                 DispatchDebugMessagesAsyncCallback);
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
+#if defined(__arm__)
+  // See https://github.com/iojs/io.js/issues/1376
+  // and https://code.google.com/p/v8/issues/detail?id=4019
+  // TODO(bnoordhuis): Remove test/parallel/test-arm-math-exp-regress-1376.js
+  // and this workaround when v8:4019 has been fixed and the patch back-ported.
+  V8::SetFlagsFromString("--nofast_math", sizeof("--nofast_math") - 1);
+#endif
+
 #if defined(NODE_V8_OPTIONS)
   // Should come before the call to V8::SetFlagsFromCommandLine()
   // so the user can disable a flag --foo at run-time by passing

--- a/src/node.cc
+++ b/src/node.cc
@@ -3541,7 +3541,13 @@ void Init(int* argc,
                 DispatchDebugMessagesAsyncCallback);
   uv_unref(reinterpret_cast<uv_handle_t*>(&dispatch_debug_messages_async));
 
-#if defined(__arm__)
+#if defined(__ARM_ARCH_6__) || \
+    defined(__ARM_ARCH_6J__) || \
+    defined(__ARM_ARCH_6K__) || \
+    defined(__ARM_ARCH_6M__) || \
+    defined(__ARM_ARCH_6T2__) || \
+    defined(__ARM_ARCH_6ZK__) || \
+    defined(__ARM_ARCH_6Z__)
   // See https://github.com/iojs/io.js/issues/1376
   // and https://code.google.com/p/v8/issues/detail?id=4019
   // TODO(bnoordhuis): Remove test/parallel/test-arm-math-exp-regress-1376.js

--- a/test/parallel/test-arm-math-exp-regress-1376.js
+++ b/test/parallel/test-arm-math-exp-regress-1376.js
@@ -1,0 +1,30 @@
+// See https://github.com/iojs/io.js/issues/1376
+// and https://code.google.com/p/v8/issues/detail?id=4019
+
+Math.abs(-0.5);
+Math.acos(-0.5);
+Math.acosh(-0.5);
+Math.asin(-0.5);
+Math.asinh(-0.5);
+Math.atan(-0.5);
+Math.atanh(-0.5);
+Math.cbrt(-0.5);
+Math.ceil(-0.5);
+Math.cos(-0.5);
+Math.cosh(-0.5);
+Math.exp(-0.5);
+Math.expm1(-0.5);
+Math.floor(-0.5);
+Math.fround(-0.5);
+Math.log(-0.5);
+Math.log10(-0.5);
+Math.log1p(-0.5);
+Math.log2(-0.5);
+Math.round(-0.5);
+Math.sign(-0.5);
+Math.sin(-0.5);
+Math.sinh(-0.5);
+Math.sqrt(-0.5);
+Math.tan(-0.5);
+Math.tanh(-0.5);
+Math.trunc(-0.5);


### PR DESCRIPTION
The "fast" implementation of Math.exp() and Math.tanh() emits ARMv7
movt/movw instructions on ARMv6 (notably, the original Raspberry Pi.)

Disable fast math for now.  The adventurous can enable it again with
the --fast_math switch.

Refs: #1376
V8-Bug: https://code.google.com/p/v8/issues/detail?id=4019

R=@silverwind?

https://jenkins-iojs.nodesource.com/view/iojs/job/iojs+any-pr+multi/489/