### PR TITLE
repl: do not save history for non-terminal repl

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -57,7 +57,7 @@ function createRepl(env, cb) {
   }
 
   const repl = REPL.start(opts);
-  if (env.NODE_REPL_HISTORY_PATH) {
+  if (opts.terminal && env.NODE_REPL_HISTORY_PATH) {
     return setupHistory(repl, env.NODE_REPL_HISTORY_PATH, cb);
   }
   repl._historyPrev = _replHistoryMessage;


### PR DESCRIPTION
When running in non-TTY mode - the `repl.history` is `undefined` and
is not actually populated. Saving it will result in a crashes of
subsequent repl runs.

Fix: https://github.com/iojs/io.js/issues/1574