### PR TITLE
install: Replacing map with loop

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -76,8 +76,13 @@ def try_remove(path, dst):
   try_unlink(target_path)
   try_rmdir_r(os.path.dirname(target_path))
 
-def install(paths, dst): map(lambda path: try_copy(path, dst), paths)
-def uninstall(paths, dst): map(lambda path: try_remove(path, dst), paths)
+def install(paths, dst):
+  for path in paths:
+    try_copy(path, dst)
+
+def uninstall(paths, dst):
+  for path in paths:
+    try_remove(path, dst)
 
 def update_shebang(path, shebang):
   print 'updating shebang of %s to %s' % (path, shebang)


### PR DESCRIPTION
In Python, `map` creates a new list and it should not be used if the 
returned list is ignored. Since we actually ignore it, the idiomatic
way to do this would be to use normal for loop