### PR TITLE
tls_wrap: use localhost if options.host is empty

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -858,7 +858,7 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var hostname = options.servername ||
                  options.host ||
-                 options.socket && options.socket._host ||
+                 (options.socket && options.socket._host) ||
                  'localhost',
       NPN = {},
       context = tls.createSecureContext(options);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -858,7 +858,8 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var hostname = options.servername ||
                  options.host ||
-                 options.socket && options.socket._host,
+                 options.socket && options.socket._host ||
+                 'localhost',
       NPN = {},
       context = tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -6,6 +6,7 @@ if (!common.hasCrypto) {
 }
 var tls = require('tls');
 
+var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
@@ -20,7 +21,7 @@ tls.createServer({
   cert: cert
 }).listen(common.PORT);
 
-tls.connect({
+var socket = tls.connect({
     port: common.PORT,
     ca: cert,
     // No host set here. 'localhost' is the default,
@@ -28,6 +29,6 @@ tls.connect({
     // Error: Hostname/IP doesn't match certificate's altnames:
     //   "Host: undefined. is not cert's CN: localhost"
 }, function() {
-    console.log('OK');
+    assert(socket.authorized);
     process.exit();
 });

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -13,7 +13,8 @@ var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
 // https://github.com/iojs/io.js/issues/1489
-// tls.connect(options) with no options.host should accept a cert with CN:'localhost'
+// tls.connect(options) with no options.host should accept a cert with
+//   CN:'localhost'
 tls.createServer({
   key: key,
   cert: cert
@@ -24,7 +25,8 @@ tls.connect({
     ca: cert,
     // No host set here. 'localhost' is the default,
     // but tls.checkServerIdentity() breaks before the fix with:
-    // Error: Hostname/IP doesn't match certificate's altnames: "Host: undefined. is not cert's CN: localhost"
+    // Error: Hostname/IP doesn't match certificate's altnames:
+    //   "Host: undefined. is not cert's CN: localhost"
 }, function () {
     console.log('OK');
     process.exit();

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -1,0 +1,31 @@
+var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
+var fs = require('fs');
+var path = require('path');
+
+var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
+var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
+
+// https://github.com/iojs/io.js/issues/1489
+// tls.connect(options) with no options.host should accept a cert with CN:'localhost'
+tls.createServer({
+  key: key,
+  cert: cert
+}).listen(common.PORT);
+
+tls.connect({
+    port: common.PORT,
+    ca: cert,
+    // No host set here. 'localhost' is the default,
+    // but tls.checkServerIdentity() breaks before the fix with:
+    // Error: Hostname/IP doesn't match certificate's altnames: "Host: undefined. is not cert's CN: localhost"
+}, function () {
+    console.log('OK');
+    process.exit();
+});

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -27,7 +27,7 @@ tls.connect({
     // but tls.checkServerIdentity() breaks before the fix with:
     // Error: Hostname/IP doesn't match certificate's altnames:
     //   "Host: undefined. is not cert's CN: localhost"
-}, function () {
+}, function() {
     console.log('OK');
     process.exit();
 });


### PR DESCRIPTION
That's my PR for #1489. Thanks @Fishrock123 for the actual fix idea

cc: @silverwind @Fishrock123 

```
tls.connect(options) with no options.host should accept a certificate
with CN: 'localhost'. Fix Error: Hostname/IP doesn't match
certificate's altnames: "Host: undefined. is not cert's CN: localhost"

'localhost' is not added directly to defaults because that is not
always desired (for example, when using options.socket)
```

This is my first PR here, I would really appreciate a careful review ;)