### PR TITLE
util: support inspecting Map, Set, and Promise

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -285,7 +285,7 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', empty, braces, formatter;
+  var base = '', empty = false, braces, formatter;
 
   if (Array.isArray(value)) {
     braces = ['[', ']'];
@@ -302,26 +302,25 @@ function formatValue(ctx, value, recurseTimes) {
     formatter = formatSet;
   } else if (value instanceof Map) {
     braces = ['Map {', '}'];
-    // ditto
+    // Ditto.
     if (ctx.showHidden)
       keys.unshift('size');
     empty = value.size === 0;
     formatter = formatMap;
   } else {
-    // Only create a mirror if the object superficially looks like a Promise
+    // Only create a mirror if the object superficially looks like a Promise.
     var promiseInternals = value instanceof Promise && inspectPromise(value);
     if (promiseInternals) {
       braces = ['Promise {', '}'];
-      empty = false;
       formatter = formatPromise;
     } else {
       braces = ['{', '}'];
-      empty = true; // no other data than keys
+      empty = true;  // No other data than keys.
       formatter = formatObject;
     }
   }
 
-  empty = empty && keys.length === 0;
+  empty = empty === true && keys.length === 0;
 
   // Make functions say that they are functions
   if (typeof value === 'function') {
@@ -362,7 +361,7 @@ function formatValue(ctx, value, recurseTimes) {
     base = ' ' + '[Boolean: ' + formatted + ']';
   }
 
-  if (empty) {
+  if (empty === true) {
     return braces[0] + base + braces[1];
   }
 
@@ -459,8 +458,8 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   value.forEach(function(v) {
-    var str = formatValue(ctx, v,
-                          recurseTimes === null ? null : recurseTimes - 1);
+    var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+    var str = formatValue(ctx, v, nextRecurseTimes);
     output.push(str);
   });
   keys.forEach(function(key) {
@@ -474,10 +473,10 @@ function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   value.forEach(function(v, k) {
-    var str = formatValue(ctx, k,
-                          recurseTimes === null ? null : recurseTimes - 1);
+    var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+    var str = formatValue(ctx, k, nextRecurseTimes);
     str += ' => ';
-    str += formatValue(ctx, v, recurseTimes === null ? null : recurseTimes - 1);
+    str += formatValue(ctx, v, nextRecurseTimes);
     output.push(str);
   });
   keys.forEach(function(key) {
@@ -493,8 +492,8 @@ function formatPromise(ctx, value, recurseTimes, visibleKeys, keys) {
   if (internals.status === 'pending') {
     output.push('<pending>');
   } else {
-    var str = formatValue(ctx, internals.value,
-                          recurseTimes === null ? null : recurseTimes - 1);
+    var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+    var str = formatValue(ctx, internals.value, nextRecurseTimes);
     if (internals.status === 'rejected') {
       output.push('<rejected> ' + str);
     } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -285,11 +285,11 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', empty = keys.length === 0, braces, formatter;
+  var base = '', empty, braces, formatter;
 
   if (Array.isArray(value)) {
     braces = ['[', ']'];
-    empty = empty && value.length === 0;
+    empty = value.length === 0;
     formatter = formatArray;
   } else if (value instanceof Set) {
     braces = ['Set {', '}'];
@@ -298,14 +298,14 @@ function formatValue(ctx, value, recurseTimes) {
     // property isn't selected by Object.getOwnPropertyNames().
     if (ctx.showHidden)
       keys.unshift('size');
-    empty = empty && value.size === 0;
+    empty = value.size === 0;
     formatter = formatSet;
   } else if (value instanceof Map) {
     braces = ['Map {', '}'];
     // ditto
     if (ctx.showHidden)
       keys.unshift('size');
-    empty = empty && value.size === 0;
+    empty = value.size === 0;
     formatter = formatMap;
   } else {
     // Only create a mirror if the object superficially looks like a Promise
@@ -316,9 +316,12 @@ function formatValue(ctx, value, recurseTimes) {
       formatter = formatPromise;
     } else {
       braces = ['{', '}'];
+      empty = true; // no other data than keys
       formatter = formatObject;
     }
   }
+
+  empty = empty && keys.length === 0;
 
   // Make functions say that they are functions
   if (typeof value === 'function') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -276,12 +276,24 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', array = false, braces = ['{', '}'];
+  var base = '', braces;
 
-  // Make Array say that they are Array
   if (Array.isArray(value)) {
-    array = true;
     braces = ['[', ']'];
+  } else if (value instanceof Set) {
+    braces = ['Set {', '}'];
+    // With `showHidden`, `length` will display as a hidden property for
+    // arrays. For consistency's sake, do the same for `size`, even though this
+    // property isn't selected by Object.getOwnPropertyNames().
+    if (ctx.showHidden)
+      keys.unshift('size');
+  } else if (value instanceof Map) {
+    braces = ['Map {', '}'];
+    // ditto
+    if (ctx.showHidden)
+      keys.unshift('size');
+  } else {
+    braces = ['{', '}'];
   }
 
   // Make functions say that they are functions
@@ -323,7 +335,10 @@ function formatValue(ctx, value, recurseTimes) {
     base = ' ' + '[Boolean: ' + formatted + ']';
   }
 
-  if (keys.length === 0 && (!array || value.length === 0)) {
+  if (keys.length === 0 &&
+      (!Array.isArray(value) || value.length === 0) &&
+      (!(value instanceof Set) || value.size === 0) &&
+      (!(value instanceof Map) || value.size === 0)) {
     return braces[0] + base + braces[1];
   }
 
@@ -338,11 +353,15 @@ function formatValue(ctx, value, recurseTimes) {
   ctx.seen.push(value);
 
   var output;
-  if (array) {
+  if (Array.isArray(value)) {
     output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
+  } else if (value instanceof Set) {
+    output = formatSet(ctx, value, recurseTimes, visibleKeys, keys);
+  } else if (value instanceof Map) {
+    output = formatMap(ctx, value, recurseTimes, visibleKeys, keys);
   } else {
     output = keys.map(function(key) {
-      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
+      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, false);
     });
   }
 
@@ -412,6 +431,38 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
           key, true));
     }
+  });
+  return output;
+}
+
+
+function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
+  var output = [];
+  value.forEach(function(v) {
+    var str = formatValue(ctx, v,
+                          recurseTimes === null ? null : recurseTimes - 1);
+    output.push(str);
+  });
+  keys.forEach(function(key) {
+    output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+                               key, false));
+  });
+  return output;
+}
+
+
+function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
+  var output = [];
+  value.forEach(function(v, k) {
+    var str = formatValue(ctx, k,
+                          recurseTimes === null ? null : recurseTimes - 1);
+    str += ' => ';
+    str += formatValue(ctx, v, recurseTimes === null ? null : recurseTimes - 1);
+    output.push(str);
+  });
+  keys.forEach(function(key) {
+    output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+                               key, false));
   });
   return output;
 }
