### PR TITLE
js_stream: fix buffer index in DoWrite

### DIFF
--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -89,7 +89,7 @@ int JSStream::DoWrite(WriteWrap* w,
 
   Local<Array> bufs_arr = Array::New(env()->isolate(), count);
   for (size_t i = 0; i < count; i++)
-    bufs_arr->Set(i, Buffer::New(env(), bufs[0].base, bufs[0].len));
+    bufs_arr->Set(i, Buffer::New(env(), bufs[i].base, bufs[i].len));
 
   Local<Value> argv[] = {
     w->object(),

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -1,0 +1,65 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path'),
+    tls = require('tls'),
+    stream = require('stream'),
+    net = require('net');
+
+var common = require('../common');
+
+var server;
+var cert_dir = path.resolve(__dirname, '../fixtures'),
+    options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
+                cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+                ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+                ciphers: 'AES256-GCM-SHA384' };
+var content = 'hello world';
+var recv_bufs = [];
+var send_data = '';
+server = tls.createServer(options, function(s) {
+  s.on('data', function(c) {
+    recv_bufs.push(c);
+  });
+});
+server.listen(common.PORT, function() {
+  var raw = net.connect(common.PORT);
+
+  var pending = false;
+  raw.on('readable', function() {
+    if (pending)
+      p._read();
+  });
+
+  var p = new stream.Duplex({
+    read: function read() {
+      pending = false;
+
+      var chunk = raw.read();
+      if (chunk) {
+        this.push(chunk);
+      } else {
+        pending = true;
+      }
+    },
+    write: function write(data, enc, cb) {
+      raw.write(data, enc, cb);
+    }
+  });
+
+  var socket = tls.connect({
+    socket: p,
+    rejectUnauthorized: false
+  }, function() {
+    for (var i = 0; i < 50; ++i) {
+      socket.write(content);
+      send_data += content;
+    }
+    socket.end();
+    server.close();
+  });
+});
+
+process.on('exit', function() {
+  var recv_data = (Buffer.concat(recv_bufs)).toString();
+  assert.strictEqual(send_data, recv_data);
+});


### PR DESCRIPTION
The index of buffer to write in JSStream was always 0 by mistake. This fix was to use increment index of buffer arrays. The test was originally made by @mscdex in #1594.

CI results are https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/646/ . Most of failures are caused by cpplint errors.

Fixes: https://github.com/iojs/io.js/issues/1595
Fixes: https://github.com/iojs/io.js/pull/1594

R= @indutny 