### PR TITLE
v8: add type check to make failed calls visible

### DIFF
--- a/doc/api/v8.markdown
+++ b/doc/api/v8.markdown
@@ -20,7 +20,7 @@ Returns an object with the following properties
 }
 ```
 
-## setFlagsFromString()
+## setFlagsFromString(string)
 
 Set additional V8 command line flags.  Use with care; changing settings
 after the VM has started may result in unpredictable behavior, including

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -60,6 +60,13 @@ void GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 
 
 void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  if (args.Length() < 1)
+    return env->ThrowTypeError("v8 flag is required");
+  if (!args[0]->IsString())
+    return env->ThrowTypeError("v8 flag must be a string");
+
   String::Utf8Value flags(args[0]);
   V8::SetFlagsFromString(*flags, flags.length());
 }

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -1,0 +1,6 @@
+var common = require('../common');
+var assert = require('assert');
+var v8 = require('v8');
+
+assert.throws(function() {v8.setFlagsFromString(1)}, TypeError);
+assert.throws(function() {v8.setFlagsFromString()}, TypeError);


### PR DESCRIPTION
Calling v8.setFlagsFromString with e.g a function as a flag argument gave no exception or warning that the function call will fail. There is now an exception if the function gets called with the wrong flag type (string is required) or that a flag is expected. v8 flags are only possible as strings.
Other APIs (`fs` or `net`) already provide exceptions if the argument has not the expected type. 