### PR TITLE
string_bytes: fix build warning

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -681,7 +681,7 @@ Local<Value> StringBytes::Encode(Isolate* isolate,
   Local<String> val;
   switch (encoding) {
     case BUFFER:
-      return scope.Escape(Buffer::New(buf, buflen));
+      return scope.Escape(Buffer::New(isolate, buf, buflen));
 
     case ASCII:
       if (contains_non_ascii(buf, buflen)) {


### PR DESCRIPTION
Buffer::New() now needs to be passed an Isolate. Fix one instance where
that was not passed.