### PR TITLE
buffer: fix copy() segfault with zero arguments

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -303,10 +303,10 @@ void Base64Slice(const FunctionCallbackInfo<Value>& args) {
 void Copy(const FunctionCallbackInfo<Value> &args) {
   Environment* env = Environment::GetCurrent(args);
 
-  Local<Object> target = args[0]->ToObject(env->isolate());
-
-  if (!HasInstance(target))
+  if (!HasInstance(args[0]))
     return env->ThrowTypeError("first arg should be a Buffer");
+
+  Local<Object> target = args[0]->ToObject(env->isolate());
 
   ARGS_THIS(args.This())
   size_t target_length = target->GetIndexedPropertiesExternalArrayDataLength();

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -1179,3 +1179,8 @@ var ps = Buffer.poolSize;
 Buffer.poolSize = 0;
 assert.equal(Buffer(1).parent, undefined);
 Buffer.poolSize = ps;
+
+// Test Buffer.copy() segfault
+assert.throws(function() {
+  Buffer(10).copy();
+});


### PR DESCRIPTION
Buffer#copy() immediately does a ToObject() on the first argument before
it checks if it's even an Object. This causes
Object::HasIndexedPropertiesInExternalArrayData() to be run on nothing,
triggering the segfault. Instead run HasInstance() on the args Value.
Which will check if it's actually an Object, before checking if it
contains data.

Fixes: https://github.com/iojs/io.js/issues/1519