### PR TITLE
timers: use Number() on timeout/repeat values

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -168,7 +168,7 @@ exports.active = function(item) {
 
 
 exports.setTimeout = function(callback, after) {
-  after *= 1; // coalesce to number or NaN
+  after = Number(after); // coalesce to number or NaN
 
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     after = 1; // schedule on next tick, follows browser behaviour
@@ -224,7 +224,7 @@ exports.clearTimeout = function(timer) {
 
 
 exports.setInterval = function(callback, repeat) {
-  repeat *= 1; // coalesce to number or NaN
+  repeat = Number(repeat); // coalesce to number or NaN
 
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour


### PR DESCRIPTION
This results in a ~14-23% performance increase in the 'breadth' timers benchmark.

[Related jsperf](http://jsperf.com/string-to-int-conversion-parseint-vs-number-vs-bitwise/10)