### PR TITLE
lib: deprecate the smalloc module

### DIFF
--- a/lib/internal/smalloc.js
+++ b/lib/internal/smalloc.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const smalloc = process.binding('smalloc');
+const kMaxLength = smalloc.kMaxLength;
+const kMinType = smalloc.kMinType;
+const kMaxType = smalloc.kMaxType;
+const util = require('util');
+
+exports.alloc = alloc;
+exports.copyOnto = copyOnto;
+exports.dispose = dispose;
+exports.hasExternalData = hasExternalData;
+
+// don't allow kMaxLength to accidentally be overwritten. it's a lot less
+// apparent when a primitive is accidentally changed.
+Object.defineProperty(exports, 'kMaxLength', {
+  enumerable: true, value: kMaxLength, writable: false
+});
+
+Object.defineProperty(exports, 'Types', {
+  enumerable: true, value: Object.freeze(smalloc.types), writable: false
+});
+
+
+// usage: obj = alloc(n[, obj][, type]);
+function alloc(n, obj, type) {
+  n = n >>> 0;
+
+  if (obj === undefined)
+    obj = {};
+
+  if (typeof obj === 'number') {
+    type = obj >>> 0;
+    obj = {};
+  } else if (util.isPrimitive(obj)) {
+    throw new TypeError('obj must be an Object');
+  }
+
+  if (Array.isArray(obj))
+    throw new TypeError('obj cannot be an array');
+  if (obj instanceof Buffer)
+    throw new TypeError('obj cannot be a Buffer');
+  if (smalloc.isTypedArray(obj))
+    throw new TypeError('obj cannot be a typed array');
+  if (smalloc.hasExternalData(obj))
+    throw new TypeError('object already has external array data');
+
+  if (type < kMinType || type > kMaxType)
+    throw new TypeError('unknown external array type: ' + type);
+  if (n > kMaxLength)
+    throw new RangeError('Attempt to allocate array larger than maximum ' +
+                         'size: 0x' + kMaxLength.toString(16) + ' elements');
+
+  return smalloc.alloc(obj, n, type);
+}
+
+
+function dispose(obj) {
+  if (util.isPrimitive(obj))
+    throw new TypeError('obj must be an Object');
+  if (obj instanceof Buffer)
+    throw new TypeError('obj cannot be a Buffer');
+  if (smalloc.isTypedArray(obj))
+    throw new TypeError('obj cannot be a typed array');
+  if (!smalloc.hasExternalData(obj))
+    throw new TypeError('obj has no external array data');
+
+  smalloc.dispose(obj);
+}
+
+
+function copyOnto(source, sourceStart, dest, destStart, copyLength) {
+  if (util.isPrimitive(source))
+    throw new TypeError('source must be an Object');
+  if (util.isPrimitive(dest))
+    throw new TypeError('dest must be an Object');
+  if (!smalloc.hasExternalData(source))
+    throw new TypeError('source has no external array data');
+  if (!smalloc.hasExternalData(dest))
+    throw new TypeError('dest has no external array data');
+
+  return smalloc.copyOnto(source, sourceStart, dest, destStart, copyLength);
+}
+
+
+function hasExternalData(obj) {
+  if (util.isPrimitive(obj))
+    return false;
+
+  return smalloc.hasExternalData(obj);
+}

--- a/lib/smalloc.js
+++ b/lib/smalloc.js
@@ -1,91 +1,27 @@
 'use strict';
 
-const smalloc = process.binding('smalloc');
-const kMaxLength = smalloc.kMaxLength;
-const kMinType = smalloc.kMinType;
-const kMaxType = smalloc.kMaxType;
-const util = require('util');
+const smalloc = require('internal/smalloc');
+const deprecate = require('util').deprecate;
 
-exports.alloc = alloc;
-exports.copyOnto = copyOnto;
-exports.dispose = dispose;
-exports.hasExternalData = hasExternalData;
+exports.alloc =
+    deprecate(smalloc.alloc, 'smalloc.alloc: Deprecated, use typed arrays');
 
