### PR TITLE
Backport fixes to v1.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap -J parallel sequential message
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release -J message parallel sequential
+	$(MAKE) jslint
+	$(MAKE) cpplint
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 test-ci:
-	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release -J message parallel sequential
+	$(PYTHON) tools/test.py -p tap --logfile test.tap --mode=release message parallel sequential
 	$(MAKE) jslint
 	$(MAKE) cpplint
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -871,7 +871,8 @@ exports.connect = function(/* [port, host], options, cb */) {
 
   var hostname = options.servername ||
                  options.host ||
-                 options.socket && options.socket._host,
+                 (options.socket && options.socket._host) ||
+                 'localhost',
       NPN = {},
       context = tls.createSecureContext(options);
   tls.convertNPNProtocols(options.NPNProtocols, NPN);

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const isEncoding = Buffer.isEncoding;
-
 function assertEncoding(encoding) {
-  if (encoding && !isEncoding(encoding)) {
+  // Do not cache `Buffer.isEncoding`, some modules monkey-patch it to support
+  // additional encodings
+  if (encoding && !Buffer.isEncoding(encoding)) {
     throw new Error('Unknown encoding: ' + encoding);
   }
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -779,7 +779,9 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  CHECK(args[0]->IsInt32());
+  if (!args[0]->IsInt32())
+    return env->ThrowTypeError("First argument must be file descriptor");
+
   CHECK(Buffer::HasInstance(args[1]));
 
   int fd = args[0]->Int32Value();

--- a/test/common.js
+++ b/test/common.js
@@ -184,7 +184,7 @@ exports.platformTimeout = function(ms) {
     return ms;
 
   if (process.config.variables.arm_version === '6')
-    return 6 * ms;  // ARMv6
+    return 7 * ms;  // ARMv6
 
   return 2 * ms;  // ARMv7 and up.
 };

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -150,7 +150,7 @@ if (process.argv[2] === 'child') {
   };
 
   var min = 190;
-  var max = common.platformTimeout(1500);
+  var max = common.platformTimeout(2000);
   process.on('exit', function() {
     assert.equal(disconnected, count);
     assert.equal(connected, count);

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -51,7 +51,7 @@ function onNoMoreLines() {
 
 setTimeout(function testTimedOut() {
   assert(false, 'test timed out.');
-}, common.platformTimeout(3000)).unref();
+}, common.platformTimeout(4000)).unref();
 
 process.on('exit', function onExit() {
   // Kill processes in reverse order to avoid timing problems on Windows where

--- a/test/parallel/test-fs-write-no-fd.js
+++ b/test/parallel/test-fs-write-no-fd.js
@@ -1,0 +1,11 @@
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+
+assert.throws(function() {
+  fs.write(null, new Buffer(1), 0, 1);
+}, /TypeError/);
+
+assert.throws(function() {
+  fs.write(null, '1', 0, 1);
+}, /TypeError/);

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -1,0 +1,34 @@
+var common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  process.exit();
+}
+var tls = require('tls');
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+
+var cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
+var key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
+
+// https://github.com/iojs/io.js/issues/1489
+// tls.connect(options) with no options.host should accept a cert with
+//   CN:'localhost'
+tls.createServer({
+  key: key,
+  cert: cert
+}).listen(common.PORT);
+
+var socket = tls.connect({
+    port: common.PORT,
+    ca: cert,
+    // No host set here. 'localhost' is the default,
+    // but tls.checkServerIdentity() breaks before the fix with:
+    // Error: Hostname/IP doesn't match certificate's altnames:
+    //   "Host: undefined. is not cert's CN: localhost"
+}, function() {
+    assert(socket.authorized);
+    process.exit();
+});

--- a/test/sequential/test-next-tick-error-spin.js
+++ b/test/sequential/test-next-tick-error-spin.js
@@ -8,7 +8,7 @@ if (process.argv[2] !== 'child') {
   });
   var timer = setTimeout(function() {
     throw new Error('child is hung');
-  }, 3000);
+  }, common.platformTimeout(3000));
   child.on('exit', function(code) {
     console.error('ok');
     assert(!code);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -52,6 +52,7 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% sequential parallel message -J&set jslint=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap -J message sequential parallel&set jslint=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -52,7 +52,7 @@ if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% sequential parallel message -J&set jslint=1&goto arg-ok
-if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap -J message sequential parallel&set jslint=1&goto arg-ok
+if /i "%1"=="test-ci"       set test_args=%test_args% -p tap --logfile test.tap message sequential parallel&set jslint=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
 if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok


### PR DESCRIPTION
Just fixes. Especially to the tests and how the CI runs are now run, this will make v1.x CI runs viable again.

Also, due to the `string_decoder` thing, might be worthwhile to do a 1.8.2 in the coming weeks.