### PR TITLE
build: move --with-intl to intl optgroup

### DIFF
--- a/configure
+++ b/configure
@@ -237,7 +237,7 @@ parser.add_option('--with-etw',
     dest='with_etw',
     help='build with ETW (default is true on Windows)')
 
-parser.add_option('--with-intl',
+intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',
     default='none',


### PR DESCRIPTION
Minor cosmetic change to `./configure` output.