### PR TITLE
remove -J from test-ci and fix test-net-dns-custom-lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release -J message parallel sequential
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release message parallel sequential
 	$(MAKE) jslint
 	$(MAKE) cpplint
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -52,7 +52,7 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% sequential parallel message -J&set jslint=1&goto arg-ok
-if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap -J message sequential parallel&set jslint=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap message sequential parallel&set jslint=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok


### PR DESCRIPTION
This pulls in #1531 as well because it's the way to get passing builds on Jenkins when combined with removing `-J` from the test runner.

Ideally we _should_ be able to use `-J` but it's borked on most of the build slaves but it would be nice if we could have it working so they are quicker to run. Something for @indutny to chime in on perhaps, @jbergstroem has also been looking at it.

Test run for these 2 commits: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/630/