### PR TITLE
buffer: improve Buffer.byteLength(string, encoding)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -276,6 +276,9 @@ function byteLength(string, encoding) {
   if (typeof(string) !== 'string')
     string = String(string);
 
+  if (string.length === 0)
+    return 0;
+
   switch (encoding) {
     case 'ascii':
     case 'binary':


### PR DESCRIPTION
When string is empty, it will running into binding also.
It make the performance is wasted.