### PR TITLE
gitignore: ignore xcode workspaces and projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ deps/zlib/zlib.target.mk
 tools/faketime
 icu_config.gypi
 test.tap
+
+# Xcode workspaces and project folders
+*.xcodeproj
+*.xcworkspace


### PR DESCRIPTION
Calling ./configure --xcode creates xcode projects and a workspace for io.js for each dep. This commit adds them to the git ignore like vs project files.