### PR TITLE
repl: Fix debugger / require bugs

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -107,8 +107,13 @@ function setupHistory(repl, historyPath, ready) {
     }
     repl._historyHandle = hnd;
     repl.on('line', online);
-    repl.resume();
-    return ready(null, repl);
+
+    // reading the file data out erases it
+    repl.once('flushHistory', function() {
+      repl.resume();
+      ready(null, repl);
+    });
+    flushHistory();
   }
 
   // ------ history listeners ------

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -1,28 +1,21 @@
 'use strict';
 
-module.exports = {createRepl: createRepl};
-
 const Interface = require('readline').Interface;
 const REPL = require('repl');
 const path = require('path');
+
+module.exports = Object.create(REPL);
+module.exports.createInternalRepl = createRepl;
 
 // XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
 // The debounce is to guard against code pasted into the REPL.
 const kDebounceHistoryMS = 15;
 
-try {
-  // hack for require.resolve("./relative") to work properly.
-  module.filename = path.resolve('repl');
-} catch (e) {
-  // path.resolve('repl') fails when the current working directory has been
-  // deleted.  Fall back to the directory name of the (absolute) executable
-  // path.  It's not really correct but what are the alternatives?
-  const dirname = path.dirname(process.execPath);
-  module.filename = path.resolve(dirname, 'repl');
+// XXX(chrisdickinson): hack to make sure that the internal debugger
+// uses the original repl.
+function replStart() {
+  return REPL.start.apply(REPL, arguments);
 }
-
-// hack for repl require to work properly with node_modules folders
-module.paths = require('module')._nodeModulePaths(module.filename);
 
 function createRepl(env, cb) {
   const opts = {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -32,6 +32,20 @@ const Console = require('console').Console;
 const domain = require('domain');
 const debug = util.debuglog('repl');
 
+try {
+  // hack for require.resolve("./relative") to work properly.
+  module.filename = path.resolve('repl');
+} catch (e) {
+  // path.resolve('repl') fails when the current working directory has been
+  // deleted.  Fall back to the directory name of the (absolute) executable
+  // path.  It's not really correct but what are the alternatives?
+  const dirname = path.dirname(process.execPath);
+  module.filename = path.resolve(dirname, 'repl');
+}
+
+// hack for repl require to work properly with node_modules folders
+module.paths = require('module')._nodeModulePaths(module.filename);
+
 // If obj.hasOwnProperty has been overridden, then calling
 // obj.hasOwnProperty(prop) will break.
 // See: https://github.com/joyent/node/issues/1707

--- a/src/node.js
+++ b/src/node.js
@@ -130,7 +130,8 @@
         // If -i or --interactive were passed, or stdin is a TTY.
         if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
           // REPL
-          Module.requireRepl().createInternalRepl(process.env, function(err, repl) {
+          var cliRepl = Module.requireRepl();
+          cliRepl.createInternalRepl(process.env, function(err, repl) {
             if (err) {
               throw err;
             }

--- a/src/node.js
+++ b/src/node.js
@@ -130,7 +130,7 @@
         // If -i or --interactive were passed, or stdin is a TTY.
         if (process._forceRepl || NativeModule.require('tty').isatty(0)) {
           // REPL
-          Module.requireRepl().createRepl(process.env, function(err, repl) {
+          Module.requireRepl().createInternalRepl(process.env, function(err, repl) {
             if (err) {
               throw err;
             }


### PR DESCRIPTION
Hey all – found some (embarrassing) bugs I introduced while poking at the v2.0.0 nightly.

The first commit fixes the debugger – it started getting the new internal repl module, which did not expose the same interface as the public repl module. This is a quick fix, intended to be removed in the future – I'd like to spend some time on the debugger to bring it to parity with the new internal repl features.

The second commit fixes node_modules resolution support. This slipped past me the first time around, because I misread the purpose of the preamble (`hack for require.resolve("./relative") to work properly.`, from the source) and moved it to the internal module. I thought that it addressed `require('./local-file.js')` from the repl; it actually addressed `require('dependency-from-node-modules')`, and needed to be available to the repl eval function. This fixes that breakage. (And I also am heaping a ton of apologies on this one!) 

These should block v2.0.0 (or the repl improvements should be backed out.)
