### PR TITLE
doc: Document forced pushing with git

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -212,3 +212,13 @@ Time to push it:
 ```text
 $ git push origin v1.x
 ```
+
+### I just made a mistake
+
+With git, there's a way to override remote trees by force pushing
+(`git push -f`). This should generally be seen as forbidden (since
+you're rewriting history on a repository other people are working
+against) but is allowed for simpler slip-ups such as typo's in commit
+messages. You are only allowed to force push to any io.js branch
+within 10 minutes from your original push. After that period passes,
+consider the commit as final.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -219,7 +219,7 @@ With git, there's a way to override remote trees by force pushing
 (`git push -f`). This should generally be seen as forbidden (since
 you're rewriting history on a repository other people are working
 against) but is allowed for simpler slip-ups such as typos in commit
-messages. You are only allowed to force push to any io.js branch
-within 10 minutes from your original push. If someone else pushes to
-the branch your commit lives in or the 10 minute period passes,
-consider the commit final.
+messages. However, you are only allowed to force push to any io.js
+branch within 10 minutes from your original push. If someone else
+pushes to the branch your commit lives in or the 10 minute period
+passes, consider the commit final.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -221,4 +221,4 @@ you're rewriting history on a repository other people are working
 against) but is allowed for simpler slip-ups such as typo's in commit
 messages. You are only allowed to force push to any io.js branch
 within 10 minutes from your original push. After that period passes,
-consider the commit as final.
+consider the commit final.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -218,7 +218,7 @@ $ git push origin v1.x
 With git, there's a way to override remote trees by force pushing
 (`git push -f`). This should generally be seen as forbidden (since
 you're rewriting history on a repository other people are working
-against) but is allowed for simpler slip-ups such as typo's in commit
+against) but is allowed for simpler slip-ups such as typos in commit
 messages. You are only allowed to force push to any io.js branch
 within 10 minutes from your original push. After that period passes,
 consider the commit final.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -220,5 +220,6 @@ With git, there's a way to override remote trees by force pushing
 you're rewriting history on a repository other people are working
 against) but is allowed for simpler slip-ups such as typos in commit
 messages. You are only allowed to force push to any io.js branch
-within 10 minutes from your original push. After that period passes,
+within 10 minutes from your original push. If someone else pushes to
+the branch your commit lives in or the 10 minute period passes,
 consider the commit final.


### PR DESCRIPTION
Mention that we generally disallow forced pushes but allow it in trivial cases within 10 minutes of the original push.

Refs #1355