### PR TITLE
[WIP]tools: remove closure_linter to eslint on windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -181,8 +181,7 @@ goto jslint
 :jslint
 if not defined jslint goto exit
 echo running jslint
-set PYTHONPATH=tools/closure_linter/;tools/gflags/
-python tools/closure_linter/closure_linter/gjslint.py --unix_mode --strict --nojsdoc -r lib/ -r src/ --exclude_files lib/punycode.js
+%config%\iojs tools/eslint/bin/eslint.js src lib --reset --quiet
 goto exit
 
 :create-msvs-files-failed


### PR DESCRIPTION
This is a work in progress.
I found an error on Windows CI. gjslint still exists on vbuild.bat.
BUT, I don't have a Windows environment... So I have not confirmed this yet. 
If I got our Jenkins permission, I will run the tests on Windows.
