### PR TITLE
string_decoder: don't cache Buffer.isEncoding

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const isEncoding = Buffer.isEncoding;
-
 function assertEncoding(encoding) {
-  if (encoding && !isEncoding(encoding)) {
+  // Do not cache `Buffer.isEncoding`, some modules monkey-patch it to support
+  // additional encodings
+  if (encoding && !Buffer.isEncoding(encoding)) {
     throw new Error('Unknown encoding: ' + encoding);
   }
 }


### PR DESCRIPTION
Some modules are monkey-patching Buffer.isEncoding, so without this
they cannot do that.