@@ -488,7 +539,10 @@ function reduceToSingleString(output, base, braces) {
 
   if (length > 60) {
     return braces[0] +
-           (base === '' ? '' : base + '\n ') +
+           // If the opening "brace" is too large, like in the case of "Set {",
+           // we need to force the first item to be on the next line or the
+           // items will not line up correctly.
+           (base === '' && braces[0].length === 1 ? '' : base + '\n ') +
            ' ' +
            output.join(',\n  ') +
            ' ' +

--- a/lib/util.js
+++ b/lib/util.js
@@ -192,6 +192,16 @@ function arrayToHash(array) {
 }
 
 
+function inspectPromise(p) {
+  // FIXME cache?
+  var Debug = require('vm').runInDebugContext('Debug');
+  var mirror = Debug.MakeMirror(p);
+  if (!mirror.isPromise())
+    return null;
+  return {status: mirror.status(), value: mirror.promiseValue().value_};
+}
+
+
 function formatValue(ctx, value, recurseTimes) {
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
@@ -292,6 +302,8 @@ function formatValue(ctx, value, recurseTimes) {
     // ditto
     if (ctx.showHidden)
       keys.unshift('size');
+  } else if (inspectPromise(value)) { // not instanceof in case of polyfill
+    braces = ['Promise {', '}'];
   } else {
     braces = ['{', '}'];
   }
@@ -338,7 +350,9 @@ function formatValue(ctx, value, recurseTimes) {
   if (keys.length === 0 &&
       (!Array.isArray(value) || value.length === 0) &&
       (!(value instanceof Set) || value.size === 0) &&
-      (!(value instanceof Map) || value.size === 0)) {
+      (!(value instanceof Map) || value.size === 0) &&
+      // FIXME stop calling inspectPromise so much
+      (!inspectPromise(value))) {
     return braces[0] + base + braces[1];
   }
 
@@ -359,6 +373,8 @@ function formatValue(ctx, value, recurseTimes) {
     output = formatSet(ctx, value, recurseTimes, visibleKeys, keys);
   } else if (value instanceof Map) {
     output = formatMap(ctx, value, recurseTimes, visibleKeys, keys);
+  } else if (inspectPromise(value)) {
+    output = formatPromise(ctx, value, recurseTimes, visibleKeys, keys);
   } else {
     output = keys.map(function(key) {
       return formatProperty(ctx, value, recurseTimes, visibleKeys, key, false);
@@ -460,6 +476,29 @@ function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
     str += formatValue(ctx, v, recurseTimes === null ? null : recurseTimes - 1);
     output.push(str);
   });
+  keys.forEach(function(key) {
+    output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+                               key, false));
+  });
+  return output;
+}
+
+
+function formatPromise(ctx, value, recurseTimes, visibleKeys, keys) {
+  // FIXME cache?
+  var output = [];
+  var internals = inspectPromise(value);
+  if (internals.status === 'pending') {
+    output.push('<pending>');
+  } else {
+    var str = formatValue(ctx, internals.value,
+                          recurseTimes === null ? null : recurseTimes - 1);
+    if (internals.status === 'rejected') {
+      output.push('<rejected> ' + str);
+    } else {
+      output.push(str);
+    }
+  }
   keys.forEach(function(key) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                key, false));

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const uv = process.binding('uv');
+const Debug = require('vm').runInDebugContext('Debug');
 
 const formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {
@@ -193,9 +194,7 @@ function arrayToHash(array) {
 
 
 function inspectPromise(p) {
-  // FIXME cache?
-  var Debug = require('vm').runInDebugContext('Debug');
-  var mirror = Debug.MakeMirror(p);
+  var mirror = Debug.MakeMirror(p, true);
   if (!mirror.isPromise())
     return null;
   return {status: mirror.status(), value: mirror.promiseValue().value_};
@@ -286,10 +285,12 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', braces;
+  var base = '', empty = keys.length === 0, braces, formatter;
 
   if (Array.isArray(value)) {
     braces = ['[', ']'];
+    empty = empty && value.length === 0;
+    formatter = formatArray;
   } else if (value instanceof Set) {
     braces = ['Set {', '}'];
     // With `showHidden`, `length` will display as a hidden property for
@@ -297,15 +298,26 @@ function formatValue(ctx, value, recurseTimes) {
     // property isn't selected by Object.getOwnPropertyNames().
     if (ctx.showHidden)
       keys.unshift('size');
+    empty = empty && value.size === 0;
+    formatter = formatSet;
   } else if (value instanceof Map) {
     braces = ['Map {', '}'];
     // ditto
     if (ctx.showHidden)
       keys.unshift('size');
-  } else if (inspectPromise(value)) { // not instanceof in case of polyfill
-    braces = ['Promise {', '}'];
+    empty = empty && value.size === 0;
+    formatter = formatMap;
   } else {
-    braces = ['{', '}'];
+    // Only create a mirror if the object superficially looks like a Promise
+    var promiseInternals = value instanceof Promise && inspectPromise(value);
+    if (promiseInternals) {
+      braces = ['Promise {', '}'];
+      empty = false;
+      formatter = formatPromise;
+    } else {
+      braces = ['{', '}'];
+      formatter = formatObject;
+    }
   }
 
   // Make functions say that they are functions
@@ -347,12 +359,7 @@ function formatValue(ctx, value, recurseTimes) {
     base = ' ' + '[Boolean: ' + formatted + ']';
   }
 
-  if (keys.length === 0 &&
-      (!Array.isArray(value) || value.length === 0) &&
-      (!(value instanceof Set) || value.size === 0) &&
-      (!(value instanceof Map) || value.size === 0) &&
-      // FIXME stop calling inspectPromise so much
-      (!inspectPromise(value))) {
+  if (empty) {
     return braces[0] + base + braces[1];
   }
 
@@ -366,20 +373,7 @@ function formatValue(ctx, value, recurseTimes) {
 
   ctx.seen.push(value);
 
-  var output;
-  if (Array.isArray(value)) {
-    output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
-  } else if (value instanceof Set) {
-    output = formatSet(ctx, value, recurseTimes, visibleKeys, keys);
-  } else if (value instanceof Map) {
-    output = formatMap(ctx, value, recurseTimes, visibleKeys, keys);
-  } else if (inspectPromise(value)) {
-    output = formatPromise(ctx, value, recurseTimes, visibleKeys, keys);
-  } else {
-    output = keys.map(function(key) {
-      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, false);
-    });
-  }
+  var output = formatter(ctx, value, recurseTimes, visibleKeys, keys);
 
   ctx.seen.pop();
 
@@ -429,6 +423,13 @@ function formatPrimitiveNoColor(ctx, value) {
 
 function formatError(value) {
   return '[' + Error.prototype.toString.call(value) + ']';
+}
+
+
+function formatObject(ctx, value, recurseTimes, visibleKeys, keys) {
+  return keys.map(function(key) {
+    return formatProperty(ctx, value, recurseTimes, visibleKeys, key, false);
+  });
 }
 
 
@@ -483,9 +484,7 @@ function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
   return output;
 }
 
-
 function formatPromise(ctx, value, recurseTimes, visibleKeys, keys) {
-  // FIXME cache?
   var output = [];
   var internals = inspectPromise(value);
   if (internals.status === 'pending') {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -237,15 +237,15 @@ if (typeof Symbol !== 'undefined') {
 }
 
 // test Set
-assert.equal(util.inspect(new Set), 'Set {}')
-assert.equal(util.inspect(new Set([1, 2, 3])), 'Set { 1, 2, 3 }')
-var set = new Set(["foo"])
-set.bar = 42
-assert.equal(util.inspect(set, true), 'Set { \'foo\', [size]: 1, bar: 42 }')
+assert.equal(util.inspect(new Set), 'Set {}');
+assert.equal(util.inspect(new Set([1, 2, 3])), 'Set { 1, 2, 3 }');
+var set = new Set(["foo"]);
+set.bar = 42;
+assert.equal(util.inspect(set, true), 'Set { \'foo\', [size]: 1, bar: 42 }');
 
 // test Map
-assert.equal(util.inspect(new Map), 'Map {}')
-assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])), 'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }')
-var map = new Map([["foo", null]])
-map.bar = 42
-assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }')
+assert.equal(util.inspect(new Map), 'Map {}');
+assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])), 'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }');
+var map = new Map([["foo", null]]);
+map.bar = 42;
+assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -249,3 +249,35 @@ assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])), 'Map { 1 => 
 var map = new Map([["foo", null]]);
 map.bar = 42;
 assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }');
