### PR TITLE
win,node-gyp: enable delay-load hook by default

### DIFF
--- a/deps/npm/node_modules/node-gyp/addon.gypi
+++ b/deps/npm/node_modules/node-gyp/addon.gypi
@@ -1,7 +1,7 @@
 {
   'target_defaults': {
     'type': 'loadable_module',
-    'win_delay_load_hook': 'false',
+    'win_delay_load_hook': 'true',
     'product_prefix': '',
 
     'include_dirs': [


### PR DESCRIPTION
The delay-load hook allows node.exe/iojs.exe to be renamed. See efadffe for more background.
I want to consider seizing the opportunity that comes with a major version bump to switch to a reasonable default.

This PR is against the v1.x branch but it obviously should not land on this branch.
@iojs/tc 