### PR TITLE
utils: Removing unused GuessWordSize function

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -89,12 +89,5 @@ def GuessArchitecture():
     return None
 
 
-def GuessWordsize():
-  if '64' in platform.machine():
-    return '64'
-  else:
-    return '32'
-
-
 def IsWindows():
   return GuessOS() == 'win32'


### PR DESCRIPTION
Apart from the fact that the implementation is not reliable,
GuessWordSize is not used anywhere in the codebase. So, removing it.