+
+// Test alignment of items in container
+// Assumes that the first numeric character is the start of an item.
+
+function checkAlignment(container) {
+  var lines = util.inspect(container).split("\n");
+  var pos;
+  lines.forEach(function(line) {
+    var npos = line.search(/\d/);
+    if (npos !== -1) {
+      if (pos !== undefined)
+        assert.equal(pos, npos, "container items not aligned");
+      pos = npos;
+    }
+  });
+}
+
+var big_array = [];
+for (var i = 0; i < 100; i++) {
+  big_array.push(i);
+}
+
+checkAlignment(big_array);
+checkAlignment(function(){
+  var obj = {};
+  big_array.forEach(function(v) {
+    obj[v] = null;
+  })
+  return obj;
+}());
+checkAlignment(new Set(big_array));
+checkAlignment(new Map(big_array.map(function (y) { return [y, null] })));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -239,16 +239,18 @@ if (typeof Symbol !== 'undefined') {
 // test Set
 assert.equal(util.inspect(new Set), 'Set {}');
 assert.equal(util.inspect(new Set([1, 2, 3])), 'Set { 1, 2, 3 }');
-var set = new Set(["foo"]);
+var set = new Set(['foo']);
 set.bar = 42;
 assert.equal(util.inspect(set, true), 'Set { \'foo\', [size]: 1, bar: 42 }');
 
 // test Map
 assert.equal(util.inspect(new Map), 'Map {}');
-assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])), 'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }');
-var map = new Map([["foo", null]]);
+assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])),
+             'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }');
+var map = new Map([['foo', null]]);
 map.bar = 42;
-assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }');
+assert.equal(util.inspect(map, true),
+             'Map { \'foo\' => null, [size]: 1, bar: 42 }');
 
 // test Promise
 assert.equal(util.inspect(Promise.resolve(3)), 'Promise { 3 }');
@@ -271,13 +273,13 @@ global.Promise = oldPromise;
 // Assumes that the first numeric character is the start of an item.
 
 function checkAlignment(container) {
-  var lines = util.inspect(container).split("\n");
+  var lines = util.inspect(container).split('\n');
   var pos;
   lines.forEach(function(line) {
     var npos = line.search(/\d/);
     if (npos !== -1) {
       if (pos !== undefined)
-        assert.equal(pos, npos, "container items not aligned");
+        assert.equal(pos, npos, 'container items not aligned');
       pos = npos;
     }
   });
@@ -289,7 +291,7 @@ for (var i = 0; i < 100; i++) {
 }
 
 checkAlignment(big_array);
-checkAlignment(function(){
+checkAlignment(function() {
   var obj = {};
   big_array.forEach(function(v) {
     obj[v] = null;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -276,7 +276,7 @@ checkAlignment(function(){
   var obj = {};
   big_array.forEach(function(v) {
     obj[v] = null;
-  })
+  });
   return obj;
 }());
 checkAlignment(new Set(big_array));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -235,3 +235,17 @@ if (typeof Symbol !== 'undefined') {
   assert.equal(util.inspect(subject, options), '[ 1, 2, 3, [length]: 3, [Symbol(symbol)]: 42 ]');
 
 }
+
+// test Set
+assert.equal(util.inspect(new Set), 'Set {}')
+assert.equal(util.inspect(new Set([1, 2, 3])), 'Set { 1, 2, 3 }')
+var set = new Set(["foo"])
+set.bar = 42
+assert.equal(util.inspect(set, true), 'Set { \'foo\', [size]: 1, bar: 42 }')
+
+// test Map
+assert.equal(util.inspect(new Map), 'Map {}')
+assert.equal(util.inspect(new Map([[1, 'a'], [2, 'b'], [3, 'c']])), 'Map { 1 => \'a\', 2 => \'b\', 3 => \'c\' }')
+var map = new Map([["foo", null]])
+map.bar = 42
+assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }')

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -250,6 +250,23 @@ var map = new Map([["foo", null]]);
 map.bar = 42;
 assert.equal(util.inspect(map, true), 'Map { \'foo\' => null, [size]: 1, bar: 42 }');
 
+// test Promise
+assert.equal(util.inspect(Promise.resolve(3)), 'Promise { 3 }');
+assert.equal(util.inspect(Promise.reject(3)), 'Promise { <rejected> 3 }');
+assert.equal(util.inspect(new Promise(function() {})), 'Promise { <pending> }');
+var promise = Promise.resolve('foo');
+promise.bar = 42;
+assert.equal(util.inspect(promise), 'Promise { \'foo\', bar: 42 }');
+
+// Make sure it doesn't choke on polyfills. Unlike Set/Map, there is no standard
+// interface to synchronously inspect a Promise, so our techniques only work on
+// a bonafide native Promise.
+var oldPromise = Promise;
+global.Promise = function() { this.bar = 42; };
+assert.equal(util.inspect(new Promise), '{ bar: 42 }');
+global.Promise = oldPromise;
+
+
 // Test alignment of items in container
 // Assumes that the first numeric character is the start of an item.
 


### PR DESCRIPTION
Among other things, this makes working with ES6 containers bearable on the REPL.

Before:

```js
> new Map([[1, "foo"], [null, "bar"], [{quux: 42}, undefined]])
{}
```

After:

```js
> new Map([[1, "foo"], [null, "bar"], [{quux: 42}, undefined]])
Map { 1 => 'foo', null => 'bar', { quux: 42 } => undefined }
```

The output format is inspired by Chrome DevTools.

~~I would like to support inspecting promises but I do not know of a way to synchronously obtain the status and fulfillment value. If someone would like to point me in the right direction I can provide a followup PR.~~ (see below)