### PR TITLE
If `$NODE_PATH` ends with a delimiter, `require` will act unexpected

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -489,7 +489,9 @@ Module._initPaths = function() {
 
   var nodePath = process.env['NODE_PATH'];
   if (nodePath) {
-    paths = nodePath.split(path.delimiter).concat(paths);
+    paths = nodePath.split(path.delimiter).filter(function(path) {
+      return !!path;
+    }).concat(paths);
   }
 
   modulePaths = paths;

--- a/test/parallel/test-module-globalpaths-nodepath.js
+++ b/test/parallel/test-module-globalpaths-nodepath.js
@@ -6,20 +6,22 @@ var module = require('module');
 var isWindows = process.platform === 'win32';
 
 var partA, partB;
+var partC = '';
 
 if (isWindows) {
   partA = 'C:\\Users\\Rocko Artischocko\\AppData\\Roaming\\npm';
   partB = 'C:\\Program Files (x86)\\nodejs\\';
-  process.env['NODE_PATH'] = partA + ';' + partB;
+  process.env['NODE_PATH'] = partA + ';' + partB + ';' + partC;
 } else {
   partA = '/usr/test/lib/node_modules';
   partB = '/usr/test/lib/node';
-  process.env['NODE_PATH'] = partA + ':' + partB;
+  process.env['NODE_PATH'] = partA + ':' + partB + ':' + partC;
 }
 
 module._initPaths();
 
 assert.ok(module.globalPaths.indexOf(partA) !== -1);
 assert.ok(module.globalPaths.indexOf(partB) !== -1);
+assert.ok(module.globalPaths.indexOf(partC) === -1);
 
 assert.ok(Array.isArray(module.globalPaths));


### PR DESCRIPTION
This is a copy of #1487 that follows contributing guide. Sorry for the trouble.

---

Here is a repo that explains the difference: https://github.com/chrisyip/NODE_PATH_DEMO.

```
Using node v1.8.1
Current NODE_PATH is '/usr/local/lib/node_modules'
Executing 'node foo/bar.js', you should seeing an error...

In foo/bar.js
module.js:336
    throw err;
          ^
Error: Cannot find module 'index.js'
    at Function.Module._resolveFilename (module.js:334:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:363:17)
    at require (module.js:382:17)
    at Object.<anonymous> (/Users/Chris/Workspace/node/NODE_PATH_DEMO/foo/bar.js:2:13)
    at Module._compile (module.js:428:26)
    at Object.Module._extensions..js (module.js:446:10)
    at Module.load (module.js:353:32)
    at Function.Module._load (module.js:308:12)
    at Function.Module.runMain (module.js:469:10)

Appeding a trailing colon to NODE_PATH
NODE_PATH now is '/usr/local/lib/node_modules:' <- notice the colon in the end
Executing 'node foo/bar.js'...

In foo/bar.js
index.js loaded
index.js: I should not be required
```

After [separation](https://github.com/iojs/io.js/blob/master/lib/module.js#L492), `nodePath` will become `[ '/usr/local/lib/node_modules', '' ]` (in the above case).

I know node should not take the responsibility for env variables, but since `''` is meaningless, I suggest to remove `''` from `nodePath` before using it.
