### PR TITLE
tools: make eslint work on subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ bench-idle:
 	./$(NODE_EXE) benchmark/idle_clients.js &
 
 jslint:
-	./$(NODE_EXE) tools/eslint/bin/eslint.js src/*.js lib/*.js --reset --quiet
+	./$(NODE_EXE) tools/eslint/bin/eslint.js src lib --reset --quiet
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_lttng.cc


### PR DESCRIPTION
The old pattern didn't include files in `lib/internal`. This changes the pattern to directories which makes eslint apply to all subdirectories as well.

related: #1685 

cc: @yosuke-furukawa 