### PR TITLE
tools?: refactor test-npm into shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,19 +138,7 @@ test-debugger: all
 	$(PYTHON) tools/test.py debugger
 
 test-npm: $(NODE_EXE)
-	rm -rf npm-cache npm-tmp npm-prefix
-	mkdir npm-cache npm-tmp npm-prefix
-	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
-	     npm_config_prefix="$(shell pwd)/npm-prefix" \
-	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../$(NODE_EXE) cli.js install --ignore-scripts
-	cd deps/npm ; npm_config_cache="$(shell pwd)/npm-cache" \
-	     npm_config_prefix="$(shell pwd)/npm-prefix" \
-	     npm_config_tmp="$(shell pwd)/npm-tmp" \
-	     ../../$(NODE_EXE) cli.js run-script test-all && \
-	     ../../$(NODE_EXE) cli.js prune --prod && \
-	     cd ../.. && \
-	     rm -rf npm-cache npm-tmp npm-prefix
+	NODE_EXE=$(NODE_EXE) tools/test-npm.sh
 
 test-npm-publish: $(NODE_EXE)
 	npm_package_config_publishtest=true ./$(NODE_EXE) deps/npm/test/run.js

--- a/tools/test-npm.sh
+++ b/tools/test-npm.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# always change the working directory to the project's root directory
+cd $(dirname $0)/..
+
+# pass NODE_EXE from something like Makefile
+# it should point to either {./}node or {./}node.exe, depending on the platform
+if [ -z $NODE_EXE ]; then
+  echo "No node executable provided. Bailing." >&2
+  exit 0
+fi
+
+rm -rf test-npm
+mkdir test-npm
+
+# make a copy of deps/npm to run the tests on
+cp -r deps/npm/ test-npm/
+
+cd test-npm
+
+# do a rm first just in case deps/npm contained these
+rm -rf npm-cache npm-tmp npm-prefix
+mkdir npm-cache npm-tmp npm-prefix
+
+# set some npm env varibles to point to our new temporary folders
+export npm_config_cache="npm-cache"
+export npm_config_prefix="npm-prefix"
+export npm_config_tmp="npm-tmp"
+
+# install npm devDependencies and run npm's tests
+../$NODE_EXE cli.js install --ignore-scripts
+../$NODE_EXE cli.js run-script test-all
+
+# clean up everything one single shot
+cd .. && rm -rf test-npm


### PR DESCRIPTION
[As suggested](https://github.com/iojs/io.js/pull/1576#discussion_r29820936), test-npm now resides in a separate script file, and makes a copy of deps/npm to run the tests on.

R=@othiym23 / @iojs/build / @evanlucas 