### PR TITLE
build: fix RELEASE check (URGENT)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ docclean:
 RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
 VERSION=v$(RAWVER)
 FULLVERSION=$(VERSION)
-RELEASE=($shell sed -ne 's/#define NODE_VERSION_IS_RELEASE \([01]\)/\1/p' src/node_version.h)
+RELEASE=$(shell sed -ne 's/#define NODE_VERSION_IS_RELEASE \([01]\)/\1/p' src/node_version.h)
 PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
 NPMVERSION=v$(shell cat deps/npm/package.json | grep '"version"' | sed 's/^[^:]*: "\([^"]*\)",.*/\1/')
 ifeq ($(findstring x86_64,$(shell uname -m)),x86_64)


### PR DESCRIPTION
Ref: https://github.com/iojs/io.js/pull/1405

please review @jbergstroem || @bnoordhuis asap or I'm just going to merge this and release a 1.7.1, 1.7.0 is a write-off because this is broken unfortunately.