### PR TITLE
src: remove duplicate byteLength

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -746,7 +746,6 @@ void Initialize(Handle<Object> target,
   env->SetMethod(target, "setupBufferJS", SetupBufferJS);
 
   env->SetMethod(target, "byteLength", ByteLength);
-  env->SetMethod(target, "byteLength", ByteLength);
   env->SetMethod(target, "compare", Compare);
   env->SetMethod(target, "fill", Fill);
   env->SetMethod(target, "indexOfBuffer", IndexOfBuffer);


### PR DESCRIPTION
In commit 36a77956, the byteLength was added repeatedly.