### PR TITLE
tls_wrap: Unlink TLSWrap and SecureContext objects asap.

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -289,15 +289,22 @@ TLSSocket.prototype._wrapHandle = function(handle) {
     }
   });
 
-  this.on('close', this._destroySSL);
+  this.on('close', function() {
+    this._destroySSL();
+    res = null;
+  });
 
   return res;
 };
 
 TLSSocket.prototype._destroySSL = function _destroySSL() {
+  if (!this.ssl) return;
   this.ssl.destroySSL();
-  if (this.ssl._secureContext.singleUse)
+  if (this.ssl._secureContext.singleUse) {
     this.ssl._secureContext.context.close();
+    this.ssl._secureContext.context = null;
+  }
+  this.ssl = null;
 };
 
 TLSSocket.prototype._init = function(socket, wrap) {


### PR DESCRIPTION
This makes `TLSWrap` and `SecureContext` objects collectable by the incremental gc.

`res = null;` destroys the cyclic reference in the `reading` property, `delete this.ssl` removes the remaining reference. `delete this.ssl._secureContext.context;` makes SecureContext objects collectable by the incremental gc even though there might be references to `this.ssl._secureContext` somewhere.

The `reading` property will throw an error if accessed after the socket is closed. If this is unwanted then the property getter/setter should be altered. ~~Can someone please comment on this part?~~ Should be ok as it is.

Test results for 20000 opened-closed non keep-alive connections to localhost (100 parallel requests):

1. b4ad5d7:
 1. Incremental GC timings: [2,3,3,5,6,6,11,11,10,10,10,11,11,9,10,10,11,10,10,11,12,10,12,10,12] = 226ms.
 1. Full GC timings: [31,29,31,30,29,30,31,22,32,29,31,30,29,29,29,30,31,29,29,19,27] = 607ms.
 1. GC runs: 25 incremental + 21 full = 46 total.
 1. Total GC time: 883ms.
 1. Average GC time: 19ms.
1. b4ad5d7 + this pull request:
 1. Incremental GC timings: [2,3,3,5,6,6,13,11,12,11,10,11,14,10,11,12,10,13,11,12,10,11,12,10,11,13,11,11,12,10,14,10,13,10,12,11,11,10] = 388ms.
 1. Full GC timings: [16,12,13,11,12,15,13,16,13,13,14,14,13,12] = 187ms.
 1. GC runs: 38 incremental + 14 full = 52 total.
 1. Total GC time: 525ms.
 1. Average GC time: 11ms.