### PR TITLE
build: improve make test-npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,17 +140,15 @@ test-debugger: all
 test-npm: $(NODE_EXE)
 	rm -rf npm-cache npm-tmp npm-prefix
 	mkdir npm-cache npm-tmp npm-prefix
-	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
-	     npm_config_prefix="$(shell pwd)/npm-prefix" \
-	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../$(NODE_EXE) cli.js install --ignore-scripts
-	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
-	     npm_config_prefix="$(shell pwd)/npm-prefix" \
-	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../$(NODE_EXE) cli.js run-script test-all && \
-	     ../../$(NODE_EXE) cli.js prune --prod && \
-	     cd ../.. && \
-	     rm -rf npm-cache npm-tmp npm-prefix
+	cd deps/npm ; npm_config_cache="$(CURDIR)/npm-cache" \
+		npm_config_prefix="$(CURDIR)/npm-prefix" \
+		npm_config_tmp="$(CURDIR)/npm-tmp" \
+		../../$(NODE_EXE) cli.js install --ignore-scripts && \
+		../../$(NODE_EXE) cli.js run-script test-all && \
+		../../$(NODE_EXE) cli.js prune --prod && \
+		rm -rf node_modules/.bin && \
+		cd ../.. && \
+		rm -rf npm-cache npm-tmp npm-prefix
 
 test-npm-publish: $(NODE_EXE)
 	npm_package_config_publishtest=true ./$(NODE_EXE) deps/npm/test/run.js


### PR DESCRIPTION
replaces #1567

I think I'm doing this correctly, is there any reason it was separated into two commands? Did that make it parallel? It didn't seem to change per noticeably for me.

Also, now removes `deps/npm/node_modules/.bin`, which is generated by `make test-npm`.

R=@othiym23 