### PR TITLE
install: Fixing NameError

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -198,8 +198,8 @@ def run(args):
   # argv[2] is a custom install prefix for packagers (think DESTDIR)
   # argv[3] is a custom install prefix (think PREFIX)
   # Difference is that dst_dir won't be included in shebang lines etc.
-  if len(args) > 2:
-    dst_dir = args[2]
+  dst_dir = args[2] if len(args) > 2 else ''
+
   if len(args) > 3:
     node_prefix = args[3]
 


### PR DESCRIPTION
If `len(args)` is lesser than two, then `install_path = dst_dir + node_prefix + '/'` would throw a `NameError`, because `dst_dir` will not be defined yet. So, we are assigning an empty string as the default value, if `len(args)` is lesser than or equal to two.