### PR TITLE
Give more context to unhandled error events

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -140,7 +140,10 @@ EventEmitter.prototype.emit = function emit(type) {
     } else if (er instanceof Error) {
       throw er; // Unhandled 'error' event
     } else {
-      throw new Error('Uncaught, unspecified "error" event.');
+      // At least give some kind of context to the user
+      var err = new Error('Uncaught, unspecified "error" event. (' + er + ')');
+      err.context = er;
+      throw err;
     }
     return false;
   }

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -1,0 +1,8 @@
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var EE = new EventEmitter();
+
+assert.throws(function() {
+  EE.emit('error', 'Accepts a string');
+}, /Accepts a string/);


### PR DESCRIPTION
Previously, in the event of an unhandled error event, if the error is a
not an actual Error, then a default error is thrown. Now, if a string
is the unhandled error, it is wrapped in an Error and then thrown.

This provides more context in the event a string is emitted for the
error event.

This PR also prints the error to stderr in the event it is not a string or an Error object.

I see this as being controversial, but it was quite minimal so I wanted to see what everyone else thinks.

/cc @iojs/collaborators 