### PR TITLE
doc: add TC meeting 2015-04-29 minutes

### DIFF
--- a/doc/tc-meetings/2015-04-29.md
+++ b/doc/tc-meetings/2015-04-29.md
@@ -1,0 +1,101 @@
+# io.js TC Meeting 2015-04-29
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=-e675TT4WEA
+* **Google Plus Event page**: https://plus.google.com/events/cei87pqnichrtt4qggbbo656bpk
+* **GitHub Issue**: https://github.com/iojs/io.js/issues/1557
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1C9nfm_5EhNz1jifITbtQcnGBX4R9vktoZ9KsFiCU7sQ
+
+## Agenda
+
+Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
+
+* Release Proposal: v2.0.0 [#1532](https://github.com/iojs/io.js/pull/1532)
+* Forward-port from v1.x [#1559](https://github.com/iojs/io.js/pull/1559)
+* Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+* Combined node.js/io.js TC/core call about convergence doc [#1413](https://github.com/iojs/io.js/issues/1413)
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Brian
+* Chris (TC)
+* Domenic
+* Fedor (TC)
+* Jeremiah
+* Shigeki
+* Trevor (TC)
+
+
+### Review of last meeting
+
+* [#1130](https://github.com/iojs/io.js/issues/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+* [#1481](https://github.com/iojs/io.js/issues/1481) Nominating @mikeal to the TC
+* [#1500](https://github.com/iojs/io.js/issues/1500) Nominating Brian White @mscdex to the TC
+* [#1501](https://github.com/iojs/io.js/issues/1501) Nominating Shigeki Ohtsu @shigeki to the TC
+* [#1393](https://github.com/iojs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+* [#1413](https://github.com/iojs/io.js/issues/1413) Combined node.js/io.js TC/Core Call
+* [#1416](https://github.com/iojs/io.js/issues/1416) Diffing io.js and the Node.js Foundation
+
+
+### Quick stand-up
+
+* Ben: nothing
+* Bert: nothing
+* Brian: finished optimizations for JS HTTP parser, posted a few questions; other miscellaneous improvements in core HTTP.
+* Chris: upgraded V8 and documented the process; also did some work on the REPL so that classes (and let/const) work
+* Domenic: PR reviews for v2.0.0, starting on V8 extension work to improve startup time
+* Fedor: worked on fixing some TLS memory issues, so far appears to be a large improvement in memory usage.
+* Jeremiah: issue management; discussions on moving npm out of the repo, which seems to have converged toward a helper tool instead of moving it out of the repo
+* Mikeal: connection too bad to stand up.
+* Shigeki: working on SSL issues; root cert updates. Chrome and Firefox do whitelist of CNNIC cert hashes.
+* Trevor: looking at bugs, streams compliance
+
+## Minutes
+
+### Release Proposal: v2.0.0 [#1532](https://github.com/iojs/io.js/pull/1532)
+
+* Domenic:
+  - v8 changes merged
+  - worried that we’re getting into a bad cycle of “wait a few more days” for things to land
+  - process.send
+  - open an rc, add to website for a few days, ship by friday
+* Bert/Ben:
+  - talk of process.send
+    - Ben: should not hold up release, windows tests break right now
+    - less of a regression than a change
+* Domenic:
+  - these releases are a train
+  - don’t hold up the train for features
+    - make sure it’s ready for 3
+* url updates from petka: might be ready
+  - ci run passes on all platforms but arm7
+* Domenic recalls in the runup to 1.0 – “nobody tests rc's” was the consensus
+
+Chris, Trevor: discussion about how the `master` and `next` branches are used.
+
+* process.send changes will slip for v2.0
+* waiting for Petka’s comment and review on url changes (https://github.com/iojs/io.js/pull/1561)
+* release 2.x asap (friday)
+
+After the release:
+
+* the master branch will contain version 2.x.
+* api-breaking changes will land on the ‘next’ branch alongside v8 upgrades. master will be merged into next regularly
+* fixes are backported to the maintenance (v1.x) branch
+
+### Forward-port from v1.x [#1559](https://github.com/iojs/io.js/pull/1559)
+
+Discussed current plan for backporting patches to maintenance patches.
+
+* Consensus that we should give the “land in master and backport” plan a go and see how it works out.
+
+### Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+
+### Combined node.js/io.js TC/core call [#1413](https://github.com/iojs/io.js/issues/1413)
+
+## Next meeting
+
+* April 6th


### PR DESCRIPTION
_(Note to whoever took these minutes: please try and keep international audiences in mind, particularly when writing dates, next meeting of "5/6" is guessable via context but only the USA writes dates this way and it's confusing for the rest of us)_