### PR TITLE
repl: fix persistent history

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -26,8 +26,9 @@ module.paths = require('module')._nodeModulePaths(module.filename);
 
 function createRepl(env, cb) {
   const opts = {
-    useGlobal: true,
-    ignoreUndefined: false
+    ignoreUndefined: false,
+    terminal: process.stdout.isTTY,
+    useGlobal: true
   };
 
   if (parseInt(env.NODE_NO_READLINE)) {
@@ -57,8 +58,8 @@ function createRepl(env, cb) {
   }
 
   const repl = REPL.start(opts);
-  if (opts.terminal && env.NODE_REPL_HISTORY_PATH) {
-    return setupHistory(repl, env.NODE_REPL_HISTORY_PATH, cb);
+  if (opts.terminal && env.NODE_REPL_HISTORY_FILE) {
+    return setupHistory(repl, env.NODE_REPL_HISTORY_FILE, cb);
   }
   repl._historyPrev = _replHistoryMessage;
   cb(null, repl);
@@ -158,7 +159,7 @@ function _replHistoryMessage() {
   if (this.history.length === 0) {
     this._writeToOutput(
         '\nPersistent history support disabled. ' +
-        'Set the NODE_REPL_HISTORY_PATH environment variable to ' +
+        'Set the NODE_REPL_HISTORY_FILE environment variable to ' +
         'a valid, user-writable path to enable.\n'
     );
     this._refreshLine();


### PR DESCRIPTION
https://github.com/iojs/io.js/commit/ea5195ccaf6d51262c9089c2ec5c6f5634bc12b5 broke history as `opts.terminal` was never set to a truthy value. Also renamed the history file variable to match the docs.

cc: @chrisdickinson @indutny 