### PR TITLE
test: adjust Makefile/test-ci, add to vcbuild.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap -J parallel sequential message
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release -J message parallel sequential
+	$(MAKE) jslint
+	$(MAKE) cpplint
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -52,6 +52,7 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% sequential parallel message -J&set jslint=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap -J message sequential parallel&set jslint=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok


### PR DESCRIPTION
make `test-ci` consistent with `test` and introduce it to vcbuild.bat -- jenkins is now looking for it so the builds are failing without this addition (I've been testing tap output). Also puts in linting to CI which has been missing until now.