### PR TITLE
build: improve shared library flags logic

### DIFF
--- a/configure
+++ b/configure
@@ -658,37 +658,37 @@ def configure_node(o):
 def configure_libz(o):
   o['variables']['node_shared_zlib'] = b(options.shared_zlib)
 
-  if b(options.shared_zlib) == True:
+  if options.shared_zlib:
     o['libraries'] += ['-l%s' % options.shared_zlib_libname]
-  if options.shared_zlib_libpath:
-    o['libraries'] += ['-L%s' % options.shared_zlib_libpath]
-  if options.shared_zlib_includes:
-    o['include_dirs'] += [options.shared_zlib_includes]
+    if options.shared_zlib_libpath:
+      o['libraries'] += ['-L%s' % options.shared_zlib_libpath]
+    if options.shared_zlib_includes:
+      o['include_dirs'] += [options.shared_zlib_includes]
 
 
 def configure_http_parser(o):
     o['variables']['node_shared_http_parser'] = b(options.shared_http_parser)
-    
-    if b(options.shared_http_parser) == True:
+
+    if options.shared_http_parser:
       o['libraries'] += ['-l%s' % options.shared_http_parser_libname]
-    if options.shared_http_parser_libpath:
+      if options.shared_http_parser_libpath:
         o['libraries'] += ['-L%s' % options.shared_http_parser_libpath]
-    if options.shared_http_parser_includes:
+      if options.shared_http_parser_includes:
         o['include_dirs'] += [options.shared_http_parser_includes]
 
 
 def configure_libuv(o):
   o['variables']['node_shared_libuv'] = b(options.shared_libuv)
 
-  if b(options.shared_libuv) == True:
+  if options.shared_libuv:
     o['libraries'] += ['-l%s' % options.shared_libuv_libname]
-  if options.shared_libuv_libpath:
-    o['libraries'] += ['-L%s' % options.shared_libuv_libpath]
-  else:
-    o['variables']['uv_library'] = 'static_library'
+    if options.shared_libuv_libpath:
+      o['libraries'] += ['-L%s' % options.shared_libuv_libpath]
+    else:
+      o['variables']['uv_library'] = 'static_library'
 
-  if options.shared_libuv_includes:
-    o['include_dirs'] += [options.shared_libuv_includes]
+    if options.shared_libuv_includes:
+      o['include_dirs'] += [options.shared_libuv_includes]
 
 
 def configure_v8(o):


### PR DESCRIPTION
This is one of the commit from #1429 which fixes a bug with shared library flags. The other pull request doesn't necessarily have any issues but could benefit from a bit more review. This should be simple enough to get reviewed and merged ahead of 1.8.0

/R=@rvagg, ?