### PR TITLE
os: refine tmpdir() trailing slash stripping

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -22,6 +22,9 @@ exports.platform = function() {
   return process.platform;
 };
 
+const trailingSlashRe = isWindows ? /[^:]\\$/
+                                  : /.\/$/;
+
 exports.tmpdir = function() {
   var path;
   if (isWindows) {
@@ -34,7 +37,7 @@ exports.tmpdir = function() {
            process.env.TEMP ||
            '/tmp';
   }
-  if (/[\\\/]$/.test(path))
+  if (trailingSlashRe.test(path))
     path = path.slice(0, -1);
   return path;
 };

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -15,6 +15,12 @@ if (process.platform === 'win32') {
   assert.equal(os.tmpdir(), expected);
   process.env.TEMP = '\\temp\\';
   assert.equal(os.tmpdir(), '\\temp');
+  process.env.TEMP = '\\tmpdir/';
+  assert.equal(os.tmpdir(), '\\tmpdir/');
+  process.env.TEMP = '\\';
+  assert.equal(os.tmpdir(), '\\');
+  process.env.TEMP = 'C:\\';
+  assert.equal(os.tmpdir(), 'C:\\');
 } else {
   assert.equal(os.tmpdir(), '/tmpdir');
   process.env.TMPDIR = '';
@@ -25,6 +31,10 @@ if (process.platform === 'win32') {
   assert.equal(os.tmpdir(), '/tmp');
   process.env.TMPDIR = '/tmpdir/';
   assert.equal(os.tmpdir(), '/tmpdir');
+  process.env.TMPDIR = '/tmpdir\\';
+  assert.equal(os.tmpdir(), '/tmpdir\\');
+  process.env.TMPDIR = '/';
+  assert.equal(os.tmpdir(), '/');
 }
 
 var endianness = os.endianness();


### PR DESCRIPTION
`os.tmpdir()` began stripping trailing slashes in b57cc51d8d3f4ad279591ae8fa6584ee22773b97. This causes problems if the temp directory is simply `'/'`. It also stripped trailing slashes without first determining which slash type is used by the current operating system. This commit only strips trailing slashes if another character precedes the slash. On Windows, it checks for `':'`, as not to strip slashes from something like `'C:\'`.

Related to #1669.