### PR TITLE
src: export the ParseEncoding function on Windows

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -246,9 +246,10 @@ inline void NODE_SET_PROTOTYPE_METHOD(v8::Handle<v8::FunctionTemplate> recv,
 #define NODE_SET_PROTOTYPE_METHOD node::NODE_SET_PROTOTYPE_METHOD
 
 enum encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
-enum encoding ParseEncoding(v8::Isolate* isolate,
-                            v8::Handle<v8::Value> encoding_v,
-                            enum encoding default_encoding = BINARY);
+NODE_EXTERN enum encoding ParseEncoding(
+    v8::Isolate* isolate,
+    v8::Handle<v8::Value> encoding_v,
+    enum encoding default_encoding = BINARY);
 NODE_DEPRECATED("Use ParseEncoding(isolate, ...)",
                 inline enum encoding ParseEncoding(
       v8::Handle<v8::Value> encoding_v,


### PR DESCRIPTION
Makes the `ParseEncoding` symbol visible to addons on Windows.  It was already visible on Unices.

I ran into this when writing an addon that used `ParseEncoding`; the VS2013 build failed with:

```
(Link target) ->
  blake2.obj : error LNK2001: unresolved external symbol "enum node::encoding __cdecl node::ParseEncoding(class v8::Isolate *,class v8::Handle<class v8::Value>,enum node::encoding)" (?ParseEncoding@node@@YA?AW4encoding@1@PEAVIsolate@v8@@V?$Handle@VValue@v8@@@4@W421@@Z) [L:\home\at\NodeProjects\node-blake2\build\blake2.vcxproj]
  L:\home\at\NodeProjects\node-blake2\build\Release\blake2.node : fatal error LNK1120: 1 unresolved externals [L:\home\at\NodeProjects\node-blake2\build\blake2.vcxproj]

    9 Warning(s)
    2 Error(s)
```

It built fine after adding the `NODE_EXPORT`.

Similar to an older fix https://github.com/joyent/node/issues/3811