### PR TITLE
build: Expose xz compression level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ TARBALL=$(TARNAME).tar
 BINARYNAME=$(TARNAME)-$(PLATFORM)-$(ARCH)
 BINARYTAR=$(BINARYNAME).tar
 XZ=$(shell which xz > /dev/null 2>&1; echo $$?)
+XZ_COMPRESSION ?= 9
 PKG=out/$(TARNAME).pkg
 PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker
 
@@ -296,7 +297,7 @@ $(TARBALL): release-only $(NODE_EXE) doc
 	rm -rf $(TARNAME)
 	gzip -c -f -9 $(TARNAME).tar > $(TARNAME).tar.gz
 ifeq ($(XZ), 0)
-	xz -c -f -9 $(TARNAME).tar > $(TARNAME).tar.xz
+	xz -c -f -$(XZ_COMPRESSION) $(TARNAME).tar > $(TARNAME).tar.xz
 endif
 	rm $(TARNAME).tar
 
@@ -314,7 +315,7 @@ $(BINARYTAR): release-only
 	rm -rf $(BINARYNAME)
 	gzip -c -f -9 $(BINARYNAME).tar > $(BINARYNAME).tar.gz
 ifeq ($(XZ), 0)
-	xz -c -f -9 $(BINARYNAME).tar > $(BINARYNAME).tar.xz
+	xz -c -f -$(XZ_COMPRESSION) $(BINARYNAME).tar > $(BINARYNAME).tar.xz
 endif
 	rm $(BINARYNAME).tar
 


### PR DESCRIPTION
On machines with limited resources a fair tradeoff could be trading result size with less memory and cpu consumption. Expose a variable that overrides the default (9).

Note: xz is often used to gain maximum possible compression, so avoid lowering this if possible.

Refs #1396.