### PR TITLE
buffer: improve Buffer.concat([])

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -12,6 +12,8 @@ exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
 exports.INSPECT_MAX_BYTES = 50;
 
+const EMPTY_BUFFER = new Buffer(0);
+
 
 Buffer.poolSize = 8 * 1024;
 var poolSize, poolOffset, allocPool;
@@ -256,7 +258,7 @@ Buffer.concat = function(list, length) {
   }
 
   if (list.length === 0)
-    return new Buffer(0);
+    return EMPTY_BUFFER;
   else if (list.length === 1)
     return list[0];
 


### PR DESCRIPTION
When i do benchmark testing with Buffer.concat(), found that
Buffer.concat([]) is even slower than Buffer.concat([buf]).

The reason is Buffer.concat([]) must create new Buffer(0) every time.
So create one const Buffer(0), and return the same Buffer.

This change improve Buffer.concat([]) speed about ~80 times.