### PR TITLE
net: ensure WriteWrap references the handle

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -627,6 +627,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   }
 
   var req = new WriteWrap();
+  req.handle = this._handle;
   req.oncomplete = afterWrite;
   req.async = false;
   var err;


### PR DESCRIPTION
`StreamBase::AfterWrite` is passing handle as an argument to the
`afterWrite` function in net.js. Thus GC should not collect the handle
and the request separately and assume that they are tied together.

With this commit - request will always outlive the StreamBase instance,
helping us survive the GC pass.

Fix: https://github.com/iojs/io.js/pull/1580