### PR TITLE
build: don't compile debug build with -Og

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -14,7 +14,7 @@
     'node_tag%': '',
     'uv_library%': 'static_library',
 
-    # Default to -Og for debug builds.
+    # Default to -O0 for debug builds.
     'v8_optimized_debug%': 0,
 
     # Enable disassembler for `--print-code` v8 options
@@ -54,13 +54,8 @@
           'v8_enable_handle_zapping%': 1,
         },
         'defines': [ 'DEBUG', '_DEBUG' ],
-        'cflags': [ '-g' ],
+        'cflags': [ '-g', '-O0' ],
         'conditions': [
-          ['clang==1', {
-            'cflags': [ '-O0' ],  # https://llvm.org/bugs/show_bug.cgi?id=20765
-          }, {
-            'cflags': [ '-Og' ],  # Debug-friendly optimizations only.
-          }],
           ['target_arch=="x64"', {
             'msvs_configuration_platform': 'x64',
           }],


### PR DESCRIPTION
It's not supported by clang and commit e67542a ("build: disable -Og
when building with clang") is not sufficient because the configure
script no longer writes the 'clang' variable to common.gypi.

I could fix the configure script but I don't care enough actually do
so.  A fixed configure script won't help anyway when the compiler is
overridden through the CXX environment variable at compile time.

R=@Fishrock123?