-// don't allow kMaxLength to accidentally be overwritten. it's a lot less
-// apparent when a primitive is accidentally changed.
+exports.copyOnto =
+    deprecate(smalloc.copyOnto,
+              'smalloc.copyOnto: Deprecated, use typed arrays');
+
+exports.dispose =
+    deprecate(smalloc.dispose,
+              'smalloc.dispose: Deprecated, use typed arrays');
+
+exports.hasExternalData =
+    deprecate(smalloc.hasExternalData,
+              'smalloc.hasExternalData: Deprecated, use typed arrays');
+
 Object.defineProperty(exports, 'kMaxLength', {
-  enumerable: true, value: kMaxLength, writable: false
+  enumerable: true, value: smalloc.kMaxLength, writable: false
 });
 
 Object.defineProperty(exports, 'Types', {
-  enumerable: true, value: Object.freeze(smalloc.types), writable: false
+  enumerable: true, value: Object.freeze(smalloc.Types), writable: false
 });
-
-
-// usage: obj = alloc(n[, obj][, type]);
-function alloc(n, obj, type) {
-  n = n >>> 0;
-
-  if (obj === undefined)
-    obj = {};
-
-  if (typeof obj === 'number') {
-    type = obj >>> 0;
-    obj = {};
-  } else if (util.isPrimitive(obj)) {
-    throw new TypeError('obj must be an Object');
-  }
-
-  if (Array.isArray(obj))
-    throw new TypeError('obj cannot be an array');
-  if (obj instanceof Buffer)
-    throw new TypeError('obj cannot be a Buffer');
-  if (smalloc.isTypedArray(obj))
-    throw new TypeError('obj cannot be a typed array');
-  if (smalloc.hasExternalData(obj))
-    throw new TypeError('object already has external array data');
-
-  if (type < kMinType || type > kMaxType)
-    throw new TypeError('unknown external array type: ' + type);
-  if (n > kMaxLength)
-    throw new RangeError('Attempt to allocate array larger than maximum ' +
-                         'size: 0x' + kMaxLength.toString(16) + ' elements');
-
-  return smalloc.alloc(obj, n, type);
-}
-
-
-function dispose(obj) {
-  if (util.isPrimitive(obj))
-    throw new TypeError('obj must be an Object');
-  if (obj instanceof Buffer)
-    throw new TypeError('obj cannot be a Buffer');
-  if (smalloc.isTypedArray(obj))
-    throw new TypeError('obj cannot be a typed array');
-  if (!smalloc.hasExternalData(obj))
-    throw new TypeError('obj has no external array data');
-
-  smalloc.dispose(obj);
-}
-
-
-function copyOnto(source, sourceStart, dest, destStart, copyLength) {
-  if (util.isPrimitive(source))
-    throw new TypeError('source must be an Object');
-  if (util.isPrimitive(dest))
-    throw new TypeError('dest must be an Object');
-  if (!smalloc.hasExternalData(source))
-    throw new TypeError('source has no external array data');
-  if (!smalloc.hasExternalData(dest))
-    throw new TypeError('dest has no external array data');
-
-  return smalloc.copyOnto(source, sourceStart, dest, destStart, copyLength);
-}
-
-
-function hasExternalData(obj) {
-  if (util.isPrimitive(obj))
-    return false;
-
-  return smalloc.hasExternalData(obj);
-}

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const v8binding = process.binding('v8');
-const smalloc = require('smalloc');
+const smalloc = require('internal/smalloc');
 
 const heapStatisticsBuffer =
     smalloc.alloc(v8binding.kHeapStatisticsBufferLength,

--- a/node.gyp
+++ b/node.gyp
@@ -71,6 +71,7 @@
       'lib/zlib.js',
 
       'lib/internal/freelist.js',
+      'lib/internal/smalloc.js',
     ],
   },
 


### PR DESCRIPTION
Upcoming V8 changes will make it impossible to keep supporting the
smalloc module so deprecate it now and tell people to switch to
typed arrays.

The module is used in core in a few places so this commit makes the
public module private and replaces the public part with wrappers that
print deprecation notices.

R=@domenic @trevnorris 

TBD: Deprecate src/smalloc.h as well?  Probably a good thing but the header is used when building core and deprecation warnings would be annoying (although I guess it could be made conditional on NODE_WANT_INTERNALS.)