### PR TITLE
buffer: little improve for Buffer.concat method

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -247,6 +247,11 @@ Buffer.concat = function(list, length) {
   if (!Array.isArray(list))
     throw new TypeError('list argument must be an Array of Buffers.');
 
+  if (list.length === 0)
+    return new Buffer(0);
+  else if (list.length === 1)
+    return list[0];
+
   if (length === undefined) {
     length = 0;
     for (var i = 0; i < list.length; i++)
@@ -254,11 +259,6 @@ Buffer.concat = function(list, length) {
   } else {
     length = length >>> 0;
   }
-
-  if (list.length === 0)
-    return new Buffer(0);
-  else if (list.length === 1)
-    return list[0];
 
   var buffer = new Buffer(length);
   var pos = 0;


### PR DESCRIPTION
When buffer list less than 2, no need to calculate the length.
The change's benchmark result is here:
https://gist.github.com/JacksonTian/2c9e2bdec00018e010e6
It improve 15% ~ 25% speed when list only have one buffer,
to other cases no effect.