### PR TITLE
src: fix -Wmissing-field-initializers warning

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -554,7 +554,9 @@ const struct http_parser_settings Parser::settings = {
   Parser::on_header_value,
   Parser::on_headers_complete,
   Parser::on_body,
-  Parser::on_message_complete
+  Parser::on_message_complete,
+  nullptr,  // on_chunk_header
+  nullptr   // on_chunk_complete
 };
 
 


### PR DESCRIPTION
Fix the following (non-serious) compiler warning:

    ../src/node_http_parser.cc:558:1: warning: missing initializer for
    member 'http_parser_settings::on_chunk_header'
    [-Wmissing-field-initializers]
    };
    ^
    ../src/node_http_parser.cc:558:1: warning: missing initializer for
    member 'http_parser_settings::on_chunk_complete'
    [-Wmissing-field-initializers]

Introduced in commit b3a7da1 ("deps: update http_parser to 2.5.0").

R=@indutny?